### PR TITLE
Disable alpha in backbuffer for webgl.

### DIFF
--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["sebcrozet <developer@crozet.re>"]
 
 [dependencies]
-nalgebra = "0.17"
+nalgebra = "0.18"
 kiss3d = { path = "../..", features = [ "conrod" ] }
 stdweb = "0.4"
 rand = { version = "0.6", features = [ "stdweb" ] }

--- a/src/context/webgl_context.rs
+++ b/src/context/webgl_context.rs
@@ -29,6 +29,8 @@ impl WebGLContext {
             .unwrap()
             .try_into()
             .unwrap();
+        // We disable alpha for the backbuffer so we get a behavior closer to OpenGL.
+        // See https://webglfundamentals.org/webgl/lessons/webgl-and-alpha.html
         let web_ctxt: WebGLRenderingContext = js!(
             return @{canvas}.getContext("webgl", { alpha: false });
         ).try_into().unwrap();

--- a/src/context/webgl_context.rs
+++ b/src/context/webgl_context.rs
@@ -29,7 +29,9 @@ impl WebGLContext {
             .unwrap()
             .try_into()
             .unwrap();
-        let web_ctxt: WebGLRenderingContext = canvas.get_context().unwrap();
+        let web_ctxt: WebGLRenderingContext = js!(
+            return @{canvas}.getContext("webgl", { alpha: false });
+        ).try_into().unwrap();
         let ctxt = Rc::new(web_ctxt);
         WebGLContext { ctxt }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ Thanks to all the Rustaceans for their help, and their OpenGL bindings.
 
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
-#![deny(non_upper_case_globals)]
+#![warn(non_upper_case_globals)] // FIXME: should be denied.
 #![deny(unused_qualifications)]
 #![warn(missing_docs)] // FIXME: should be denied.
 #![warn(unused_results)]


### PR DESCRIPTION
This will ensure a WebGL behavior closer to OpenGL.
Fix #169 