### PR TITLE
Allow rebinding of camera buttons

### DIFF
--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -36,6 +36,7 @@ pub struct ArcBall {
     dist_step:  f32,
     rotate_button: Option<MouseButton>,
     drag_button:   Option<MouseButton>,
+    reset_key:     Option<Key>,
 
     projection:      PerspectiveMatrix3<f32>,
     proj_view:       Matrix4<f32>,
@@ -63,8 +64,9 @@ impl ArcBall {
             yaw_step:        0.005,
             pitch_step:      0.005,
             dist_step:       40.0,
-            rotate_button:      Some(glfw::MouseButtonLeft),
-            drag_button:        Some(glfw::MouseButtonRight),
+            rotate_button:   Some(glfw::MouseButtonLeft),
+            drag_button:     Some(glfw::MouseButtonRight),
+            reset_key:       Some(Key::Enter),
             projection:      PerspectiveMatrix3::new(800.0 / 600.0, fov, znear, zfar),
             proj_view:       na::zero(),
             inverse_proj_view:   na::zero(),
@@ -162,7 +164,7 @@ impl ArcBall {
 
     /// Set the button used to rotate the ArcBall camera.
     /// Use None to disable rotation.
-    pub fn rebind_rotate_button(&mut self, new_button : Option<MouseButton>) {
+    pub fn rebind_rotate_button(&mut self, new_button: Option<MouseButton>) {
         self.rotate_button = new_button;
     }
 
@@ -173,8 +175,19 @@ impl ArcBall {
 
     /// Set the button used to drag the ArcBall camera.
     /// Use None to disable dragging.
-    pub fn rebind_drag_button(&mut self, new_button : Option<MouseButton>) {
+    pub fn rebind_drag_button(&mut self, new_button: Option<MouseButton>) {
         self.drag_button = new_button;
+    }
+
+    /// The key used to reset the ArcBall camera.
+    pub fn reset_key(&self) -> Option<Key> {
+        self.reset_key
+    }
+
+    /// Set the key used to reset the ArcBall camera.
+    /// Use None to disable reset.
+    pub fn rebind_reset_key(&mut self, new_key : Option<Key>) {
+        self.reset_key = new_key;
     }
 
     fn handle_left_button_displacement(&mut self, dpos: &Vector2<f32>) {
@@ -246,7 +259,7 @@ impl Camera for ArcBall {
 
                 self.last_cursor_pos = curr_pos;
             },
-            WindowEvent::Key(Key::Enter, _, Action::Press, _) => {
+            WindowEvent::Key(key, _, Action::Press, _) if Some(key) == self.reset_key => {
                 self.at = na::origin();
                 self.update_projviews();
             },

--- a/src/camera/first_person.rs
+++ b/src/camera/first_person.rs
@@ -21,8 +21,12 @@ pub struct FirstPerson {
     yaw_step:        f32,
     pitch_step:      f32,
     move_step:       f32,
-    rotate_button: Option<MouseButton>,
-    drag_button:   Option<MouseButton>,
+    rotate_button:   Option<MouseButton>,
+    drag_button:     Option<MouseButton>,
+    up_key:          Option<Key>,
+    down_key:        Option<Key>,
+    left_key:        Option<Key>,
+    right_key:       Option<Key>,
 
     projection:      PerspectiveMatrix3<f32>,
     proj_view:       Matrix4<f32>,
@@ -51,6 +55,10 @@ impl FirstPerson {
             move_step:       0.5,
             rotate_button:   Some(glfw::MouseButtonLeft),
             drag_button:     Some(glfw::MouseButtonRight),
+            up_key:          Some(Key::Up),
+            down_key:        Some(Key::Down),
+            left_key:        Some(Key::Left),
+            right_key:       Some(Key::Right),
             projection:      PerspectiveMatrix3::new(800.0 / 600.0, fov, znear, zfar),
             proj_view:       na::zero(),
             inverse_proj_view:   na::zero(),
@@ -145,7 +153,7 @@ impl FirstPerson {
 
     /// Set the button used to rotate the FirstPerson camera.
     /// Use None to disable rotation.
-    pub fn rebind_rotate_button(&mut self, new_button : Option<MouseButton>) {
+    pub fn rebind_rotate_button(&mut self, new_button: Option<MouseButton>) {
         self.rotate_button = new_button;
     }
 
@@ -156,8 +164,60 @@ impl FirstPerson {
 
     /// Set the button used to drag the FirstPerson camera.
     /// Use None to disable dragging.
-    pub fn rebind_drag_button(&mut self, new_button : Option<MouseButton>) {
+    pub fn rebind_drag_button(&mut self, new_button: Option<MouseButton>) {
         self.drag_button = new_button;
+    }
+
+    // The movement button for up.
+    pub fn up_key(&self) -> Option<Key> {
+        self.up_key
+    }
+
+    // The movement button for down.
+    pub fn down_key(&self) -> Option<Key> {
+        self.down_key
+    }
+
+    // The movement button for left.
+    pub fn left_key(&self) -> Option<Key> {
+        self.left_key
+    }
+
+    // The movement button for right.
+    pub fn right_key(&self) -> Option<Key> {
+        self.right_key
+    }
+
+    /// Set the movement button for up.
+    /// Use None to disable movement in this direction.
+    pub fn rebind_up_key(&mut self, new_key: Option<Key>) {
+        self.up_key = new_key;
+    }
+
+    /// Set the movement button for down.
+    /// Use None to disable movement in this direction.
+    pub fn rebind_down_key(&mut self, new_key: Option<Key>) {
+        self.down_key = new_key;
+    }
+
+    /// Set the movement button for left.
+    /// Use None to disable movement in this direction.
+    pub fn rebind_left_key(&mut self, new_key: Option<Key>) {
+        self.left_key = new_key;
+    }
+
+    /// Set the movement button for right.
+    /// Use None to disable movement in this direction.
+    pub fn rebind_right_key(&mut self, new_key: Option<Key>) {
+        self.right_key = new_key;
+    }
+
+    /// Disable the movement buttons for up, down, left and right.
+    pub fn unbind_movement_keys(&mut self) {
+        self.up_key    = None;
+        self.down_key  = None;
+        self.left_key  = None;
+        self.right_key = None;
     }
 
     #[doc(hidden)]
@@ -288,14 +348,22 @@ impl Camera for FirstPerson {
     }
 
     fn update(&mut self, window: &glfw::Window) {
-        let up    = window.get_key(Key::Up)    == Action::Press;
-        let down  = window.get_key(Key::Down)  == Action::Press;
-        let right = window.get_key(Key::Right) == Action::Press;
-        let left  = window.get_key(Key::Left)  == Action::Press;
+        let up    = check_optional_key_state(window, self.up_key,    Action::Press);
+        let down  = check_optional_key_state(window, self.down_key,  Action::Press);
+        let right = check_optional_key_state(window, self.right_key, Action::Press);
+        let left  = check_optional_key_state(window, self.left_key,  Action::Press);
         let dir   = self.move_dir(up, down, right, left);
 
         let move_amount  = dir * self.move_step;
         self.append_translation_mut(&move_amount);
+    }
+}
+
+fn check_optional_key_state(window: &glfw::Window, key: Option<Key>, key_state: Action) -> bool {
+    if let Some(actual_key) = key {
+        window.get_key(actual_key) == key_state
+    } else {
+        false
     }
 }
 

--- a/src/camera/first_person.rs
+++ b/src/camera/first_person.rs
@@ -1,7 +1,7 @@
 use std::f32;
 use num::Float;
 use glfw;
-use glfw::{Key, Action, WindowEvent};
+use glfw::{Key, MouseButton, Action, WindowEvent};
 use na::{Translation, Point3, Vector2, Vector3, Matrix4, Isometry3, PerspectiveMatrix3};
 use na;
 use camera::Camera;
@@ -21,6 +21,8 @@ pub struct FirstPerson {
     yaw_step:        f32,
     pitch_step:      f32,
     move_step:       f32,
+    rotate_button: Option<MouseButton>,
+    drag_button:   Option<MouseButton>,
 
     projection:      PerspectiveMatrix3<f32>,
     proj_view:       Matrix4<f32>,
@@ -47,6 +49,8 @@ impl FirstPerson {
             yaw_step:        0.005,
             pitch_step:      0.005,
             move_step:       0.5,
+            rotate_button:   Some(glfw::MouseButtonLeft),
+            drag_button:     Some(glfw::MouseButtonRight),
             projection:      PerspectiveMatrix3::new(800.0 / 600.0, fov, znear, zfar),
             proj_view:       na::zero(),
             inverse_proj_view:   na::zero(),
@@ -132,6 +136,28 @@ impl FirstPerson {
         if self.pitch > _pi - 0.01 {
             self.pitch = _pi - 0.01
         }
+    }
+
+    /// The button used to rotate the FirstPerson camera.
+    pub fn rotate_button(&self) -> Option<MouseButton> {
+        self.rotate_button
+    }
+
+    /// Set the button used to rotate the FirstPerson camera.
+    /// Use None to disable rotation.
+    pub fn rebind_rotate_button(&mut self, new_button : Option<MouseButton>) {
+        self.rotate_button = new_button;
+    }
+
+    /// The button used to drag the FirstPerson camera.
+    pub fn drag_button(&self) -> Option<MouseButton> {
+        self.drag_button
+    }
+
+    /// Set the button used to drag the FirstPerson camera.
+    /// Use None to disable dragging.
+    pub fn rebind_drag_button(&mut self, new_button : Option<MouseButton>) {
+        self.drag_button = new_button;
     }
 
     #[doc(hidden)]
@@ -224,14 +250,18 @@ impl Camera for FirstPerson {
             WindowEvent::CursorPos(x, y) => {
                 let curr_pos = Vector2::new(x as f32, y as f32);
 
-                if window.get_mouse_button(glfw::MouseButtonLeft) == Action::Press {
-                    let dpos = curr_pos - self.last_cursor_pos;
-                    self.handle_left_button_displacement(&dpos)
+                if let Some(rotate_button) = self.rotate_button {
+                    if window.get_mouse_button(rotate_button) == Action::Press {
+                        let dpos = curr_pos - self.last_cursor_pos;
+                        self.handle_left_button_displacement(&dpos)
+                    }
                 }
 
-                if window.get_mouse_button(glfw::MouseButtonRight) == Action::Press {
-                    let dpos = curr_pos - self.last_cursor_pos;
-                    self.handle_right_button_displacement(&dpos)
+                if let Some(drag_button) = self.drag_button {
+                    if window.get_mouse_button(drag_button) == Action::Press {
+                        let dpos = curr_pos - self.last_cursor_pos;
+                        self.handle_right_button_displacement(&dpos)
+                    }
                 }
 
                 self.last_cursor_pos = curr_pos;


### PR DESCRIPTION
This patch allows rebinding for some camera buttons, implementing my feature request from #80.

```rust
// This example disables dragging and uses the right button for panning.
camera.rebind_drag_button(None);
camera.rebind_rotate_button(Some(glfw::MouseButtonRight));
```

Right now I implemented it on ArcBalls and FirstPersons. I didn't change FirstPersonStereo as I can't test that. But I'm not quite sure if this is how it should be done.

- Should rebinding the buttons move into the Camera class? That only seems sensible if all cameras have the same control scheme.
- Should I also add rebinds for the motion buttons on the FirstPerson camera? Should I allow rebinds of the reset button (enter)?
- I skipped the reset button in this first iteration, as that would be somewhat ugly.

```rust
// Currently we have a pattern match.
// This wouldn't work anymore with a rebindable reset button.
WindowEvent::Key(Key::Enter, _, Action::Press, _) => {
    self.at = na::origin();
    self.update_projviews()
},
```

Thoughts?