### PR TITLE
Update README.md for version 0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Simply add the following to your `Cargo.toml` file:
 
 ```
 [dependencies]
-kiss3d = "0.16"
+kiss3d = "0.21"
 ```
 
 


### PR DESCRIPTION
See issue #167. 0.16 (currently listed in the readme) doesn't build in recent Rust, but 0.21 does. This makes for a confusing initial user experience. :)