### PR TITLE
Updated view matrix to negate look at positions

### DIFF
--- a/src/planar_camera/sidescroll.rs
+++ b/src/planar_camera/sidescroll.rs
@@ -93,9 +93,11 @@ impl Sidescroll {
         self.drag_button = new_button;
     }
 
+    /// Move the camera based on drag from right mouse button
+    /// `dpos` is assumed to be in window space so the y-axis is flipped
     fn handle_right_button_displacement(&mut self, dpos: &Vector2<f32>) {
-        self.at.x += dpos.x / self.zoom;
-        self.at.y -= dpos.y / self.zoom;
+        self.at.x -= dpos.x / self.zoom;
+        self.at.y += dpos.y / self.zoom;
         self.update_projviews();
     }
 
@@ -106,7 +108,7 @@ impl Sidescroll {
     }
 
     fn update_projviews(&mut self) {
-        self.view = Translation2::new(self.at.x, self.at.y).to_homogeneous();
+        self.view = Translation2::new(-self.at.x, -self.at.y).to_homogeneous();
         self.scaled_proj = self.proj;
         self.scaled_proj.m11 *= self.zoom;
         self.scaled_proj.m22 *= self.zoom;
@@ -164,13 +166,19 @@ impl PlanarCamera for Sidescroll {
 
     fn update(&mut self, _: &Canvas) {}
 
+    /// Calculate the global position of the given window coordinate
     fn unproject(&self, window_coord: &Point2<f32>, size: &Vector2<f32>) -> Point2<f32> {
+        // Convert window coordinates (origin at top left) to normalized screen coordinates
+        // (origin at the center of the screen)
         let normalized_coords = Point2::new(
             2.0 * window_coord.x / size.x - 1.0,
             2.0 * -window_coord.y / size.y + 1.0,
         );
 
+        // Project normalized screen coordinate to screen space
         let unprojected_hom = self.inv_scaled_proj * normalized_coords.to_homogeneous();
-        Point2::from_homogeneous(unprojected_hom).unwrap() - self.at.coords
+
+        // Convert from screen space to global space
+        Point2::from_homogeneous(unprojected_hom).unwrap() + self.at.coords
     }
 }


### PR DESCRIPTION
Fix for #195 

Negated the view matrix and then a couple of other functions that relied on the wrong behavior. I added some comments to methods I encountered based on my understanding of that they were doing. Some of them might need updated to be more correct. 

Tested on my machine with both `look_at` and mouse movements. I did a quick check for examples using this code but I couldn't find any so it should be safe.

This will have a behavioral change for anything using this and working round the `look_at` bug by negating it themselves.