### PR TITLE
Update to rustc 0.13.0-nightly (39d740266 2015-01-01 15:51:08 +0000)

### DIFF
--- a/examples/decomp.rs
+++ b/examples/decomp.rs
@@ -91,7 +91,7 @@ fn main() {
                     let mut part_faces = Vec::new();
 
                     for i in partitioning.into_iter() {
-                        part_faces.push(faces.read().data().as_ref().unwrap()[i]);
+                        part_faces.push(faces.read().unwrap().data().as_ref().unwrap()[i]);
                     }
 
                     let faces = GPUVector::new(part_faces, BufferType::ElementArray, AllocationType::StaticDraw);

--- a/examples/relativity.rs
+++ b/examples/relativity.rs
@@ -60,7 +60,7 @@ fn main() {
      * Render
      */
     while window.render_with_camera(&mut observer) {
-        let mut c = context.write();
+        let mut c = context.write().unwrap();
 
         for event in window.events().iter() {
             match event.value {
@@ -275,7 +275,7 @@ impl Material for RelativisticMaterial {
         let ctxt = self.context.clone();
 
         {
-            let c = ctxt.read();
+            let c = ctxt.read().unwrap();
             // XXX: this relative velocity est very wrong!
             self.rel_vel.upload(&c.speed_of_player);
             self.light_vel.upload(&c.speed_of_light);

--- a/src/loader/obj.rs
+++ b/src/loader/obj.rs
@@ -5,6 +5,7 @@ use std::io::Reader;
 use std::str::Words;
 use std::str::FromStr;
 use std::io::IoResult;
+use std::iter::repeat;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::{Arc, RWLock};
@@ -361,7 +362,7 @@ fn reformat(coords:     Vec<Coord>,
 
     let resn = resn.unwrap_or_else(|| Mesh::compute_normals_array(resc.as_slice(), allfs.as_slice()));
     let resn = Arc::new(RWLock::new(GPUVector::new(resn, BufferType::Array, AllocationType::StaticDraw)));
-    let resu = resu.unwrap_or_else(|| Vec::from_elem(resc.len(), na::orig()));
+    let resu = resu.unwrap_or_else(|| repeat(na::orig()).take(resc.len()).collect());
     let resu = Arc::new(RWLock::new(GPUVector::new(resu, BufferType::Array, AllocationType::StaticDraw)));
     let resc = Arc::new(RWLock::new(GPUVector::new(resc, BufferType::Array, AllocationType::StaticDraw)));
 

--- a/src/resource/shader.rs
+++ b/src/resource/shader.rs
@@ -1,6 +1,7 @@
 use std::mem;
 use std::ptr;
 use std::str;
+use std::iter::repeat;
 use std::kinds::marker::NoCopy;
 use std::io::fs::File;
 use std::io::fs::PathExtensions;
@@ -203,7 +204,7 @@ fn check_shader_error(shader: GLuint) {
             if info_log_len > 0 {
                 // error check for fail to allocate memory omitted
                 let mut chars_written = 0;
-                let info_log = " ".repeat(info_log_len as uint);
+                let info_log: String = repeat(' ').take(info_log_len as uint).collect();
 
                 let mut c_str = info_log.to_c_str();
 

--- a/src/scene/object.rs
+++ b/src/scene/object.rs
@@ -204,13 +204,13 @@ impl Object {
     /// Mutably access the object's vertices.
     #[inline(always)]
     pub fn modify_vertices(&mut self, f: &mut |&mut Vec<Pnt3<GLfloat>>| -> ()) {
-        let _ = self.mesh.borrow_mut().coords().write().data_mut().as_mut().map(|coords| (*f)(coords));
+        let _ = self.mesh.borrow_mut().coords().write().unwrap().data_mut().as_mut().map(|coords| (*f)(coords));
     }
 
     /// Access the object's vertices.
     #[inline(always)]
     pub fn read_vertices(&self, f: &mut |&[Pnt3<GLfloat>]| -> ()) {
-        let _ = self.mesh.borrow().coords().read().data().as_ref().map(|coords| (*f)(coords.as_slice()));
+        let _ = self.mesh.borrow().coords().read().unwrap().data().as_ref().map(|coords| (*f)(coords.as_slice()));
     }
 
     /// Recomputes the normals of this object's mesh.
@@ -222,37 +222,37 @@ impl Object {
     /// Mutably access the object's normals.
     #[inline(always)]
     pub fn modify_normals(&mut self, f: &mut |&mut Vec<Vec3<GLfloat>>| -> ()) {
-        let _ = self.mesh.borrow_mut().normals().write().data_mut().as_mut().map(|normals| (*f)(normals));
+        let _ = self.mesh.borrow_mut().normals().write().unwrap().data_mut().as_mut().map(|normals| (*f)(normals));
     }
 
     /// Access the object's normals.
     #[inline(always)]
     pub fn read_normals(&self, f: &mut |&[Vec3<GLfloat>]| -> ()) {
-        let _ = self.mesh.borrow().normals().read().data().as_ref().map(|normals| (*f)(normals.as_slice()));
+        let _ = self.mesh.borrow().normals().read().unwrap().data().as_ref().map(|normals| (*f)(normals.as_slice()));
     }
 
     /// Mutably access the object's faces.
     #[inline(always)]
     pub fn modify_faces(&mut self, f: &mut |&mut Vec<Vec3<GLuint>>| -> ()) {
-        let _ = self.mesh.borrow_mut().faces().write().data_mut().as_mut().map(|faces| (*f)(faces));
+        let _ = self.mesh.borrow_mut().faces().write().unwrap().data_mut().as_mut().map(|faces| (*f)(faces));
     }
 
     /// Access the object's faces.
     #[inline(always)]
     pub fn read_faces(&self, f: &mut |&[Vec3<GLuint>]| -> ()) {
-        let _ = self.mesh.borrow().faces().read().data().as_ref().map(|faces| (*f)(faces.as_slice()));
+        let _ = self.mesh.borrow().faces().read().unwrap().data().as_ref().map(|faces| (*f)(faces.as_slice()));
     }
 
     /// Mutably access the object's texture coordinates.
     #[inline(always)]
     pub fn modify_uvs(&mut self, f: &mut |&mut Vec<Pnt2<GLfloat>>| -> ()) {
-        let _ = self.mesh.borrow_mut().uvs().write().data_mut().as_mut().map(|uvs| (*f)(uvs));
+        let _ = self.mesh.borrow_mut().uvs().write().unwrap().data_mut().as_mut().map(|uvs| (*f)(uvs));
     }
 
     /// Access the object's texture coordinates.
     #[inline(always)]
     pub fn read_uvs(&self, f: &mut |&[Pnt2<GLfloat>]| -> ()) {
-        let _ = self.mesh.borrow().uvs().read().data().as_ref().map(|uvs| (*f)(uvs.as_slice()));
+        let _ = self.mesh.borrow().uvs().read().unwrap().data().as_ref().map(|uvs| (*f)(uvs.as_slice()));
     }
 
 

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -47,7 +47,7 @@ impl Font {
             face:             ptr::null_mut(),
             texture_atlas:    0,
             atlas_dimensions: na::zero(),
-            glyphs:           Vec::from_fn(128, |_| None),
+            glyphs:           range(0, 128).map(|_:int| None).collect(),
             height:           0,
             nocpy:            NoCopy
         };

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -9,6 +9,7 @@ use std::io::timer::Timer;
 use std::cell::RefCell;
 use std::rc::Rc;
 use libc;
+use std::iter::repeat;
 use std::time::Duration;
 use time;
 use gl;
@@ -374,7 +375,7 @@ impl Window {
 
         if out.len() < size {
             let diff = size - out.len();
-            out.grow(diff, 0);
+	    out.extend(repeat(0).take(diff));
         }
         else {
             out.truncate(size)


### PR DESCRIPTION
Main thing is unwrapping RWLock return values -- see: https://github.com/rust-lang/rust/pull/19661
The other stuff is moving off deprecated iterator API to avoid warnings.
TODO: we may also want to pull kiss3d_recording out to a separate cargo project, since it appears Cargo can only produce one lib crate per project.