### PR TITLE
add an example for creating and closing a window multipe times

### DIFF
--- a/examples/multi_windows.rs
+++ b/examples/multi_windows.rs
@@ -1,0 +1,12 @@
+extern crate kiss3d;
+
+use kiss3d::window::Window;
+
+fn main() {
+    for _ in 0..2 {
+        let mut window = Window::new("Kiss3d: window");
+        window.add_cube(1.0, 1.0, 1.0);
+        window.render();
+        window.close();
+    }
+}


### PR DESCRIPTION
This example will currently fail with:
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1281`,
 right: `0`', src/resource/effect.rs:86:9
