### PR TITLE
Add (get|set)_projection methods to FirstPerson camera.

### DIFF
--- a/src/camera/first_person.rs
+++ b/src/camera/first_person.rs
@@ -74,6 +74,17 @@ impl FirstPerson {
         self.pitch_step = step;
     }
 
+    /// Sets the 3D projection.
+    ///
+    /// The default value is 1.3333334.
+    #[inline]
+    pub fn set_projection(&mut self, aspect: f32, fov: f32, znear: f32, zfar: f32) {
+        self.projection = PerspMat3::new(aspect, fov, znear, zfar);
+    }
+
+    pub fn get_projection(&mut self) -> PerspMat3<f32> {
+        self.projection
+    }
 
     /// Sets the yaw increment per mouse movement.
     ///


### PR DESCRIPTION
I could not come up with any documentation that was useful.
I tried requiring a `PerspMat3` but I am very new to Rust so could not seem to get this done properly.