### PR TITLE
Remove unnecessary use of `#[repr(packed)]`.

### DIFF
--- a/src/text/glyph.rs
+++ b/src/text/glyph.rs
@@ -4,7 +4,6 @@
 
 use na::Vec2;
 
-#[repr(packed)]
 /// A ttf glyph.
 pub struct Glyph {
     #[doc(hidden)]


### PR DESCRIPTION
This struct is laid out the same way with or without `packed`, since
the leading fields are all `Vec2`s and so will be densely packed, and
each of those `Vec2<f32>`s is 8 bytes, so the `Vec<u8>` field is also
always going to be always aligned (8 bytes on 64-bit platforms).

The removal is good because there's some correctness issues with it, so
there may be breaking changes to it in future and removing it now will
avoid them all together. See
https://github.com/rust-lang/rust/issues/27060.