### PR TITLE
Function to change axis pointing upward on Arc Ball camera [issue #122]

### DIFF
--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -42,6 +42,7 @@ pub struct ArcBall {
     proj_view: Matrix4<f32>,
     inverse_proj_view: Matrix4<f32>,
     last_cursor_pos: Vector2<f32>,
+    up_axis: Vector3<f32>,
 }
 
 impl ArcBall {
@@ -75,6 +76,7 @@ impl ArcBall {
             proj_view: na::zero(),
             inverse_proj_view: na::zero(),
             last_cursor_pos: na::zero(),
+            up_axis: Vector3::y(),
         };
 
         res.look_at(eye, at);
@@ -227,6 +229,12 @@ impl ArcBall {
         self.proj_view = self.proj * self.view;
         self.inverse_proj_view = self.proj_view.try_inverse().unwrap();
     }
+
+    #[inline]
+    pub fn set_up_axis(&mut self, up_axis: Vector3<f32>) {
+        self.up_axis = up_axis;
+    }
+
 }
 
 impl Camera for ArcBall {
@@ -235,7 +243,7 @@ impl Camera for ArcBall {
     }
 
     fn view_transform(&self) -> Isometry3<f32> {
-        Isometry3::look_at_rh(&self.eye(), &self.at, &Vector3::y())
+        Isometry3::look_at_rh(&self.eye(), &self.at,  &self.up_axis)
     }
 
     fn eye(&self) -> Point3<f32> {


### PR DESCRIPTION
New function to change axis pointing upward on Arc Ball camera.

- Important! **Only camera view is affected, not camera movements.** It means camera movements using keyboard/mouse are only consistent when using Y axis up.
- Default is still Y axis up.
- Procedural objects are still pointing upward in Y direction when generated.
- Related to issue #122.

**Note: Making camera movements consistent with up-axis would require adding conditional statements in many functions, hence complexifying code source and increasing its length significantly. I'm not sure that's what you want in a KISS project.**

Example:

```
let eye = Point3::new(20.0_f32, 20.0,  20.0);
let at = Point3::origin();
let mut first_person = ArcBall::new(eye, at);
first_person.set_up_axis(Vector3::z());
```