### PR TITLE
Added missing methods to load texture from memory

### DIFF
--- a/src/scene/planar_scene_node.rs
+++ b/src/scene/planar_scene_node.rs
@@ -279,6 +279,7 @@ impl PlanarSceneNodeData {
     ///
     /// # Arguments
     ///   * `path` - relative path of the texture on the disk
+    ///   * `name` - &str identifier to store this texture under
     #[inline]
     pub fn set_texture_from_file(&mut self, path: &Path, name: &str) {
         let texture = TextureManager::get_global_manager(|tm| tm.add(path, name));
@@ -292,6 +293,7 @@ impl PlanarSceneNodeData {
     ///
     /// # Arguments
     ///   * `path` - relative path of the texture on the disk
+    ///   * `image_data` - slice of bytes containing encoded image
     ///   * `name` - &str identifier to store this texture under
     #[inline]
     pub fn set_texture_from_memory(&mut self, image_data: &[u8], name: &str) {

--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -316,6 +316,7 @@ impl SceneNodeData {
     ///
     /// # Arguments
     ///   * `path` - relative path of the texture on the disk
+    ///   * `name` - &str identifier to store this texture under
     #[inline]
     pub fn set_texture_from_file(&mut self, path: &Path, name: &str) {
         let texture = TextureManager::get_global_manager(|tm| tm.add(path, name));
@@ -329,6 +330,7 @@ impl SceneNodeData {
     ///
     /// # Arguments
     ///   * `path` - relative path of the texture on the disk
+    ///   * `image_data` - slice of bytes containing encoded image
     ///   * `name` - &str identifier to store this texture under
     #[inline]
     pub fn set_texture_from_memory(&mut self, image_data: &[u8], name: &str) {

--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -325,6 +325,20 @@ impl SceneNodeData {
 
     /// Sets the texture of the objects contained by this node and its children.
     ///
+    /// The texture is loaded from a byte slice and registered by the global `TextureManager`.
+    ///
+    /// # Arguments
+    ///   * `path` - relative path of the texture on the disk
+    ///   * `name` - &str identifier to store this texture under
+    #[inline]
+    pub fn set_texture_from_memory(&mut self, image_data: &[u8], name: &str) {
+        let texture = TextureManager::get_global_manager(|tm| tm.add_image_from_memory(image_data, name));
+
+        self.set_texture(texture)
+    }
+
+    /// Sets the texture of the objects contained by this node and its children.
+    ///
     /// The texture must already have been registered as `name`.
     #[inline]
     pub fn set_texture_with_name(&mut self, name: &str) {
@@ -1014,6 +1028,18 @@ impl SceneNode {
     #[inline]
     pub fn set_texture_from_file(&mut self, path: &Path, name: &str) {
         self.data_mut().set_texture_from_file(path, name)
+    }
+
+    /// Sets the texture of the objects contained by this node and its children.
+    ///
+    /// The texture is loaded from a file and registered by the global `TextureManager`.
+    ///
+    /// # Arguments
+    ///   * `image_data` - slice of bytes containing encoded image
+    ///   * `name` - &str to identify this texture in `TextureManager`
+
+    pub fn set_texture_from_memory(&mut self, image_data: &[u8], name: &str) {
+        self.data_mut().set_texture_from_memory(image_data, name)
     }
 
     /// Sets the texture of the objects contained by this node and its children.


### PR DESCRIPTION
This seems like an obvious omission and it fixed the issue I was dealing with.

But I'm new here, so let me know if I've missed something.

It looks like in https://github.com/sebcrozet/kiss3d/commit/ff27b216cc62c4ad691cc5b6af9699044e8696f9 methods for setting textures from memory were added to planar_scene_node.rs and not to scene_node.rs.

This PR addresses that, and a few omissions from nearby doc comments as well.