### PR TITLE
Update example dependency now that 0.12 has been released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Simply add the following to your `Cargo.toml` file:
 
 ```
 [dependencies]
-kiss3d = "0.11"
+kiss3d = "0.12"
 ```
 
 


### PR DESCRIPTION
Verified that 0.12 has been pushed to crates, so the quickstart should point to the latest version.