### PR TITLE
Automatically provide correct uvs for planar rectangle

### DIFF
--- a/examples/texturing.rs
+++ b/examples/texturing.rs
@@ -6,13 +6,6 @@ use na::{Vector3, UnitComplex, UnitQuaternion, Translation2};
 use kiss3d::window::Window;
 use kiss3d::light::Light;
 
-const RECTANGLE_UVS: [[f32; 2]; 4] = [
-        [0.0, 0.0],
-        [1.0, 1.0],
-        [0.0, 1.0],
-        [1.0, 0.0],
-    ];
-
 fn main() {
     let mut window = Window::new("Kiss3d: texturing");
 
@@ -24,13 +17,6 @@ fn main() {
     r.append_translation(&Translation2::new(-100.0, -100.0));
     r.set_color(0.0, 0.0, 1.0);
     r.set_texture_from_memory(include_bytes!("./media/kitten.png"), "kitten_mem");
-
-    r.modify_uvs(&mut |points|{
-        for(i, p) in points.iter_mut().enumerate() {
-            p[0] = RECTANGLE_UVS[i][0];
-            p[1] = RECTANGLE_UVS[i][1];
-        }
-    });
 
     window.set_light(Light::StickToCamera);
 

--- a/src/resource/planar_mesh_manager.rs
+++ b/src/resource/planar_mesh_manager.rs
@@ -33,9 +33,15 @@ impl PlanarMeshManager2 {
             Point2::new(-0.5, 0.5),
             Point2::new(0.5, -0.5),
         ];
+        let rect_uvs = vec![
+            Point2::new(1.0, 0.0),
+            Point2::new(0.0, 1.0),
+            Point2::new(0.0, 0.0),
+            Point2::new(1.0, 1.0),
+        ];
 
         let rect_ids = vec![Point3::new(0, 1, 2), Point3::new(1, 0, 3)];
-        let rect = PlanarMesh::new(rect_vtx, rect_ids, None, false);
+        let rect = PlanarMesh::new(rect_vtx, rect_ids, Some(rect_uvs), false);
         res.add(Rc::new(RefCell::new(rect)), "rectangle");
 
         let mut circle_vtx = vec![Point2::origin()];


### PR DESCRIPTION
Also fixed the actual values so when you create a rectangle and apply an image to is as a texture it is right side up