### PR TITLE
Update some (most) dependency versions to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ bitflags     = "1.0"
 num-traits   = "0.2"
 nalgebra     = "0.16"
 ncollide3d   = "0.17"
-image        = "0.19"
+image        = "0.20"
 serde        = "1.0"
 serde_derive = "1.0"
-rusttype     = { version = "0.6", features = [ "gpu_cache" ] }
+rusttype     = { version = "0.7", features = [ "gpu_cache" ] }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
-gl = "0.10.0"
+gl = "0.11"
 glutin = "0.19"
 
 # We repeat all three targets instead of any(target_arch = "wasm32", target_arch = "asmjs")
@@ -55,5 +55,5 @@ stdweb = "0.4"
 stdweb-derive = "0.5"
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.6"
 ncollide2d  = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,5 @@ stdweb = "0.4"
 stdweb-derive = "0.5"
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.5"
 ncollide2d  = "0.17"

--- a/src/text/renderer.rs
+++ b/src/text/renderer.rs
@@ -57,9 +57,10 @@ impl TextRenderer {
         /* We're using 1 byte alignment buffering. */
         verify!(ctxt.pixel_storei(Context::UNPACK_ALIGNMENT, 1));
 
-        let texture = verify!(ctxt
-            .create_texture()
-            .expect("Font texture creation failed."));
+        let texture = verify!(
+            ctxt.create_texture()
+                .expect("Font texture creation failed.")
+        );
         verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture)));
         verify!(ctxt.tex_image2d(
             Context::TEXTURE_2D,

--- a/src/text/renderer.rs
+++ b/src/text/renderer.rs
@@ -4,7 +4,7 @@
 
 use na::{Point2, Point3, Vector2};
 use rusttype;
-use rusttype::gpu_cache::{Cache, CacheBuilder};
+use rusttype::gpu_cache::Cache;
 use std::rc::Rc;
 
 use context::{Context, Texture};

--- a/src/text/renderer.rs
+++ b/src/text/renderer.rs
@@ -45,11 +45,9 @@ impl TextRenderer {
         //
         let atlas_width = 1024;
         let atlas_height = 1024;
-        let cache = CacheBuilder {
-            width: atlas_width,
-            height: atlas_height,
-            ..CacheBuilder::default()
-        }.build();
+        let cache = Cache::builder()
+            .dimensions(atlas_width, atlas_height)
+            .build();
 
         //
         // Create texture.
@@ -59,10 +57,9 @@ impl TextRenderer {
         /* We're using 1 byte alignment buffering. */
         verify!(ctxt.pixel_storei(Context::UNPACK_ALIGNMENT, 1));
 
-        let texture = verify!(
-            ctxt.create_texture()
-                .expect("Font texture creation failed.")
-        );
+        let texture = verify!(ctxt
+            .create_texture()
+            .expect("Font texture creation failed."));
         verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture)));
         verify!(ctxt.tex_image2d(
             Context::TEXTURE_2D,


### PR DESCRIPTION
Most dependencies updated.
Couldn't update `rand` to latest because example `procedural` fails with new version.

**Note: wasm build failure is unrelated to this PR**