### PR TITLE
Another guard to prevent GL_INVALID_OPERATION errors on exit

### DIFF
--- a/src/resource/gpu_vector.rs
+++ b/src/resource/gpu_vector.rs
@@ -27,7 +27,9 @@ impl GLHandle {
 impl Drop for GLHandle {
     fn drop(&mut self) {
         unsafe {
-            verify!(gl::DeleteBuffers(1, &self.handle))
+            if gl::IsBuffer(self.handle) != 0 {
+                verify!(gl::DeleteBuffers(1, &self.handle))
+            }
         }
     }
 }


### PR DESCRIPTION
I was playing around with the 'obj' example and it panicked when closing - I guess I never ran this example when I added the first batch of guards.