### PR TITLE
texture path in examples procedural and texturing crashed (Windows)

### DIFF
--- a/examples/procedural.rs
+++ b/examples/procedural.rs
@@ -21,7 +21,7 @@ fn main() {
     let cube = ncollide3d::procedural::cuboid(&Vector3::new(0.7f32, 0.2, 0.4));
     let mut c = window.add_trimesh(cube, Vector3::from_element(1.0));
     c.append_translation(&Translation3::new(1.0, 0.0, 0.0));
-    c.set_texture_from_file(&Path::new("media/kitten.png"), "kitten");
+    c.set_texture_from_file(&Path::new("./examples/media/kitten.png"), "kitten");
 
     /*
      * A sphere.

--- a/examples/texturing.rs
+++ b/examples/texturing.rs
@@ -18,12 +18,12 @@ fn main() {
 
     let mut c = window.add_cube(1.0, 1.0, 1.0);
     c.set_color(1.0, 0.0, 0.0);
-    c.set_texture_from_file(&Path::new("media/kitten.png"), "kitten");
+    c.set_texture_from_file(&Path::new("./examples/media/kitten.png"), "kitten");
 
     let mut r = window.add_rectangle(100.0, 100.0);
     r.append_translation(&Translation2::new(-100.0, -100.0));
     r.set_color(0.0, 0.0, 1.0);
-    r.set_texture_from_memory(include_bytes!("media/kitten.png"), "kitten_mem");
+    r.set_texture_from_memory(include_bytes!("./media/kitten.png"), "kitten_mem");
 
     r.modify_uvs(&mut |points|{
         for(i, p) in points.iter_mut().enumerate() {


### PR DESCRIPTION
The examples wouldn't run. Haven't tried it on linux, so I'm not sure if this is only a Windows issue.