### PR TITLE
Fix errors when compiling with clippy

### DIFF
--- a/src/camera/camera.rs
+++ b/src/camera/camera.rs
@@ -35,7 +35,6 @@ pub trait Camera {
 
     /// Upload the camera view and projection to the gpu. This can be called multiple times on the
     /// render loop.
-    #[inline]
     fn upload(
         &self,
         pass: usize,

--- a/src/planar_camera/planar_camera.rs
+++ b/src/planar_camera/planar_camera.rs
@@ -19,7 +19,6 @@ pub trait PlanarCamera {
 
     /// Upload the camera view and projection to the gpu. This can be called multiple times on the
     /// render loop.
-    #[inline]
     fn upload(
         &self,
         proj: &mut ShaderUniform<Matrix3<f32>>,

--- a/src/post_processing/waves.rs
+++ b/src/post_processing/waves.rs
@@ -72,7 +72,7 @@ impl PostProcessingEffect for Waves {
          */
         self.shader.use_program();
 
-        let move_amount = self.time * 2.0 * f32: consts::PI * 0.75; // 3/4 of a wave cycle per second
+        let move_amount = self.time * 2.0 * f32::consts::PI * 0.75; // 3/4 of a wave cycle per second
 
         self.offset.upload(&move_amount);
 

--- a/src/post_processing/waves.rs
+++ b/src/post_processing/waves.rs
@@ -4,6 +4,8 @@
 // useless for anybody else.
 // This is inspired _a lot_ by: http://en.wikibooks.org/wiki/Opengl::Programming/Post-Processing
 
+use std::f32;
+
 use na::Vector2;
 
 use context::Context;
@@ -70,7 +72,7 @@ impl PostProcessingEffect for Waves {
          */
         self.shader.use_program();
 
-        let move_amount = self.time * 2.0 * 3.14159 * 0.75; // 3/4 of a wave cycle per second
+        let move_amount = self.time * 2.0 * f32: consts::PI * 0.75; // 3/4 of a wave cycle per second
 
         self.offset.upload(&move_amount);
 


### PR DESCRIPTION
Specifically 2 instances of `#[inline]` had to be removed because of:

> use of `#[inline]` on trait method `upload` which has no body
> 
> note: #[deny(clippy::inline_fn_without_body)] on by default
> help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inline_fn_without_bodyclippy(clippy::inline_fn_without_body)

**Note: wasm build failure is unrelated to this PR**