### PR TITLE
Enable setting the size of points when using the draw_point API.

### DIFF
--- a/src/point_renderer.rs
+++ b/src/point_renderer.rs
@@ -33,10 +33,15 @@ impl PointRenderer {
             shader:     shader
         }
     }
- 
+
     /// Indicates whether some points have to be drawn.
     pub fn needs_rendering(&self) -> bool {
         self.points.len() != 0
+    }
+
+    /// Sets the point size for the rendered points.
+    pub fn set_point_size(&mut self, pt_size: f32) {
+        verify!(gl::PointSize(pt_size));
     }
 
     /// Adds a line to be drawn during the next frame. Lines are not persistent between frames.

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -120,7 +120,7 @@ impl Window {
     pub fn set_framerate_limit(&mut self, fps: Option<u64>) {
         self.max_dur_per_frame = fps.map(|f| { assert!(f != 0); Duration::from_millis(1000 / f) })
     }
-    
+
     /// Set window title
     pub fn set_title(&mut self, title: &str) {
         self.window.set_title(title)
@@ -150,6 +150,12 @@ impl Window {
         self.background.x = r;
         self.background.y = g;
         self.background.z = b;
+    }
+
+    /// Set the size of all subsequent points to be drawn until the next time this function is envoked.
+    #[inline]
+    pub fn set_point_size(&mut self, pt_size: f32) {
+        self.point_renderer.set_point_size(pt_size);
     }
 
     // XXX: remove this (moved to the render_frame).
@@ -418,7 +424,7 @@ impl Window {
                            mem::transmute(&mut out[0]));
         }
     }
-    
+
     /// Get the current screen as an image
     pub fn snap_image(&self) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
         let (width, height) = self.window.get_size();
@@ -630,6 +636,7 @@ fn init_gl() {
     verify!(gl::FrontFace(gl::CCW));
     verify!(gl::Enable(gl::DEPTH_TEST));
     verify!(gl::Enable(gl::SCISSOR_TEST));
+    verify!(gl::Enable(gl::PROGRAM_POINT_SIZE));
     verify!(gl::DepthFunc(gl::LEQUAL));
     verify!(gl::FrontFace(gl::CCW));
     verify!(gl::Enable(gl::CULL_FACE));


### PR DESCRIPTION
This pull request augments the Window and PointRenderer API with a 'set_point_size' function that will allow the user to set the size of the points, in pixels, for all points in a single frame. This does not enable per point size setting. 

For simplicity, this function utilizes the glPointSize application-level function as opposed to the shader-level gl_PointSize function. This would likely have to switch to the shader version if per point size setting were to be supported.