### PR TITLE
Add public fn to Arc_Ball for mutating the "at" position

### DIFF
--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -77,6 +77,11 @@ impl ArcBall {
         self.at
     }
 
+    /// Get a mutable reference to the point the camera is looking at.
+    pub fn at_mut(&mut self) -> &mut Pnt3<f32> {
+        &mut self.at
+    }
+
     /// The arc-ball camera `yaw`.
     pub fn yaw(&self) -> f32 {
         self.yaw

--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -78,8 +78,9 @@ impl ArcBall {
     }
 
     /// Get a mutable reference to the point the camera is looking at.
-    pub fn at_mut(&mut self) -> &mut Pnt3<f32> {
-        &mut self.at
+    pub fn set_at(&mut self, at: Pnt3<f32>) {
+        self.at = at;
+        self.update_projviews();
     }
 
     /// The arc-ball camera `yaw`.


### PR DESCRIPTION
I wanted to just change the `at` position, but wasn't able to without this function.

Thanks for an awesome lib!