### PR TITLE
Function to change axis pointing upward on First Person camera [issue #122]

### DIFF
--- a/src/camera/first_person.rs
+++ b/src/camera/first_person.rs
@@ -34,6 +34,7 @@ pub struct FirstPerson {
     proj_view: Matrix4<f32>,
     inverse_proj_view: Matrix4<f32>,
     last_cursor_pos: Vector2<f32>,
+    up_axis: Vector3::y(),
 }
 
 impl FirstPerson {
@@ -326,6 +327,12 @@ impl FirstPerson {
         self.update_projviews();
     }
 
+    #[inline]
+    pub fn set_up_axis(&mut self, up_axis: Vector3<f32>) {
+        self.up_axis = up_axis;
+    }
+
+
     /// The camera observer local frame.
     fn observer_frame(&self) -> Isometry3<f32> {
         Isometry3::new_observer_frame(&self.eye, &self.at(), &Vector3::y())
@@ -339,7 +346,7 @@ impl Camera for FirstPerson {
 
     /// The camera view transformation (i-e transformation without projection).
     fn view_transform(&self) -> Isometry3<f32> {
-        Isometry3::look_at_rh(&self.eye, &self.at(), &Vector3::y())
+        Isometry3::look_at_rh(&self.eye, &self.at(), &self.up_axis)
     }
 
     fn handle_event(&mut self, canvas: &Canvas, event: &WindowEvent) {


### PR DESCRIPTION
Solves issue #122.
New function to change axis pointing upward on First Person camera.
Default is still Y axis.
Example:
```
let eye = Point3::new(20.0_f32, 20.0,  #20.0);
let at = Point3::origin();
let mut first_person = FirstPerson::new(eye, at);
first_person.set_up_axis(Vector3::z());
```