### PR TITLE
Add Conrod support + custom renderer system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ name = "kiss3d"
 path = "src/lib.rs"
 
 [features]
-conrod = [ "conrod_core" ]
+conrod = [ "kiss3d_conrod" ]
 
 
 [dependencies]
@@ -40,7 +40,7 @@ serde        = "1.0"
 serde_derive = "1.0"
 rusttype     = { version = "0.7", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "stdweb" ]}
-conrod_core  = { git = "https://github.com/sebcrozet/conrod", version = "0.63", features = [ "stdweb" ], optional = true }
+kiss3d_conrod = { version = "0.63", features = [ "stdweb" ], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
 gl = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ stdweb-derive = "0.5"
 
 [dev-dependencies]
 rand = "0.6"
-ncollide2d  = "0.19"
+ncollide2d = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ include = [
 name = "kiss3d"
 path = "src/lib.rs"
 
+[features]
+conrod = [ "conrod_core" ]
+
+
 [dependencies]
 libc         = "0.2"
 bitflags     = "1.0"
@@ -35,6 +39,8 @@ image        = "0.21"
 serde        = "1.0"
 serde_derive = "1.0"
 rusttype     = { version = "0.7", features = [ "gpu_cache" ] }
+instant      = { version = "0.1", features = [ "stdweb" ]}
+conrod_core  = { git = "https://github.com/sebcrozet/conrod", version = "0.63", features = [ "stdweb" ], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
 gl = "0.11"

--- a/examples/decomp.rs
+++ b/examples/decomp.rs
@@ -1,3 +1,4 @@
+extern crate instant;
 extern crate kiss3d;
 extern crate nalgebra as na;
 extern crate ncollide3d;

--- a/examples/decomp.rs
+++ b/examples/decomp.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
-use std::time::Instant;
+use instant::Instant;
 
 fn usage(exe_name: &str) {
     println!("Usage: {} obj_file scale clusters concavity", exe_name);

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -3,6 +3,7 @@ extern crate nalgebra as na;
 #[macro_use]
 extern crate conrod_core as conrod;
 
+use std::path::Path;
 use conrod::color::Color;
 use conrod::position::Positionable;
 
@@ -22,7 +23,10 @@ fn main() {
 //    widget_ids!(struct Ids { button, text });
     let ids = Ids::new(window.conrod_ui_mut().widget_id_generator());
     window.conrod_ui_mut().theme = theme();
-    let mut app = DemoApp::new();
+    window.add_texture(&Path::new("./examples/media/kitten.png"), "cat");
+    let cat_texture = window.conrod_texture_id("cat").unwrap();
+
+    let mut app = DemoApp::new(cat_texture);
 
     // Render loop.
     while window.render() {
@@ -102,7 +106,7 @@ widget_ids! {
         circle,
         // Image.
         image_title,
-//        rust_logo,
+        cat,
         // Button, XyPad, Toggle.
         button_title,
         button,
@@ -127,18 +131,18 @@ pub struct DemoApp {
     ball_xy: conrod::Point,
     ball_color: conrod::Color,
     sine_frequency: f32,
-//    rust_logo: conrod::image::Id,
+    cat: conrod::image::Id,
 }
 
 
 impl DemoApp {
     /// Simple constructor for the `DemoApp`.
-    pub fn new(/*rust_logo: conrod::image::Id*/) -> Self {
+    pub fn new(cat: conrod::image::Id) -> Self {
         DemoApp {
             ball_xy: [0.0, 0.0],
             ball_color: conrod::color::WHITE,
             sine_frequency: 1.0,
-//            rust_logo: rust_logo,
+            cat,
         }
     }
 }
@@ -266,11 +270,11 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
         .set(ids.image_title, ui);
 
     const LOGO_SIDE: conrod::Scalar = 144.0;
-//    widget::Image::new(app.rust_logo)
-//        .w_h(LOGO_SIDE, LOGO_SIDE)
-//        .down(60.0)
-//        .align_middle_x_of(ids.canvas)
-//        .set(ids.rust_logo, ui);
+    widget::Image::new(app.cat)
+        .w_h(LOGO_SIDE, LOGO_SIDE)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .set(ids.cat, ui);
 
 
     /////////////////////////////////
@@ -279,7 +283,7 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
 
 
     widget::Text::new("Button, XYPad and Toggle")
-//        .down_from(ids.rust_logo, 60.0)
+        .down_from(ids.cat, 60.0)
         .align_middle_x_of(ids.canvas)
         .font_size(SUBTITLE_SIZE)
         .set(ids.button_title, ui);

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,16 +1,26 @@
+#[macro_use]
 extern crate kiss3d;
 extern crate nalgebra as na;
-#[macro_use]
-extern crate conrod_core as conrod;
 
 use std::path::Path;
-use conrod::color::Color;
-use conrod::position::Positionable;
 
 use na::{Vector3, UnitQuaternion};
 use kiss3d::window::Window;
 use kiss3d::light::Light;
+#[cfg(feature = "conrod")]
+use kiss3d::conrod;
+#[cfg(feature = "conrod")]
+use kiss3d::conrod::color::Color;
+#[cfg(feature = "conrod")]
+use kiss3d::conrod::position::Positionable;
 
+#[cfg(not(feature = "conrod"))]
+fn main() {
+    panic!("The 'conrod' feature must be enabled for this example to work.")
+}
+
+
+#[cfg(feature = "conrod")]
 fn main() {
     let mut window = Window::new("Kiss3d: UI");
     window.set_background_color(1.0, 1.0, 1.0);
@@ -60,6 +70,7 @@ fn main() {
  *
  */
 /// A set of reasonable stylistic defaults that works for the `gui` below.
+#[cfg(feature = "conrod")]
 pub fn theme() -> conrod::Theme {
     use conrod::position::{Align, Direction, Padding, Position, Relative};
     conrod::Theme {
@@ -83,6 +94,7 @@ pub fn theme() -> conrod::Theme {
 }
 
 // Generate a unique `WidgetId` for each widget.
+#[cfg(feature = "conrod")]
 widget_ids! {
     pub struct Ids {
         // The scrollable canvas.
@@ -127,6 +139,7 @@ pub const WIN_W: u32 = 600;
 pub const WIN_H: u32 = 420;
 
 /// A demonstration of some application state we want to control with a conrod GUI.
+#[cfg(feature = "conrod")]
 pub struct DemoApp {
     ball_xy: conrod::Point,
     ball_color: conrod::Color,
@@ -134,7 +147,7 @@ pub struct DemoApp {
     cat: conrod::image::Id,
 }
 
-
+#[cfg(feature = "conrod")]
 impl DemoApp {
     /// Simple constructor for the `DemoApp`.
     pub fn new(cat: conrod::image::Id) -> Self {
@@ -149,6 +162,7 @@ impl DemoApp {
 
 
 /// Instantiate a GUI demonstrating every widget available in conrod.
+#[cfg(feature = "conrod")]
 pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
     use conrod::{widget, Colorable, Labelable, Positionable, Sizeable, Widget};
     use std::iter::once;

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -29,8 +29,7 @@ fn main() {
 
     window.set_light(Light::StickToCamera);
 
-//    // Generate the widget identifiers.
-//    widget_ids!(struct Ids { button, text });
+    // Generate the widget identifiers.
     let ids = Ids::new(window.conrod_ui_mut().widget_id_generator());
     window.conrod_ui_mut().theme = theme();
     window.add_texture(&Path::new("./examples/media/kitten.png"), "cat");
@@ -41,25 +40,7 @@ fn main() {
     // Render loop.
     while window.render() {
         let mut ui = window.conrod_ui_mut().set_widgets();
-
         gui(&mut ui, &ids, &mut app)
-//        Text::new("Hello")
-//            .x_y(0.0, 0.0)
-//            .font_size(100)
-//            .color(Color::Rgba(0.0, 1.0, 0.0, 0.2))
-//            .set(ids.title, &mut ui);
-//
-//        for event in Button::new()
-//            .label("hello")
-//            .w_h(400.0, 100.0)
-//            .x_y(0.0, 0.0)
-//            .center_justify_label()
-//            .color(Color::Rgba(0.0, 0.0, 1.0, 0.2))
-//            .hover_color(Color::Rgba(0.0, 1.0, 0.0, 0.2))
-//            .press_color(Color::Rgba(1.0, 0.0, 0.0, 0.2))
-//            .set(ids.introduction, &mut ui) {
-//            c.set_color(rand::random(), rand::random(), rand::random());
-//        }
     }
 }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -178,8 +178,9 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
     const TITLE: &'static str = "All Widgets";
     widget::Canvas::new()
         .pad(MARGIN)
+        .align_bottom()
+        .h(300.0)
         .scroll_kids_vertically()
-//        .color(conrod::Color::Rgba(0.5, 0.5, 0.5, 0.2))
         .set(ids.canvas, ui);
 
 
@@ -192,11 +193,7 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
     // introduction to the example.
     widget::Text::new(TITLE).font_size(TITLE_SIZE).mid_top_of(ids.canvas).set(ids.title, ui);
     const INTRODUCTION: &'static str =
-        "This example aims to demonstrate all widgets that are provided by conrod.\
-        \n\nThe widget that you are currently looking at is the Text widget. The Text widget \
-        is one of several special \"primitive\" widget types which are used to construct \
-        all other widget types. These types are \"special\" in the sense that conrod knows \
-        how to render them via `conrod::render::Primitive`s.\
+        "This example aims to demonstrate some widgets that are provided by conrod.\
         \n\nScroll down to see more widgets!";
     widget::Text::new(INTRODUCTION)
         .padded_w_of(ids.canvas, MARGIN)

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,59 +1,52 @@
-#[macro_use]
 extern crate kiss3d;
 extern crate nalgebra as na;
 #[macro_use]
-extern crate stdweb;
+extern crate conrod_core as conrod;
 
-use kiss3d::conrod::widget::{Button, button::Style, Widget, Text};
-use kiss3d::conrod::color::{Color, Colorable};
-use kiss3d::conrod::position::{Sizeable, Positionable};
-use kiss3d::conrod::Labelable;
+use conrod::color::Color;
+use conrod::position::Positionable;
 
+use na::{Vector3, UnitQuaternion};
+use kiss3d::window::Window;
 use kiss3d::light::Light;
-use kiss3d::scene::SceneNode;
-use kiss3d::window::{State, Window};
-use kiss3d::conrod;
-use na::{UnitQuaternion, Vector3};
-
-struct AppState {
-    c: SceneNode,
-    rot: UnitQuaternion<f32>,
-    ids: Ids,
-    app: DemoApp,
-}
-
-impl State for AppState {
-    fn step(&mut self, window: &mut Window) {
-        for event in window.conrod_ui().widget_input(self.ids.button).events() {
-            console!(log, format!("Found event: {:?}", event))
-        }
-
-        let mut ui = window.conrod_ui_mut().set_widgets();
-        gui(&mut ui, &self.ids, &mut self.app)
-    }
-}
 
 fn main() {
-    let mut window = Window::new("Kiss3d: wasm example");
+    let mut window = Window::new("Kiss3d: UI");
     window.set_background_color(1.0, 1.0, 1.0);
     let mut c = window.add_cube(0.1, 0.1, 0.1);
-
     c.set_color(1.0, 0.0, 0.0);
 
     window.set_light(Light::StickToCamera);
 
-    let rot = UnitQuaternion::from_axis_angle(&Vector3::y_axis(), 0.014);
-
-
-    // Generate the widget identifiers.
+//    // Generate the widget identifiers.
+//    widget_ids!(struct Ids { button, text });
     let ids = Ids::new(window.conrod_ui_mut().widget_id_generator());
-    let app = DemoApp::new();
     window.conrod_ui_mut().theme = theme();
+    let mut app = DemoApp::new();
 
+    // Render loop.
+    while window.render() {
+        let mut ui = window.conrod_ui_mut().set_widgets();
 
-    let state = AppState { c, rot, ids, app };
-
-    window.render_loop(state)
+        gui(&mut ui, &ids, &mut app)
+//        Text::new("Hello")
+//            .x_y(0.0, 0.0)
+//            .font_size(100)
+//            .color(Color::Rgba(0.0, 1.0, 0.0, 0.2))
+//            .set(ids.title, &mut ui);
+//
+//        for event in Button::new()
+//            .label("hello")
+//            .w_h(400.0, 100.0)
+//            .x_y(0.0, 0.0)
+//            .center_justify_label()
+//            .color(Color::Rgba(0.0, 0.0, 1.0, 0.2))
+//            .hover_color(Color::Rgba(0.0, 1.0, 0.0, 0.2))
+//            .press_color(Color::Rgba(1.0, 0.0, 0.0, 0.2))
+//            .set(ids.introduction, &mut ui) {
+//            c.set_color(rand::random(), rand::random(), rand::random());
+//        }
+    }
 }
 
 

--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 authors = ["sebcrozet <developer@crozet.re>"]
 
 [dependencies]
-nalgebra = "0.16"
-kiss3d = { path = "../.." }
+nalgebra = "0.17"
+kiss3d = { path = "../..", features = [ "conrod" ] }
+stdweb = "0.4"
+rand = { version = "0.6", features = [ "stdweb" ] }

--- a/src/builtin/planar_object_material.rs
+++ b/src/builtin/planar_object_material.rs
@@ -173,8 +173,6 @@ void main(){
     tex_coord_v = tex_coord;
 }";
 
-// phong-like lighting (heavily) inspired
-// http://www.mathematik.uni-marburg.de/~thormae/lectures/graphics1/code/WebGLShaderLightMat/ShaderLightMat.html
 const ANOTHER_VERY_LONG_STRING: &'static str = "#version 100
 #ifdef GL_FRAGMENT_PRECISION_HIGH
    precision highp float;

--- a/src/context/context.rs
+++ b/src/context/context.rs
@@ -155,6 +155,10 @@ impl Context {
             .uniform_matrix4fv(location.map(|e| &e.0), transpose, m)
     }
 
+    pub fn uniform4f(&self, location: Option<&UniformLocation>, x: f32, y: f32, z: f32, w: f32) {
+        self.ctxt.uniform4f(location.map(|e| &e.0), x, y, z, w)
+    }
+
     pub fn uniform3f(&self, location: Option<&UniformLocation>, x: f32, y: f32, z: f32) {
         self.ctxt.uniform3f(location.map(|e| &e.0), x, y, z)
     }
@@ -563,6 +567,7 @@ pub(crate) trait AbstractContext {
         transpose: bool,
         m: &Matrix4<f32>,
     );
+    fn uniform4f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32, z: f32, w: f32);
     fn uniform3f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32, z: f32);
     fn uniform2f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32);
     fn uniform1f(&self, location: Option<&Self::UniformLocation>, x: f32);

--- a/src/context/gl_context.rs
+++ b/src/context/gl_context.rs
@@ -129,6 +129,10 @@ impl AbstractContext for GLContext {
         unsafe { gl::UniformMatrix4fv(val(location), 1, transpose as u8, mem::transmute(m)) }
     }
 
+    fn uniform4f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32, z: f32, w: f32) {
+        unsafe { gl::Uniform4f(val(location), x, y, z, w) }
+    }
+
     fn uniform3f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32, z: f32) {
         unsafe { gl::Uniform3f(val(location), x, y, z) }
     }

--- a/src/context/gl_context.rs
+++ b/src/context/gl_context.rs
@@ -180,7 +180,7 @@ impl AbstractContext for GLContext {
             gl::BufferData(
                 target,
                 (data.len() * mem::size_of::<T>()) as GLsizeiptr,
-                mem::transmute(&data[0]),
+                data.as_ptr() as *const std::ffi::c_void,
                 usage,
             )
         }
@@ -192,7 +192,7 @@ impl AbstractContext for GLContext {
                 target,
                 offset,
                 (data.len() * mem::size_of::<T>()) as GLsizeiptr,
-                mem::transmute(&data[0]),
+                data.as_ptr() as *const std::ffi::c_void,
             )
         }
     }

--- a/src/context/webgl_context.rs
+++ b/src/context/webgl_context.rs
@@ -138,6 +138,10 @@ impl AbstractContext for WebGLContext {
             .uniform_matrix4fv(location, transpose, m.as_slice())
     }
 
+    fn uniform4f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32, z: f32, w: f32) {
+        self.ctxt.uniform4f(location, x, y, z, w)
+    }
+
     fn uniform3f(&self, location: Option<&Self::UniformLocation>, x: f32, y: f32, z: f32) {
         self.ctxt.uniform3f(location, x, y, z)
     }

--- a/src/event/event_manager.rs
+++ b/src/event/event_manager.rs
@@ -28,9 +28,9 @@ impl<'a> Event<'a> {
     #[inline]
     fn new(value: WindowEvent, inhibitor: &RefCell<Vec<WindowEvent>>) -> Event {
         Event {
-            value: value,
+            value,
             inhibited: false,
-            inhibitor: inhibitor,
+            inhibitor,
         }
     }
 }
@@ -48,8 +48,8 @@ impl<'a> Events<'a> {
         inhibitor: &'a RefCell<Vec<WindowEvent>>,
     ) -> Events<'a> {
         Events {
-            stream: stream,
-            inhibitor: inhibitor,
+            stream,
+            inhibitor,
         }
     }
 }
@@ -82,8 +82,8 @@ impl EventManager {
         inhibitor: Rc<RefCell<Vec<WindowEvent>>>,
     ) -> EventManager {
         EventManager {
-            events: events,
-            inhibitor: inhibitor,
+            events,
+            inhibitor,
         }
     }
 

--- a/src/event/window_event.rs
+++ b/src/event/window_event.rs
@@ -18,6 +18,25 @@ pub enum WindowEvent {
     CharModifiers(char, Modifiers),
 }
 
+impl WindowEvent {
+    /// Tests if this event is related to the keyboard.
+    pub fn is_keyboard_event(&self) -> bool {
+        match self {
+            WindowEvent::Key(..) | WindowEvent::Char(..) | WindowEvent::CharModifiers(..) => true,
+            _ => false
+        }
+    }
+
+    /// Tests if this event is related to the mouse.
+    pub fn is_mouse_event(&self) -> bool {
+        match self {
+            WindowEvent::MouseButton(..) | WindowEvent::CursorPos(..) |
+            WindowEvent::CursorEnter(..) | WindowEvent::Scroll(..) => true,
+            _ => false
+        }
+    }
+}
+
 // NOTE: list of keys inspired from glutin.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub enum Key {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,11 @@ extern crate stdweb;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 #[macro_use]
 extern crate stdweb_derive;
+extern crate instant;
+#[cfg(feature = "conrod")]
+pub extern crate conrod_core as conrod;
+#[cfg(feature = "conrod")]
+pub use conrod::widget_ids;
 
 
 #[deprecated(note = "Use the `renderer` module instead.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,17 +154,22 @@ extern crate stdweb;
 #[macro_use]
 extern crate stdweb_derive;
 
+
+#[deprecated(note = "Use the `renderer` module instead.")]
+pub use renderer::line_renderer;
+#[deprecated(note = "Use the `renderer` module instead.")]
+pub use renderer::point_renderer;
+
 pub mod builtin;
 pub mod camera;
 pub mod context;
 mod error;
 pub mod event;
 pub mod light;
-pub mod line_renderer;
 pub mod loader;
 pub mod planar_camera;
 pub mod planar_line_renderer;
-pub mod point_renderer;
+pub mod renderer;
 pub mod post_processing;
 pub mod resource;
 pub mod scene;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,7 @@ Thanks to all the Rustaceans for their help, and their OpenGL bindings.
 #[macro_use]
 extern crate bitflags;
 extern crate rusttype;
-// extern crate glfw;
 extern crate image;
-// extern crate libc;
 extern crate nalgebra as na;
 extern crate ncollide3d;
 extern crate num_traits as num;
@@ -155,7 +153,7 @@ extern crate stdweb;
 extern crate stdweb_derive;
 extern crate instant;
 #[cfg(feature = "conrod")]
-pub extern crate conrod_core as conrod;
+pub extern crate kiss3d_conrod as conrod;
 #[cfg(feature = "conrod")]
 pub use conrod::widget_ids;
 

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -1,0 +1,441 @@
+
+
+
+
+//! A batched point renderer.
+
+use context::{Context, Texture};
+use na::{Vector2, Point3, Point2, Point4};
+use resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use text::Font;
+use conrod::{Ui, render::PrimitiveKind};
+use conrod::text::GlyphCache;
+use rusttype::gpu_cache::Cache;
+
+#[path = "../error.rs"]
+mod error;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum RenderMode {
+    Image,
+    Shape,
+    Text { color: Point4<f32> },
+    Unknown
+}
+
+
+/// Structure which manages the display of short-living points.
+pub struct ConrodRenderer {
+    ui: Ui,
+    triangle_shader: Effect,
+    triangle_window_size: ShaderUniform<Vector2<f32>>,
+    triangle_pos: ShaderAttribute<Point2<f32>>,
+    triangle_color: ShaderAttribute<Point4<f32>>,
+    text_shader: Effect,
+    text_window_size: ShaderUniform<Vector2<f32>>,
+    text_color: ShaderUniform<Point4<f32>>,
+    text_pos: ShaderAttribute<Point2<f32>>,
+    text_uvs: ShaderAttribute<Point2<f32>>,
+    text_texture: ShaderUniform<i32>,
+    points: GPUVec<f32>,
+    indices: GPUVec<Point3<u16>>,
+    cache: GlyphCache<'static>,
+    texture: Texture,
+    resized_once: bool,
+}
+
+impl ConrodRenderer {
+    /// Creates a new points manager.
+    pub fn new(width: f64, height: f64) -> ConrodRenderer {
+        //
+        // Create shaders.
+        //
+        let triangle_shader = Effect::new_from_str(TRIANGLES_VERTEX_SRC, TRIANGLES_FRAGMENT_SRC);
+        let text_shader = Effect::new_from_str(TEXT_VERTEX_SRC, TEXT_FRAGMENT_SRC);
+
+        //
+        // Initialize UI with the default font.
+        //
+        let mut ui = conrod::UiBuilder::new([width, height]).build();
+        let _ = ui.fonts.insert(Font::default().font().clone());
+
+        //
+        // Create cache or text.
+        //
+        let atlas_width = 1024;
+        let atlas_height = 1024;
+        let cache = Cache::builder()
+            .dimensions(atlas_width, atlas_height)
+            .build();
+
+        //
+        // Create texture for text
+        //
+        let ctxt = Context::get();
+
+        /* We're using 1 byte alignment buffering. */
+        verify!(ctxt.pixel_storei(Context::UNPACK_ALIGNMENT, 1));
+
+        let texture = verify!(
+            ctxt.create_texture()
+                .expect("Font texture creation failed.")
+        );
+        verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture)));
+        verify!(ctxt.tex_image2d(
+            Context::TEXTURE_2D,
+            0,
+            Context::RED as i32,
+            atlas_width as i32,
+            atlas_height as i32,
+            0,
+            Context::RED,
+            None
+        ));
+
+        /* Clamp to the edge to avoid artifacts when scaling. */
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_WRAP_S,
+            Context::CLAMP_TO_EDGE as i32
+        ));
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_WRAP_T,
+            Context::CLAMP_TO_EDGE as i32
+        ));
+
+        /* Linear filtering usually looks best for text. */
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_MIN_FILTER,
+            Context::LINEAR as i32
+        ));
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_MAG_FILTER,
+            Context::LINEAR as i32
+        ));
+
+        ConrodRenderer {
+            ui,
+            points: GPUVec::new(Vec::new(), BufferType::Array, AllocationType::StreamDraw),
+            indices: GPUVec::new(Vec::new(), BufferType::ElementArray, AllocationType::StreamDraw),
+            triangle_window_size: triangle_shader.get_uniform("window_size").unwrap(),
+            triangle_pos: triangle_shader.get_attrib("position").unwrap(),
+            triangle_color: triangle_shader.get_attrib("color").unwrap(),
+            triangle_shader,
+            text_window_size: text_shader.get_uniform::<Vector2<f32>>("window_size").unwrap(),
+            text_color: text_shader.get_uniform::<Point4<f32>>("color").unwrap(),
+            text_pos: text_shader.get_attrib("pos").unwrap(),
+            text_uvs: text_shader.get_attrib("uvs").unwrap(),
+            text_texture: text_shader.get_uniform("tex0").unwrap(),
+            text_shader,
+            cache,
+            texture,
+            resized_once: false,
+        }
+    }
+
+    /// The mutable UI to be displayed.
+    pub fn ui_mut(&mut self) -> &mut Ui {
+        &mut self.ui
+    }
+
+    /// The UI to be displayed.
+    pub fn ui(&self) -> &Ui {
+        &self.ui
+    }
+
+    /// Actually draws the points.
+    pub fn render(&mut self, width: f32, height: f32, hidpi_factor: f32) {
+        // NOTE: this seems necessary for WASM.
+        if !self.resized_once {
+            self.ui.handle_event(conrod::event::Input::Resize(width as f64, height as f64));
+            self.resized_once = true;
+        }
+
+        let mut primitives = self.ui.draw();
+        let ctxt = Context::get();
+        let mut mode = RenderMode::Unknown;
+
+        let mut vid = 0;
+
+        verify!(ctxt.disable(Context::CULL_FACE));
+        let _ = verify!(ctxt.polygon_mode(Context::FRONT_AND_BACK, Context::FILL));
+        verify!(ctxt.enable(Context::BLEND));
+        verify!(ctxt.blend_func(Context::SRC_ALPHA, Context::ONE_MINUS_SRC_ALPHA));
+        verify!(ctxt.disable(Context::DEPTH_TEST));
+
+        loop {
+            let primitive = primitives.next();
+
+            let render = if let Some(ref primitive) = primitive {
+                match primitive.kind {
+                    PrimitiveKind::TrianglesSingleColor {..} => mode != RenderMode::Shape,
+                    PrimitiveKind::TrianglesMultiColor {..} => mode != RenderMode::Shape,
+                    PrimitiveKind::Rectangle {..} => mode != RenderMode::Shape,
+                    PrimitiveKind::Image {..} => mode != RenderMode::Image,
+                    PrimitiveKind::Text { color, ..} => {
+                        let rgba = color.to_rgb();
+                        mode != RenderMode::Text { color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3) }
+                    },
+                    PrimitiveKind::Other(_) => false,
+                }
+            } else {
+                true
+            };
+
+            if render {
+                match mode {
+                    RenderMode::Shape => {
+                        self.triangle_shader.use_program();
+                        self.triangle_pos.enable();
+                        self.triangle_color.enable();
+
+                        self.triangle_window_size.upload(&Vector2::new(width, height));
+                        unsafe { self.triangle_color.bind_sub_buffer_generic(&mut self.points, 5, 2) };
+                        unsafe { self.triangle_pos.bind_sub_buffer_generic(&mut self.points, 5, 0) };
+                        self.indices.bind();
+
+                        verify!(ctxt.draw_elements(
+                            Context::TRIANGLES,
+                            self.indices.len() as i32 * 3,
+                            Context::UNSIGNED_SHORT,
+                            0
+                        ));
+
+                        self.triangle_pos.disable();
+                        self.triangle_color.disable();
+                    }
+                    RenderMode::Text { color } => {
+                        self.text_shader.use_program();
+                        self.text_pos.enable();
+                        self.text_uvs.enable();
+                        self.text_texture.upload(&0);
+//                        console!(log, format!("Text color: {}", color));
+//                        println!("Text color: {}", color);
+                        self.text_color.upload(&color);
+                        self.text_window_size.upload(&Vector2::new(width, height));
+                        verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
+                        unsafe { self.text_pos.bind_sub_buffer_generic(&mut self.points, 3, 0) };
+                        unsafe { self.text_uvs.bind_sub_buffer_generic(&mut self.points, 3, 2) };
+//                    self.color.upload(&context.color);
+
+                        verify!(ctxt.draw_arrays(Context::TRIANGLES, 0, (self.points.len() / 4) as i32));
+
+                        self.text_pos.disable();
+                        self.text_uvs.disable();
+                    }
+                    RenderMode::Image => {}
+                    RenderMode::Unknown => {}
+                }
+
+                vid = 0;
+                mode = RenderMode::Unknown;
+                self.points.data_mut().as_mut().unwrap().clear();
+                self.indices.data_mut().as_mut().unwrap().clear();
+            }
+
+            if primitive.is_none() {
+                break;
+            }
+
+            let primitive = primitive.unwrap();
+            let vertices = self.points.data_mut().as_mut().unwrap();
+            let indices = self.indices.data_mut().as_mut().unwrap();
+            match primitive.kind {
+                PrimitiveKind::Rectangle { color } => {
+                    mode = RenderMode::Shape;
+
+                    let color = color.to_rgb();
+                    let tl = (primitive.rect.x.start, primitive.rect.y.end);
+                    let bl = (primitive.rect.x.start, primitive.rect.y.start);
+                    let br = (primitive.rect.x.end, primitive.rect.y.start);
+                    let tr = (primitive.rect.x.end, primitive.rect.y.end);
+
+                    vertices.extend_from_slice(&[
+                        tl.0 as f32 * hidpi_factor, tl.1 as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                        bl.0 as f32 * hidpi_factor, bl.1 as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                        br.0 as f32 * hidpi_factor, br.1 as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                        tr.0 as f32 * hidpi_factor, tr.1 as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                    ]);
+
+                    indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+                    indices.push(Point3::new(vid + 2, vid + 3, vid + 0));
+
+                    vid += 4;
+                },
+                PrimitiveKind::TrianglesSingleColor { color, triangles } => {
+                    mode = RenderMode::Shape;
+
+                    for triangle in triangles {
+                        let pts = triangle.points();
+
+                        vertices.extend_from_slice(&[
+                            pts[0][0] as f32 * hidpi_factor, pts[0][1] as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                            pts[1][0] as f32 * hidpi_factor, pts[1][1] as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                            pts[2][0] as f32 * hidpi_factor, pts[2][1] as f32 * hidpi_factor, color.0, color.1, color.2, color.3,
+                        ]);
+                        indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+
+                        vid += 3;
+                    }
+                },
+                PrimitiveKind::TrianglesMultiColor { triangles } => {
+                    mode = RenderMode::Shape;
+
+                    for triangle in triangles {
+                        vertices.extend_from_slice(&[
+                            triangle.0[0].0[0] as f32 * hidpi_factor, triangle.0[0].0[1] as f32 * hidpi_factor, (triangle.0[0].1).0, (triangle.0[0].1).1, (triangle.0[0].1).2,
+                            triangle.0[1].0[0] as f32 * hidpi_factor, triangle.0[1].0[1] as f32 * hidpi_factor, (triangle.0[1].1).0, (triangle.0[1].1).1, (triangle.0[1].1).2,
+                            triangle.0[2].0[0] as f32 * hidpi_factor, triangle.0[2].0[1] as f32 * hidpi_factor, (triangle.0[2].1).0, (triangle.0[2].1).1, (triangle.0[2].1).2,
+                        ]);
+                        indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+
+                        vid += 3;
+                    }
+                },
+                PrimitiveKind::Image { .. } => {}
+                PrimitiveKind::Other(_) => {}
+                PrimitiveKind::Text { color, text, font_id } => {
+                    let rgba = color.to_rgb();
+                    mode = RenderMode::Text { color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3) };
+
+                    verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
+                    verify!(ctxt.tex_parameteri(
+                        Context::TEXTURE_2D,
+                        Context::TEXTURE_WRAP_S,
+                        Context::CLAMP_TO_EDGE as i32
+                    ));
+                    verify!(ctxt.tex_parameteri(
+                        Context::TEXTURE_2D,
+                        Context::TEXTURE_WRAP_T,
+                        Context::CLAMP_TO_EDGE as i32
+                    ));
+
+                    /*
+                     * Update the text image.
+                     */
+                    let positioned_glyphs = text.positioned_glyphs(hidpi_factor);
+                    for glyph in positioned_glyphs.iter() {
+                        self.cache.queue_glyph(font_id.index(), glyph.clone());
+                    }
+
+                    let _ = self.cache.cache_queued(|rect, data| {
+                        verify!(ctxt.tex_sub_image2d(
+                            Context::TEXTURE_2D,
+                            0,
+                            rect.min.x as i32,
+                            rect.min.y as i32,
+                            rect.width() as i32,
+                            rect.height() as i32,
+                            Context::RED,
+                            Some(&data)
+                        ));
+                    });
+
+                    /*
+                     * Build the vertex buffer.
+                     */
+                    for glyph in positioned_glyphs {
+                        if let Some(Some((tex, rect))) = self.cache.rect_for(font_id.index(), &glyph).ok() {
+                            let min_px = rect.min.x as f32;
+                            let min_py = rect.min.y as f32;
+                            let max_px = rect.max.x as f32;
+                            let max_py = rect.max.y as f32;
+
+                            vertices.extend_from_slice(&[
+                                min_px, min_py,
+                                tex.min.x, tex.min.y,
+
+                                min_px, max_py,
+                                tex.min.x, tex.max.y,
+
+                                max_px, min_py,
+                                tex.max.x, tex.min.y,
+
+                                max_px, min_py,
+                                tex.max.x, tex.min.y,
+
+                                min_px, max_py,
+                                tex.min.x, tex.max.y,
+
+                                max_px, max_py,
+                                tex.max.x, tex.max.y,
+                            ]);
+                        }
+                    }
+
+                }
+            }
+        }
+
+        verify!(ctxt.enable(Context::DEPTH_TEST));
+        verify!(ctxt.disable(Context::BLEND));
+    }
+}
+
+static TRIANGLES_VERTEX_SRC: &'static str = "#version 100
+attribute vec2 position;
+attribute vec4 color;
+
+uniform vec2 window_size;
+
+varying vec4 v_color;
+
+void main(){
+    gl_Position = vec4(position / window_size, 0.0, 1.0);
+    v_color = color;
+}";
+
+static TRIANGLES_FRAGMENT_SRC: &'static str = "#version 100
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+varying vec4 v_color;
+
+void main() {
+  gl_FragColor = v_color;
+}";
+
+
+const TEXT_VERTEX_SRC: &'static str = "
+#version 100
+
+uniform vec2 window_size;
+uniform vec4 color;
+
+attribute vec2 pos;
+attribute vec2 uvs;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_Position = vec4((pos.x / window_size.x - 1.0), (1.0 - pos.y / window_size.y), 0.0, 1.0);
+    v_uvs       = uvs;
+    v_color     = color;
+}
+";
+
+const TEXT_FRAGMENT_SRC: &'static str = "
+#version 100
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+uniform sampler2D tex0;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = vec4(v_color.rgb, v_color.a * texture2D(tex0, v_uvs).r);
+}
+";

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -150,7 +150,7 @@ impl ConrodRenderer {
     pub fn render(&mut self, width: f32, height: f32, hidpi_factor: f32) {
         // NOTE: this seems necessary for WASM.
         if !self.resized_once {
-            self.ui.handle_event(conrod::event::Input::Resize(width as f64, height as f64));
+            self.ui.handle_event(conrod::event::Input::Resize(width as f64 / hidpi_factor as f64, height as f64 / hidpi_factor as f64));
             self.resized_once = true;
         }
 
@@ -384,7 +384,7 @@ uniform vec2 window_size;
 varying vec4 v_color;
 
 void main(){
-    gl_Position = vec4(position / window_size, 0.0, 1.0);
+    gl_Position = vec4(position / window_size * 2.0, 0.0, 1.0);
     v_color = color;
 }";
 
@@ -415,7 +415,7 @@ varying vec2 v_uvs;
 varying vec4 v_color;
 
 void main() {
-    gl_Position = vec4((pos.x / window_size.x - 1.0), (1.0 - pos.y / window_size.y), 0.0, 1.0);
+    gl_Position = vec4((pos.x / window_size.x - 0.5) * 2.0, (0.5 - pos.y / window_size.y) * 2.0, 0.0, 1.0);
     v_uvs       = uvs;
     v_color     = color;
 }

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -178,6 +178,7 @@ impl ConrodRenderer {
         verify!(ctxt.enable(Context::BLEND));
         verify!(ctxt.blend_func(Context::SRC_ALPHA, Context::ONE_MINUS_SRC_ALPHA));
         verify!(ctxt.disable(Context::DEPTH_TEST));
+        verify!(ctxt.enable(Context::SCISSOR_TEST));
 
 
         let rect_to_gl_rect = |rect: Rect| {
@@ -219,7 +220,6 @@ impl ConrodRenderer {
             };
 
             if render {
-                println!("scissor: {:?}", curr_scizzor.x_y_w_h());
                 let (x, y, w, h) = rect_to_gl_rect(curr_scizzor);
                 ctxt.scissor(x as i32, y as i32, w as i32, h as i32);
                 match mode {

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -318,10 +318,11 @@ impl ConrodRenderer {
                     mode = RenderMode::Shape;
 
                     for triangle in triangles {
+                        let ((a, ca), (b, cb), (c, cc)) = (triangle.0[0], triangle.0[1], triangle.0[2]);
                         vertices.extend_from_slice(&[
-                            triangle.0[0].0[0] as f32 * hidpi_factor, triangle.0[0].0[1] as f32 * hidpi_factor, (triangle.0[0].1).0, (triangle.0[0].1).1, (triangle.0[0].1).2,
-                            triangle.0[1].0[0] as f32 * hidpi_factor, triangle.0[1].0[1] as f32 * hidpi_factor, (triangle.0[1].1).0, (triangle.0[1].1).1, (triangle.0[1].1).2,
-                            triangle.0[2].0[0] as f32 * hidpi_factor, triangle.0[2].0[1] as f32 * hidpi_factor, (triangle.0[2].1).0, (triangle.0[2].1).1, (triangle.0[2].1).2,
+                            a[0] as f32 * hidpi_factor, a[1] as f32 * hidpi_factor, ca.0, ca.1, ca.2, ca.3,
+                            b[0] as f32 * hidpi_factor, b[1] as f32 * hidpi_factor, cb.0, cb.1, cb.2, cb.3,
+                            c[0] as f32 * hidpi_factor, c[1] as f32 * hidpi_factor, cc.0, cc.1, cc.2, cc.3,
                         ]);
                         indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
 

--- a/src/renderer/line_renderer.rs
+++ b/src/renderer/line_renderer.rs
@@ -4,8 +4,9 @@ use camera::Camera;
 use context::Context;
 use na::{Matrix4, Point3};
 use resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use renderer::Renderer;
 
-#[path = "error.rs"]
+#[path = "../error.rs"]
 mod error;
 
 /// Structure which manages the display of short-living lines.
@@ -58,9 +59,11 @@ impl LineRenderer {
             lines.push(color);
         }
     }
+}
 
+impl Renderer for LineRenderer {
     /// Actually draws the lines.
-    pub fn render(&mut self, pass: usize, camera: &mut Camera) {
+    fn render(&mut self, pass: usize, camera: &mut Camera) {
         if self.lines.len() == 0 {
             return;
         }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -3,8 +3,12 @@
 pub use self::point_renderer::PointRenderer;
 pub use self::line_renderer::LineRenderer;
 pub use self::renderer::Renderer;
+#[cfg(feature = "conrod")]
+pub use self::conrod_renderer::ConrodRenderer;
 
 
 pub mod line_renderer;
 pub mod point_renderer;
+#[cfg(feature = "conrod")]
+mod conrod_renderer;
 mod renderer;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,0 +1,10 @@
+//! Structures responsible for rendering elements other than kiss3d's meshes.
+
+pub use self::point_renderer::PointRenderer;
+pub use self::line_renderer::LineRenderer;
+pub use self::renderer::Renderer;
+
+
+pub mod line_renderer;
+pub mod point_renderer;
+mod renderer;

--- a/src/renderer/point_renderer.rs
+++ b/src/renderer/point_renderer.rs
@@ -33,7 +33,7 @@ impl PointRenderer {
             color: shader.get_attrib::<Point3<f32>>("color").unwrap(),
             proj: shader.get_uniform::<Matrix4<f32>>("proj").unwrap(),
             view: shader.get_uniform::<Matrix4<f32>>("view").unwrap(),
-            shader: shader,
+            shader,
             point_size: 1.0,
         }
     }

--- a/src/renderer/point_renderer.rs
+++ b/src/renderer/point_renderer.rs
@@ -4,8 +4,9 @@ use camera::Camera;
 use context::Context;
 use na::{Matrix4, Point3};
 use resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use renderer::Renderer;
 
-#[path = "error.rs"]
+#[path = "../error.rs"]
 mod error;
 
 /// Structure which manages the display of short-living points.
@@ -55,9 +56,11 @@ impl PointRenderer {
             points.push(color);
         }
     }
+}
 
+impl Renderer for PointRenderer {
     /// Actually draws the points.
-    pub fn render(&mut self, pass: usize, camera: &mut Camera) {
+    fn render(&mut self, pass: usize, camera: &mut Camera) {
         if self.points.len() == 0 {
             return;
         }

--- a/src/renderer/renderer.rs
+++ b/src/renderer/renderer.rs
@@ -1,0 +1,7 @@
+use camera::Camera;
+
+/// Trait implemented by custom renderer.
+pub trait Renderer {
+    /// Perform a rendering pass.
+    fn render(&mut self, pass: usize, camera: &mut Camera);
+}

--- a/src/resource/effect.rs
+++ b/src/resource/effect.rs
@@ -148,6 +148,13 @@ impl<T: GLPrimitive> ShaderAttribute<T> {
 
     /// Binds this attribute to non contiguous parts of a gpu vector.
     pub fn bind_sub_buffer(&mut self, vector: &mut GPUVec<T>, strides: usize, start_index: usize) {
+        unsafe { self.bind_sub_buffer_generic(vector, strides, start_index)}
+    }
+
+    /// Binds this attribute to non contiguous parts of a gpu vector.
+    ///
+    /// The type of the provided GPU buffer is not forced to match the type of this attribute.
+    pub unsafe fn bind_sub_buffer_generic<T2: GLPrimitive>(&mut self, vector: &mut GPUVec<T2>, strides: usize, start_index: usize) {
         vector.bind();
 
         verify!(Context::get().vertex_attrib_pointer(
@@ -155,8 +162,8 @@ impl<T: GLPrimitive> ShaderAttribute<T> {
             T::size() as i32,
             T::gl_type(),
             false,
-            ((strides + 1) * mem::size_of::<T>()) as i32,
-            (start_index * mem::size_of::<T>()) as GLintptr
+            ((strides + 1) * mem::size_of::<T2>()) as i32,
+            (start_index * mem::size_of::<T2>()) as GLintptr
         ));
     }
 }

--- a/src/resource/gl_primitive.rs
+++ b/src/resource/gl_primitive.rs
@@ -3,7 +3,7 @@
 use context::{Context, UniformLocation};
 use std::slice;
 
-use na::{Matrix2, Matrix3, Matrix4, Point2, Point3, Rotation2, Rotation3, Vector2, Vector3};
+use na::{Matrix2, Matrix3, Matrix4, Point2, Point3, Point4, Rotation2, Rotation3, Vector2, Vector3, Vector4};
 
 #[path = "../error.rs"]
 mod error;
@@ -267,6 +267,33 @@ unsafe impl GLPrimitive for Matrix4<f32> {
  * Impl for vectors
  *
  */
+unsafe impl GLPrimitive for Vector4<f32> {
+    #[inline]
+    fn gl_type() -> u32 {
+        Context::FLOAT
+    }
+
+    #[inline]
+    fn flatten(array: &[Self]) -> PrimitiveArray {
+        unsafe {
+            let len = array.len() * 4;
+            let ptr = array.as_ptr();
+
+            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
+        }
+    }
+
+    #[inline]
+    fn size() -> u32 {
+        4
+    }
+
+    #[inline]
+    fn upload(&self, location: &UniformLocation) {
+        verify!(Context::get().uniform4f(Some(location), self.x, self.y, self.z, self.w));
+    }
+}
+
 unsafe impl GLPrimitive for Vector3<f32> {
     #[inline]
     fn gl_type() -> u32 {
@@ -360,6 +387,33 @@ unsafe impl GLPrimitive for Vector2<f32> {
  * Impl for points
  *
  */
+unsafe impl GLPrimitive for Point4<f32> {
+    #[inline]
+    fn gl_type() -> u32 {
+        Context::FLOAT
+    }
+
+    #[inline]
+    fn flatten(array: &[Self]) -> PrimitiveArray {
+        unsafe {
+            let len = array.len() * Self::size() as usize;
+            let ptr = array.as_ptr();
+
+            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
+        }
+    }
+
+    #[inline]
+    fn size() -> u32 {
+        4
+    }
+
+    #[inline]
+    fn upload(&self, location: &UniformLocation) {
+        verify!(Context::get().uniform4f(Some(location), self.x, self.y, self.z, self.w));
+    }
+}
+
 unsafe impl GLPrimitive for Point3<f32> {
     #[inline]
     fn gl_type() -> u32 {

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -2,6 +2,7 @@ use camera::Camera;
 use planar_camera::PlanarCamera;
 use post_processing::PostProcessingEffect;
 use window::Window;
+use renderer::Renderer;
 
 /// Trait implemented by objects describing state of an application.
 ///
@@ -12,7 +13,9 @@ pub trait State: 'static {
     /// Method called at each render loop before a rendering.
     fn step(&mut self, window: &mut Window);
 
-    /// Method called at each render loop to retrieve the cameras and post-processing effects to be used for the next render.
+    /// Unless `cameras_and_effect_and_renderer` is implemented, this method called at each render loop to retrieve
+    /// the cameras and post-processing effects to be used for the next render.
+    #[deprecated(note = "This will be replaced by `.cameras_and_effect_and_renderer` which is more flexible.")]
     fn cameras_and_effect(
         &mut self,
     ) -> (
@@ -21,6 +24,18 @@ pub trait State: 'static {
         Option<&mut PostProcessingEffect>,
     ) {
         (None, None, None)
+    }
+
+    /// Method called at each render loop to retrieve the cameras, custom renderer, and post-processing effect to be used for the next render.
+    fn cameras_and_effect_and_renderer(&mut self) -> (
+        Option<&mut Camera>,
+        Option<&mut PlanarCamera>,
+        Option<&mut Renderer>,
+        Option<&mut PostProcessingEffect>,
+    ) {
+        #[allow(deprecated)]
+        let res = self.cameras_and_effect(); // For backward-compatibility.
+        (res.0, res.1, None, res.2)
     }
 }
 

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -101,10 +101,10 @@ impl AbstractCanvas for WebGLCanvas {
         let edata = data.clone();
         let _ = web::window().add_event_listener(move |e: webevent::MouseMoveEvent| {
             let mut edata = edata.borrow_mut();
-            edata.cursor_pos = Some((e.offset_x() as f64, e.offset_y() as f64));
+            edata.cursor_pos = Some((e.offset_x() as f64 * hidpi_factor, e.offset_y() as f64 * hidpi_factor));
             let _ = edata.pending_events.push(WindowEvent::CursorPos(
-                e.offset_x() as f64,
-                e.offset_y() as f64,
+                e.offset_x() as f64 * hidpi_factor,
+                e.offset_y() as f64 * hidpi_factor,
                 translate_mouse_modifiers(&e),
             ));
         });
@@ -124,7 +124,7 @@ impl AbstractCanvas for WebGLCanvas {
             let mut edata = edata.borrow_mut();
             let _ = edata.pending_events.push(WindowEvent::Scroll(
                 delta_x as f64,
-                delta_y as f64,
+                -delta_y as f64,
                 translate_mouse_modifiers(&e),
             ));
         });
@@ -182,9 +182,10 @@ impl AbstractCanvas for WebGLCanvas {
     }
 
     fn size(&self) -> (u32, u32) {
+        let hidpi_factor = self.hidpi_factor();
         (
-            self.data.borrow().canvas.offset_width() as u32,
-            self.data.borrow().canvas.offset_height() as u32,
+            (self.data.borrow().canvas.offset_width() as f64 * hidpi_factor) as u32,
+            (self.data.borrow().canvas.offset_height() as f64 * hidpi_factor) as u32,
         )
     }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -36,12 +36,14 @@ use renderer::ConrodRenderer;
 static DEFAULT_WIDTH: u32 = 800u32;
 static DEFAULT_HEIGHT: u32 = 600u32;
 
+#[cfg(feature = "conrod")]
 struct ConrodContext {
     renderer: ConrodRenderer,
     textures: conrod::image::Map<(Rc<Texture>, (u32, u32))>,
     texture_ids: HashMap<String, conrod::image::Id>
 }
 
+#[cfg(feature = "conrod")]
 impl ConrodContext {
     fn new(width: f64, height: f64) -> Self {
         Self {

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -783,8 +783,25 @@ impl Window {
 
         #[cfg(feature = "conrod")]
         {
-            if let Some(input) = window_event_to_conrod_input(*event, self.size(), self.hidpi_factor()) {
-                self.conrod_ui_mut().handle_event(input);
+            let (size, hidpi) = (self.size(), self.hidpi_factor());
+            let conrod_ui = self.conrod_ui_mut();
+            if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
+                conrod_ui.handle_event(input);
+            }
+
+            let state = &conrod_ui.global_input().current;
+            let window_id = Some(conrod_ui.window);
+
+            if event.is_keyboard_event() &&
+                state.widget_capturing_keyboard.is_some() &&
+                state.widget_capturing_keyboard != window_id {
+                return;
+            }
+
+            if event.is_mouse_event() &&
+                state.widget_capturing_mouse.is_some() &&
+                state.widget_capturing_mouse != window_id {
+                return;
             }
         }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -585,16 +585,16 @@ impl Window {
         }
 
         #[cfg(feature = "conrod")]
-        fn window_event_to_conrod_input(event: WindowEvent, size: Vector2<u32>, _hidpi: f64) -> Option<conrod::event::Input> {
+        fn window_event_to_conrod_input(event: WindowEvent, size: Vector2<u32>, hidpi: f64) -> Option<conrod::event::Input> {
             use conrod::event::Input;
             use conrod::input::{Motion, MouseButton, Button, Key as CKey};
 
             let transform_coords = |x: f64, y: f64| {
-                (x - size.x as f64 / 2.0, -(y - size.y as f64 / 2.0))
+                ((x - size.x as f64 / 2.0) / hidpi, -(y - size.y as f64 / 2.0) / hidpi)
             };
 
             match event {
-                WindowEvent::FramebufferSize(w, h) => Some(Input::Resize(w as f64, h as f64)),
+                WindowEvent::FramebufferSize(w, h) => Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi)),
                 WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
                 WindowEvent::CursorPos(x, y, _) => {
                     let (x, y) = transform_coords(x, y);

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -572,18 +572,14 @@ impl Window {
         self.canvas.cursor_pos()
     }
 
-    /// Poll events and pass them to a user-defined function. If the function returns `true`, the
-    /// default engine event handler (camera, framebuffer size, etc.) is executed, if it returns
-    /// `false`, the default engine event handler is not executed. Return `false` if you want to
-    /// override the default engine behaviour.
     #[inline]
     fn handle_events(
         &mut self,
         camera: &mut Option<&mut Camera>,
         planar_camera: &mut Option<&mut PlanarCamera>,
     ) {
-        let unhandled_events = self.unhandled_events.clone(); // FIXME: this is very ugly.
-        let events = self.events.clone(); // FIXME: this is very ugly
+        let unhandled_events = self.unhandled_events.clone(); // FIXME: could we avoid the clone?
+        let events = self.events.clone(); // FIXME: could we avoid the clone?
 
         for event in unhandled_events.borrow().iter() {
             self.handle_event(camera, planar_camera, event)

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -420,8 +420,30 @@ impl Window {
         self.conrod_context.renderer.ui()
     }
 
+    /// Returns `true` if the mouse is currently interacting with a Conrod widget.
+    #[cfg(feature = "conrod")]
+    pub fn is_conrod_ui_capturing_mouse(&self) -> bool {
+        let ui = self.conrod_ui();
+        let state = &ui.global_input().current;
+        let window_id = Some(ui.window);
 
-        /// Opens a window, hide it then calls a user-defined procedure.
+        state.widget_capturing_mouse.is_some() &&
+            state.widget_capturing_mouse != window_id
+    }
+
+    /// Returns `true` if the keyboard is currently interacting with a Conrod widget.
+    #[cfg(feature = "conrod")]
+    pub fn is_conrod_ui_capturing_keyboard(&self) -> bool {
+        let ui = self.conrod_ui();
+        let state = &ui.global_input().current;
+        let window_id = Some(ui.window);
+
+        state.widget_capturing_keyboard.is_some() &&
+            state.widget_capturing_keyboard != window_id
+    }
+
+
+    /// Opens a window, hide it then calls a user-defined procedure.
     ///
     /// # Arguments
     /// * `title` - the window title


### PR DESCRIPTION
This adds the support for Conrod, an immediate-mode UI library. For now we are using our own fork of the `conrod_core` crate in order to have WASM support.

This also adds a `Renderer` trait this allows the user to create its own renderer which is a structure with a `render` method called during a render pass. This is useful if a non-mesh object has to be rendered with a very specific shaders, and specific GPU buffers. Custom renderers can be returned by the `cameras_and_effect_and_renderer` method of the `State` trait.