### PR TITLE
Fixed the update to the latest nalgebra api (commit e50fb42ca0d4e5a98385cb239f92efbd89a73b8c) which replaced all the Material by Matrixerial

### DIFF
--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -11,12 +11,12 @@ use kiss3d::window::Window;
 use kiss3d::scene::ObjectData;
 use kiss3d::camera::Camera;
 use kiss3d::light::Light;
-use kiss3d::resource::{Shader, ShaderAttribute, ShaderUniform, Matrixerial, Mesh};
+use kiss3d::resource::{Shader, ShaderAttribute, ShaderUniform, Material, Mesh};
 
 fn main() {
     let mut window = Window::new("Kiss3d: custom_material");
     let mut c      = window.add_sphere(1.0);
-    let material   = Rc::new(RefCell::new(Box::new(NormalMatrixerial::new()) as Box<Matrixerial + 'static>));
+    let material   = Rc::new(RefCell::new(Box::new(NormalMaterial::new()) as Box<Material + 'static>));
 
     c.set_material(material);
 
@@ -26,7 +26,7 @@ fn main() {
 }
 
 // A material that draws normals
-pub struct NormalMatrixerial {
+pub struct NormalMaterial {
     shader:    Shader,
     position:  ShaderAttribute<Point3<f32>>,
     normal:    ShaderAttribute<Vector3<f32>>,
@@ -35,13 +35,13 @@ pub struct NormalMatrixerial {
     scale:     ShaderUniform<Matrix3<f32>>
 }
 
-impl NormalMatrixerial {
-    pub fn new() -> NormalMatrixerial {
+impl NormalMaterial {
+    pub fn new() -> NormalMaterial {
         let mut shader = Shader::new_from_str(NORMAL_VERTEX_SRC, NORMAL_FRAGMENT_SRC);
 
         shader.use_program();
 
-        NormalMatrixerial {
+        NormalMaterial {
             position:  shader.get_attrib("position").unwrap(),
             normal:    shader.get_attrib("normal").unwrap(),
             transform: shader.get_uniform("transform").unwrap(),
@@ -52,7 +52,7 @@ impl NormalMatrixerial {
     }
 }
 
-impl Matrixerial for NormalMatrixerial {
+impl Material for NormalMaterial {
     fn render(&mut self,
               pass:      usize,
               transform: &Isometry3<f32>,

--- a/examples/relativity.rs
+++ b/examples/relativity.rs
@@ -20,7 +20,7 @@ use kiss3d::text::Font;
 use kiss3d::scene::ObjectData;
 use kiss3d::camera::{Camera, FirstPerson};
 use kiss3d::light::Light;
-use kiss3d::resource::{Shader, ShaderAttribute, ShaderUniform, Matrixerial, Mesh};
+use kiss3d::resource::{Shader, ShaderAttribute, ShaderUniform, Material, Mesh};
 
 fn main() {
     let mut window = Window::new("Kiss3d: relativity");
@@ -30,7 +30,7 @@ fn main() {
     let fov      = f32::consts::PI / 4.0;
     let font     = Font::new(&Path::new("media/font/Inconsolata.otf"), 60);
     let context  = Arc::new(RwLock::new(Context::new(1000.0, na::zero(), eye)));
-    let material = Rc::new(RefCell::new(Box::new(RelativisticMatrixerial::new(context.clone())) as Box<Matrixerial + 'static>));
+    let material = Rc::new(RefCell::new(Box::new(RelativisticMaterial::new(context.clone())) as Box<Material + 'static>));
     let mut observer = InertialCamera::new(fov, 0.1, 100000.0, eye, at);
 
     window.set_framerate_limit(Some(60));
@@ -190,7 +190,7 @@ impl Context {
 }
 
 /// The default material used to draw objects.
-struct RelativisticMatrixerial {
+struct RelativisticMaterial {
     context:         Arc<RwLock<Context>>,
     shader:          Shader,
     pos:             ShaderAttribute<Point3<f32>>,
@@ -208,16 +208,16 @@ struct RelativisticMatrixerial {
     player_position: ShaderUniform<Point3<f32>>
 }
 
-impl RelativisticMatrixerial {
-    /// Creates a new `RelativisticMatrixerial`.
-    fn new(context: Arc<RwLock<Context>>) -> RelativisticMatrixerial {
+impl RelativisticMaterial {
+    /// Creates a new `RelativisticMaterial`.
+    fn new(context: Arc<RwLock<Context>>) -> RelativisticMaterial {
         // load the shader
         let mut shader = Shader::new_from_str(RELATIVISTIC_VERTEX_SRC, RELATIVISTIC_FRAGMENT_SRC);
 
         shader.use_program();
 
         // get the variables locations
-        RelativisticMatrixerial {
+        RelativisticMaterial {
             context:         context,
             pos:             shader.get_attrib("position").unwrap(),
             normal:          shader.get_attrib("normal").unwrap(),
@@ -250,7 +250,7 @@ impl RelativisticMatrixerial {
     }
 }
 
-impl Matrixerial for RelativisticMatrixerial {
+impl Material for RelativisticMaterial {
     fn render(&mut self,
               pass:      usize,
               transform: &Isometry3<f32>, 

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -1,8 +1,8 @@
 //! Built-in geometries, shaders and effects.
 
-pub use builtin::object_material::{OBJECT_VERTEX_SRC, OBJECT_FRAGMENT_SRC, ObjectMatrixerial};
-pub use builtin::normals_material::{NORMAL_VERTEX_SRC, NORMAL_FRAGMENT_SRC, NormalsMatrixerial};
-pub use builtin::uvs_material::{UVS_VERTEX_SRC, UVS_FRAGMENT_SRC, UvsMatrixerial};
+pub use builtin::object_material::{OBJECT_VERTEX_SRC, OBJECT_FRAGMENT_SRC, ObjectMaterial};
+pub use builtin::normals_material::{NORMAL_VERTEX_SRC, NORMAL_FRAGMENT_SRC, NormalsMaterial};
+pub use builtin::uvs_material::{UVS_VERTEX_SRC, UVS_FRAGMENT_SRC, UvsMaterial};
 
 mod object_material;
 mod normals_material;

--- a/src/builtin/normals_material.rs
+++ b/src/builtin/normals_material.rs
@@ -3,7 +3,7 @@ use gl;
 use gl::types::*;
 use na::{Point3, Vector3, Matrix3, Matrix4, Isometry3};
 use na;
-use resource::Matrixerial;
+use resource::Material;
 use scene::ObjectData;
 use light::Light;
 use camera::Camera;
@@ -14,7 +14,7 @@ mod error;
 
 
 /// A material that draws normals of an object.
-pub struct NormalsMatrixerial {
+pub struct NormalsMaterial {
     shader:    Shader,
     position:  ShaderAttribute<Point3<f32>>,
     normal:    ShaderAttribute<Vector3<f32>>,
@@ -23,14 +23,14 @@ pub struct NormalsMatrixerial {
     scale:     ShaderUniform<Matrix3<f32>>
 }
 
-impl NormalsMatrixerial {
-    /// Creates a new NormalsMatrixerial.
-    pub fn new() -> NormalsMatrixerial {
+impl NormalsMaterial {
+    /// Creates a new NormalsMaterial.
+    pub fn new() -> NormalsMaterial {
         let mut shader = Shader::new_from_str(NORMAL_VERTEX_SRC, NORMAL_FRAGMENT_SRC);
 
         shader.use_program();
 
-        NormalsMatrixerial {
+        NormalsMaterial {
             position:  shader.get_attrib("position").unwrap(),
             normal:    shader.get_attrib("normal").unwrap(),
             transform: shader.get_uniform("transform").unwrap(),
@@ -41,7 +41,7 @@ impl NormalsMatrixerial {
     }
 }
 
-impl Matrixerial for NormalsMatrixerial {
+impl Material for NormalsMaterial {
     fn render(&mut self,
               pass:      usize,
               transform: &Isometry3<f32>,
@@ -132,4 +132,3 @@ void main() {
     gl_FragColor = vec4((ls_normal + 1.0) / 2.0, 1.0);
 }
 ";
-

--- a/src/builtin/object_material.rs
+++ b/src/builtin/object_material.rs
@@ -3,7 +3,7 @@ use gl;
 use gl::types::*;
 use na::{Point2, Point3, Vector3, Matrix3, Matrix4, Isometry3};
 use na;
-use resource::Matrixerial;
+use resource::Material;
 use scene::ObjectData;
 use light::Light;
 use camera::Camera;
@@ -13,7 +13,7 @@ use resource::{Mesh, Shader, ShaderAttribute, ShaderUniform};
 mod error;
 
 /// The default material used to draw objects.
-pub struct ObjectMatrixerial {
+pub struct ObjectMaterial {
     shader:     Shader,
     pos:        ShaderAttribute<Point3<f32>>,
     normal:     ShaderAttribute<Vector3<f32>>,
@@ -26,16 +26,16 @@ pub struct ObjectMatrixerial {
     view:       ShaderUniform<Matrix4<f32>>
 }
 
-impl ObjectMatrixerial {
-    /// Creates a new `ObjectMatrixerial`.
-    pub fn new() -> ObjectMatrixerial {
+impl ObjectMaterial {
+    /// Creates a new `ObjectMaterial`.
+    pub fn new() -> ObjectMaterial {
         // load the shader
         let mut shader = Shader::new_from_str(OBJECT_VERTEX_SRC, OBJECT_FRAGMENT_SRC);
 
         shader.use_program();
 
         // get the variables locations
-        ObjectMatrixerial {
+        ObjectMaterial {
             pos:        shader.get_attrib("position").unwrap(),
             normal:     shader.get_attrib("normal").unwrap(),
             tex_coord:  shader.get_attrib("tex_coord_v").unwrap(),
@@ -63,7 +63,7 @@ impl ObjectMatrixerial {
     }
 }
 
-impl Matrixerial for ObjectMatrixerial {
+impl Material for ObjectMaterial {
     fn render(&mut self,
               pass:      usize,
               transform: &Isometry3<f32>,

--- a/src/builtin/uvs_material.rs
+++ b/src/builtin/uvs_material.rs
@@ -3,7 +3,7 @@ use gl;
 use gl::types::*;
 use na::{Point3, Point2, Vector3, Matrix3, Matrix4, Isometry3};
 use na;
-use resource::Matrixerial;
+use resource::Material;
 use scene::ObjectData;
 use light::Light;
 use camera::Camera;
@@ -14,7 +14,7 @@ mod error;
 
 
 /// A material that draws normals of an object.
-pub struct UvsMatrixerial {
+pub struct UvsMaterial {
     shader:    Shader,
     position:  ShaderAttribute<Point3<f32>>,
     uvs:       ShaderAttribute<Point2<f32>>,
@@ -23,14 +23,14 @@ pub struct UvsMatrixerial {
     scale:     ShaderUniform<Matrix3<f32>>
 }
 
-impl UvsMatrixerial {
-    /// Creates a new UvsMatrixerial.
-    pub fn new() -> UvsMatrixerial {
+impl UvsMaterial {
+    /// Creates a new UvsMaterial.
+    pub fn new() -> UvsMaterial {
         let mut shader = Shader::new_from_str(UVS_VERTEX_SRC, UVS_FRAGMENT_SRC);
 
         shader.use_program();
 
-        UvsMatrixerial {
+        UvsMaterial {
             position:  shader.get_attrib("position").unwrap(),
             uvs:       shader.get_attrib("uvs").unwrap(),
             transform: shader.get_uniform("transform").unwrap(),
@@ -41,7 +41,7 @@ impl UvsMatrixerial {
     }
 }
 
-impl Matrixerial for UvsMatrixerial {
+impl Material for UvsMaterial {
     fn render(&mut self,
               pass:      usize,
               transform: &Isometry3<f32>,

--- a/src/loader/mtl.rs
+++ b/src/loader/mtl.rs
@@ -15,7 +15,7 @@ fn error(line: usize, err: &str) -> ! {
 }
 
 /// Parses a mtl file.
-pub fn parse_file(path: &Path) -> IoResult<Vec<MtlMatrixerial>> {
+pub fn parse_file(path: &Path) -> IoResult<Vec<MtlMaterial>> {
     match File::open(path) {
         Ok(mut file) => {
             let mut sfile = String::new();
@@ -26,9 +26,9 @@ pub fn parse_file(path: &Path) -> IoResult<Vec<MtlMatrixerial>> {
 }
 
 /// Parses a string representing a mtl file.
-pub fn parse(string: &str) -> Vec<MtlMatrixerial> {
+pub fn parse(string: &str) -> Vec<MtlMaterial> {
     let mut res           = Vec::new();
-    let mut curr_material = MtlMatrixerial::new_default("".to_string());
+    let mut curr_material = MtlMaterial::new_default("".to_string());
 
     for (l, line) in string.lines().enumerate() {
         let mut words = obj::split_words(line);
@@ -48,7 +48,7 @@ pub fn parse(string: &str) -> Vec<MtlMatrixerial> {
                     match w {
                         // texture name
                         "newmtl"      => {
-                            let old = mem::replace(&mut curr_material, MtlMatrixerial::new_default(parse_name(l, words)));
+                            let old = mem::replace(&mut curr_material, MtlMaterial::new_default(parse_name(l, words)));
 
                             if old.name.len() != 0 {
                                 res.push(old);
@@ -119,9 +119,9 @@ fn parse_scalar(l: usize, mut ws: Words) -> f32 {
     x
 }
 
-/// Matrixerial informations read from a `.mtl` file.
+/// Material informations read from a `.mtl` file.
 #[derive(Clone)]
-pub struct MtlMatrixerial {
+pub struct MtlMaterial {
     /// Name of the material.
     pub name:             String,
     /// Path to the ambiant texture.
@@ -144,10 +144,10 @@ pub struct MtlMatrixerial {
     pub alpha:            f32,
 }
 
-impl MtlMatrixerial {
+impl MtlMaterial {
     /// Creates a new mtl material with a name and default values.
-    pub fn new_default(name: String) -> MtlMatrixerial {
-        MtlMatrixerial {
+    pub fn new_default(name: String) -> MtlMaterial {
+        MtlMaterial {
             name:             name,
             shininess:        60.0,
             alpha:            1.0,
@@ -172,8 +172,8 @@ impl MtlMatrixerial {
                diffuse_texture:  Option<String>,
                specular_texture: Option<String>,
                opacity_map:      Option<String>)
-               -> MtlMatrixerial {
-        MtlMatrixerial {
+               -> MtlMaterial {
+        MtlMaterial {
             name:             name,
             ambiant:          ambiant,
             diffuse:          diffuse,

--- a/src/loader/obj.rs
+++ b/src/loader/obj.rs
@@ -15,7 +15,7 @@ use gl::types::GLfloat;
 use na::{Vector3, Point2, Point3, Bounded};
 use na;
 use resource::{BufferType, AllocationType, Mesh};
-use loader::mtl::MtlMatrixerial;
+use loader::mtl::MtlMaterial;
 use loader::mtl;
 use resource::GPUVec;
 
@@ -50,7 +50,7 @@ fn warn(line: usize, err: &str) {
 }
 
 /// Parses an obj file.
-pub fn parse_file(path: &Path, mtl_base_dir: &Path, basename: &str) -> IoResult<Vec<(String, Mesh, Option<MtlMatrixerial>)>> {
+pub fn parse_file(path: &Path, mtl_base_dir: &Path, basename: &str) -> IoResult<Vec<(String, Mesh, Option<MtlMaterial>)>> {
     match File::open(path) {
         Ok(mut file) => {
             let mut sfile = String::new();
@@ -61,7 +61,7 @@ pub fn parse_file(path: &Path, mtl_base_dir: &Path, basename: &str) -> IoResult<
 }
 
 /// Parses a string representing an obj file.
-pub fn parse(string: &str, mtl_base_dir: &Path, basename: &str) -> Vec<(String, Mesh, Option<MtlMatrixerial>)> {
+pub fn parse(string: &str, mtl_base_dir: &Path, basename: &str) -> Vec<(String, Mesh, Option<MtlMaterial>)> {
     let mut coords:     Vec<Coord>             = Vec::new();
     let mut normals:    Vec<Normal>            = Vec::new();
     let mut uvs:        Vec<UV>                = Vec::new();
@@ -72,7 +72,7 @@ pub fn parse(string: &str, mtl_base_dir: &Path, basename: &str) -> Vec<(String, 
     let mut ignore_uvs                         = false;
     let mut mtllib                             = HashMap::new();
     let mut group2mtl                          = HashMap::new();
-    let mut curr_mtl                           = None::<MtlMatrixerial>;
+    let mut curr_mtl                           = None::<MtlMaterial>;
 
     groups_ids.push(Vec::new());
     let _ = groups.insert(basename.to_string(), 0);
@@ -124,11 +124,11 @@ pub fn parse(string: &str, mtl_base_dir: &Path, basename: &str) -> Vec<(String, 
 fn parse_usemtl<'a>(l:          usize,
                     ws:         Words<'a>,
                     curr_group: usize,
-                    mtllib:     &HashMap<String, MtlMatrixerial>,
-                    group2mtl:  &mut HashMap<usize, MtlMatrixerial>,
+                    mtllib:     &HashMap<String, MtlMaterial>,
+                    group2mtl:  &mut HashMap<usize, MtlMaterial>,
                     groups:     &mut HashMap<String, usize>,
                     groups_ids: &mut Vec<Vec<Point3<u32>>>,
-                    curr_mtl:   &mut Option<MtlMatrixerial>)
+                    curr_mtl:   &mut Option<MtlMaterial>)
                     -> usize {
     let mname: Vec<&'a str> = ws.collect();
     let mname = mname.join(" ");
@@ -172,7 +172,7 @@ fn parse_usemtl<'a>(l:          usize,
 fn parse_mtllib<'a>(l:            usize,
                     ws:           Words<'a>,
                     mtl_base_dir: &Path,
-                    mtllib:       &mut HashMap<String, MtlMatrixerial>) {
+                    mtllib:       &mut HashMap<String, MtlMaterial>) {
     let filename: Vec<&'a str> = ws.collect();
     let filename = filename.join(" ");
 
@@ -331,8 +331,8 @@ fn reformat(coords:     Vec<Coord>,
             uvs:        Option<Vec<UV>>,
             groups_ids: Vec<Vec<Point3<u32>>>,
             groups:     HashMap<String, usize>,
-            group2mtl:  HashMap<usize, MtlMatrixerial>)
-            -> Vec<(String, Mesh, Option<MtlMatrixerial>)> {
+            group2mtl:  HashMap<usize, MtlMaterial>)
+            -> Vec<(String, Mesh, Option<MtlMaterial>)> {
     let mut vt2id:  HashMap<Point3<u32>, u32> = HashMap::new();
     let mut vertex_ids: Vec<u32>            = Vec::new();
     let mut resc: Vec<Coord>                = Vec::new();
@@ -341,7 +341,7 @@ fn reformat(coords:     Vec<Coord>,
     let mut resfs: Vec<Vec<Point3<u32>>>      = Vec::new();
     let mut allfs: Vec<Point3<u32>>           = Vec::new();
     let mut names: Vec<String>              = Vec::new();
-    let mut mtls:  Vec<Option<MtlMatrixerial>> = Vec::new();
+    let mut mtls:  Vec<Option<MtlMaterial>> = Vec::new();
 
     for (name, i) in groups.into_iter() {
         names.push(name);

--- a/src/resource/material.rs
+++ b/src/resource/material.rs
@@ -7,7 +7,7 @@ use scene::ObjectData;
 use resource::Mesh;
 
 /// Trait implemented by materials.
-pub trait Matrixerial {
+pub trait Material {
     // FIXME: add the number of the current pass?
     /// Renders an object using this material.
     fn render(&mut self,

--- a/src/resource/material_manager.rs
+++ b/src/resource/material_manager.rs
@@ -3,10 +3,10 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use resource::Matrixerial;
-use builtin::{ObjectMatrixerial, NormalsMatrixerial, UvsMatrixerial};
+use resource::Material;
+use builtin::{ObjectMaterial, NormalsMaterial, UvsMaterial};
 
-thread_local!(static KEY_MATERIAL_MANAGER: RefCell<MatrixerialManager> = RefCell::new(MatrixerialManager::new()));
+thread_local!(static KEY_MATERIAL_MANAGER: RefCell<MaterialManager> = RefCell::new(MaterialManager::new()));
 
 /// The material manager.
 ///
@@ -16,49 +16,49 @@ thread_local!(static KEY_MATERIAL_MANAGER: RefCell<MatrixerialManager> = RefCell
 ///
 /// It keeps a cache of already-loaded materials. Note that this is only a cache, nothing more.
 /// Thus, its usage is not required to load materials.
-pub struct MatrixerialManager {
-    default_material: Rc<RefCell<Box<Matrixerial + 'static>>>,
-    materials:        HashMap<String, Rc<RefCell<Box<Matrixerial + 'static>>>>
+pub struct MaterialManager {
+    default_material: Rc<RefCell<Box<Material + 'static>>>,
+    materials:        HashMap<String, Rc<RefCell<Box<Material + 'static>>>>
 }
 
-impl MatrixerialManager {
+impl MaterialManager {
     /// Creates a new material manager.
-    pub fn new() -> MatrixerialManager {
-        // load the default ObjectMatrixerial and the LineMatrixerial
+    pub fn new() -> MaterialManager {
+        // load the default ObjectMaterial and the LineMaterial
         let mut materials = HashMap::new();
 
-        let om = Rc::new(RefCell::new(Box::new(ObjectMatrixerial::new()) as Box<Matrixerial + 'static>));
+        let om = Rc::new(RefCell::new(Box::new(ObjectMaterial::new()) as Box<Material + 'static>));
         let _ = materials.insert("object".to_string(), om.clone());
 
-        let nm = Rc::new(RefCell::new(Box::new(NormalsMatrixerial::new()) as Box<Matrixerial + 'static>));
+        let nm = Rc::new(RefCell::new(Box::new(NormalsMaterial::new()) as Box<Material + 'static>));
         let _ = materials.insert("normals".to_string(), nm.clone());
 
-        let um = Rc::new(RefCell::new(Box::new(UvsMatrixerial::new()) as Box<Matrixerial + 'static>));
+        let um = Rc::new(RefCell::new(Box::new(UvsMaterial::new()) as Box<Material + 'static>));
         let _ = materials.insert("uvs".to_string(), um.clone());
 
-        MatrixerialManager {
+        MaterialManager {
             default_material: om,
             materials:        materials
         }
     }
 
     /// Mutably applies a function to the material manager.
-    pub fn get_global_manager<T, F: FnMut(&mut MatrixerialManager) -> T>(mut f: F) -> T {
+    pub fn get_global_manager<T, F: FnMut(&mut MaterialManager) -> T>(mut f: F) -> T {
         KEY_MATERIAL_MANAGER.with(|manager| f(&mut *manager.borrow_mut()))
     }
 
     /// Gets the default material to draw objects.
-    pub fn get_default(&self) -> Rc<RefCell<Box<Matrixerial + 'static>>> {
+    pub fn get_default(&self) -> Rc<RefCell<Box<Material + 'static>>> {
         self.default_material.clone()
     }
 
     /// Get a material with the specified name. Returns `None` if the material is not registered.
-    pub fn get(&mut self, name: &str) -> Option<Rc<RefCell<Box<Matrixerial + 'static>>>> {
+    pub fn get(&mut self, name: &str) -> Option<Rc<RefCell<Box<Material + 'static>>>> {
         self.materials.get(&name.to_string()).map(|t| t.clone())
     }
 
     /// Adds a material with the specified name to this cache.
-    pub fn add(&mut self, material: Rc<RefCell<Box<Matrixerial + 'static>>>, name: &str) {
+    pub fn add(&mut self, material: Rc<RefCell<Box<Material + 'static>>>, name: &str) {
         let _ = self.materials.insert(name.to_string(), material);
     }
 

--- a/src/resource/mesh_manager.rs
+++ b/src/resource/mesh_manager.rs
@@ -9,7 +9,7 @@ use ncollide_procedural::TriMesh3;
 use ncollide_procedural as procedural;
 use resource::Mesh;
 use loader::obj;
-use loader::mtl::MtlMatrixerial;
+use loader::mtl::MtlMaterial;
 
 thread_local!(static KEY_MESH_MANAGER: RefCell<MeshManager> = RefCell::new(MeshManager::new()));
 
@@ -71,7 +71,7 @@ impl MeshManager {
     // FIXME: is this the right place to put this?
     /// Loads the meshes described by an obj file.
     pub fn load_obj(path: &Path, mtl_dir: &Path, geometry_name: &str)
-                    -> IoResult<Vec<(String, Rc<RefCell<Mesh>>, Option<MtlMatrixerial>)>> {
+                    -> IoResult<Vec<(String, Rc<RefCell<Mesh>>, Option<MtlMaterial>)>> {
         obj::parse_file(path, mtl_dir, geometry_name).map(|ms| {
             let mut res = Vec::new();
 

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -2,8 +2,8 @@
 
 pub use resource::framebuffer_manager::{FramebufferManager, RenderTarget, OffscreenBuffers};
 pub use resource::texture_manager::{Texture, TextureManager};
-pub use resource::material::Matrixerial;
-pub use resource::material_manager::MatrixerialManager;
+pub use resource::material::Material;
+pub use resource::material_manager::MaterialManager;
 pub use resource::mesh_manager::MeshManager;
 pub use resource::shader::{Shader, ShaderAttribute, ShaderUniform};
 pub use resource::gpu_vector::{GPUVec, BufferType, AllocationType};

--- a/src/scene/object.rs
+++ b/src/scene/object.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use std::path::Path;
 use gl::types::*;
 use na::{Point3, Point2, Vector3, Isometry3};
-use resource::{Texture, TextureManager, Matrixerial, Mesh};
+use resource::{Texture, TextureManager, Material, Mesh};
 use camera::Camera;
 use light::Light;
 
@@ -15,7 +15,7 @@ mod error;
 
 /// Set of data identifying a scene node.
 pub struct ObjectData {
-    material:     Rc<RefCell<Box<Matrixerial + 'static>>>,
+    material:     Rc<RefCell<Box<Material + 'static>>>,
     texture:      Rc<Texture>,
     color:        Point3<f32>,
     wlines:       f32,
@@ -88,7 +88,7 @@ impl Object {
                g:            f32,
                b:            f32,
                texture:      Rc<Texture>,
-               material:     Rc<RefCell<Box<Matrixerial + 'static>>>) -> Object {
+               material:     Rc<RefCell<Box<Material + 'static>>>) -> Object {
         let user_data = ();
         let data = ObjectData {
             color:        Point3::new(r, g, b),
@@ -150,13 +150,13 @@ impl Object {
 
     /// Gets the material of this object.
     #[inline]
-    pub fn material(&self) -> Rc<RefCell<Box<Matrixerial + 'static>>> {
+    pub fn material(&self) -> Rc<RefCell<Box<Material + 'static>>> {
         self.data.material.clone()
     }
 
     /// Sets the material of this object.
     #[inline]
-    pub fn set_material(&mut self, material: Rc<RefCell<Box<Matrixerial + 'static>>>) {
+    pub fn set_material(&mut self, material: Rc<RefCell<Box<Material + 'static>>>) {
         self.data.material = material;
     }
 

--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -4,7 +4,7 @@ use std::mem;
 use std::path::{Path, PathBuf};
 use na;
 use na::{Isometry3, Point2, Vector3, Point3, Transformation, Rotation, Translation, RotationWithTranslation};
-use resource::{Mesh, MeshManager, Texture, TextureManager, Matrixerial, MatrixerialManager};
+use resource::{Mesh, MeshManager, Texture, TextureManager, Material, MaterialManager};
 use ncollide_procedural::TriMesh3;
 use ncollide_procedural as procedural;
 use scene::Object;
@@ -157,7 +157,7 @@ impl SceneNodeData {
     // we are on a leaf? (to avoid the call to a closure required by the apply_to_*).
     /// Sets the material of the objects contained by this node and its children.
     #[inline]
-    pub fn set_material(&mut self, material: Rc<RefCell<Box<Matrixerial + 'static>>>) {
+    pub fn set_material(&mut self, material: Rc<RefCell<Box<Material + 'static>>>) {
         self.apply_to_objects_mut(&mut |o| o.set_material(material.clone()))
     }
 
@@ -166,7 +166,7 @@ impl SceneNodeData {
     /// The material must already have been registered as `name`.
     #[inline]
     pub fn set_material_with_name(&mut self, name: &str) {
-        let material = MatrixerialManager::get_global_manager(|tm| tm.get(name).unwrap_or_else(
+        let material = MaterialManager::get_global_manager(|tm| tm.get(name).unwrap_or_else(
             || panic!("Invalid attempt to use the unregistered material: {}", name)));
 
         self.set_material(material)
@@ -721,7 +721,7 @@ impl SceneNode {
     /// Creates and adds a new object to this node children using a mesh.
     pub fn add_mesh(&mut self, mesh: Rc<RefCell<Mesh>>, scale: Vector3<f32>) -> SceneNode {
         let tex    = TextureManager::get_global_manager(|tm| tm.get_default());
-        let mat    = MatrixerialManager::get_global_manager(|mm| mm.get_default());
+        let mat    = MaterialManager::get_global_manager(|mm| mm.get_default());
         let object = Object::new(mesh, 1.0, 1.0, 1.0, tex, mat);
 
         self.add_object(scale, na::one(), object)
@@ -738,7 +738,7 @@ impl SceneNode {
     /// newly created node is added to this node's children.
     pub fn add_obj(&mut self, path: &Path, mtl_dir: &Path, scale: Vector3<f32>) -> SceneNode {
         let tex = TextureManager::get_global_manager(|tm| tm.get_default());
-        let mat = MatrixerialManager::get_global_manager(|mm| mm.get_default());
+        let mat = MaterialManager::get_global_manager(|mm| mm.get_default());
 
         // FIXME: is there some error-handling stuff to do here instead of the `let _`.
         let result = MeshManager::load_obj(path, mtl_dir, path.to_str().unwrap()).map(|objs| {
@@ -828,7 +828,7 @@ impl SceneNode {
 
     /// Sets the material of the objects contained by this node and its children.
     #[inline]
-    pub fn set_material(&mut self, material: Rc<RefCell<Box<Matrixerial + 'static>>>) {
+    pub fn set_material(&mut self, material: Rc<RefCell<Box<Material + 'static>>>) {
         self.data_mut().set_material(material)
     }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -25,7 +25,7 @@ use scene::SceneNode;
 use line_renderer::LineRenderer;
 use point_renderer::PointRenderer;
 use post_processing::PostProcessingEffect;
-use resource::{FramebufferManager, RenderTarget, Texture, TextureManager, Mesh, Matrixerial};
+use resource::{FramebufferManager, RenderTarget, Texture, TextureManager, Mesh, Material};
 use light::Light;
 use text::{TextRenderer, Font};
 use window::EventManager;


### PR DESCRIPTION
Hi, I found that the commit that aded support for the latest version of nalgebra changed all the occurences of the word Material to Matrixerial, I fixed it in the commit of my pull request.

Note:
The error in travis is:
"CMake 2.8.12 or higher is required.  You are running version 2.8.11.2"