### PR TITLE
Fix SobelEdgeHighlight description

### DIFF
--- a/src/post_processing/sobel_edge_highlight.rs
+++ b/src/post_processing/sobel_edge_highlight.rs
@@ -11,7 +11,7 @@ use resource::{
 #[path = "../error.rs"]
 mod error;
 
-/// Post processing effect which turns everything in grayscales.
+/// Post processing effect which draws detected edges on top of the original buffer.
 pub struct SobelEdgeHighlight {
     shiftx: f32,
     shifty: f32,


### PR DESCRIPTION
Here's what the example does:

![2019-05-02-123554_1366x768_scrot](https://user-images.githubusercontent.com/311866/57091426-2a012f80-6cd7-11e9-8542-d7ee887d8cc0.png)

(original buffer was just the five shapes without the black edges)