### PR TITLE
code example updated to reflect nalgebra changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ As an example, having a red, rotating cube with the light attached to the camera
 extern crate kiss3d;
 extern crate nalgebra as na;
 
-use na::Vec3;
+use na::Vector3;
 use kiss3d::window::Window;
 use kiss3d::light::Light;
 
@@ -47,7 +47,7 @@ fn main() {
     window.set_light(Light::StickToCamera);
 
     while window.render() {
-        c.prepend_to_local_rotation(&Vec3::new(0.0f32, 0.014, 0.0));
+        c.prepend_to_local_rotation(&Vector3::new(0.0f32, 0.014, 0.0));
     }
 }
 ```


### PR DESCRIPTION
In nalgebra, the name of the 3d vector changed. This caused the example code in the readme to not compile. This is just a minor change to keep the readme up-to-date.