### PR TITLE
SceneNode.unlink now removes the parent from its data.

### DIFF
--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -578,7 +578,8 @@ impl SceneNode {
     /// Removes this node from its parent.
     pub fn unlink(&mut self) {
         let self_self = self.clone();
-        self.data_mut().remove_from_parent(&self_self)
+        self.data_mut().remove_from_parent(&self_self);
+        self.data_mut().parent = None
     }
 
     /// The data of this scene node.


### PR DESCRIPTION
Before, node.unlink would not touch node.data_mut().parent, which prevented you from adding the node back to the scene later. Now the parent is reset to None and adding a node back works.