### PR TITLE
Fix for rust/master IO library changes

### DIFF
--- a/src/obj.rs
+++ b/src/obj.rs
@@ -2,7 +2,7 @@
 
 use std::rt::io;
 use std::rt::io::file::FileInfo;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::vec;
 use std::str;
 use std::num::Zero;

--- a/src/post_processing/oculus_stereo.rs
+++ b/src/post_processing/oculus_stereo.rs
@@ -5,7 +5,7 @@ use std::cast;
 use std::ptr;
 use std::mem;
 use std::rt::io::file::FileInfo;
-use std::rt::io::extensions::ReaderUtil;
+use std::rt::io::Reader;
 use std::str;
 use gl;
 use gl::types::*;


### PR DESCRIPTION
This is a tiny fix for the IO rework happening in rust's type system. The `read_to_end` method was moved from `ReaderUtil` to `Reader`.
