### PR TITLE
Add `snap_image` function

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,0 +1,27 @@
+extern crate kiss3d;
+extern crate nalgebra as na;
+
+use std::path::Path;
+
+use na::Vec3;
+use kiss3d::window::Window;
+use kiss3d::light::Light;
+
+// Based on cube example.
+fn main() {
+    let mut window = Window::new("Kiss3d: cube");
+    let mut c      = window.add_cube(0.2, 0.2, 0.2);
+
+    c.set_color(1.0, 0.0, 0.0);
+    c.prepend_to_local_rotation(&Vec3::new(0.0f32, 0.785, 0.0));
+    c.prepend_to_local_rotation(&Vec3::new(-0.6f32, 0.0, 0.0));
+
+    window.set_light(Light::StickToCamera);
+
+    while window.render() {
+        let img = window.snap_image();
+        let img_path = Path::new("cube.png");
+        img.save(img_path).unwrap();
+        break;
+    }
+}

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -15,6 +15,8 @@ use std::iter::repeat;
 use time;
 use gl;
 use gl::types::*;
+use image::{ImageBuffer,Rgb};
+use image::imageops;
 use na::{Pnt2, Vec2, Vec3, Pnt3};
 use na;
 use ncollide_procedural::TriMesh3;
@@ -408,6 +410,16 @@ impl Window {
                            gl::UNSIGNED_BYTE,
                            mem::transmute(&mut out[0]));
         }
+    }
+    
+    /// Get the current screen as an image
+    pub fn snap_image(&self) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
+        let (width, height) = self.window.get_size();
+        let mut buf = Vec::new();
+        self.snap(&mut buf);
+        let img_opt = ImageBuffer::from_vec(width as u32, height as u32, buf);
+        let img = img_opt.expect("Buffer created from window was not big enough for image.");
+        imageops::flip_vertical(&img)
     }
 
     /// Gets the events manager that gives access to an event iterator.


### PR DESCRIPTION
This mainly adds a `snap_image` function to `Window`, allowing easier saving of screenshots. Also comes with an example.

Note that this also has PR #59 already in it because I found it easier for testing, so if you want to accept both, you should accept #59 first; if you don't like #59 but do like this one, I can disentangle the two.