### PR TITLE
Fix conrod TextBox widgets by forwarding WindowEvent::Char.

### DIFF
--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -137,6 +137,9 @@ impl AbstractCanvas for GLCanvas {
                     key_states[key as usize] = action;
                     let _ = out_events.send(WindowEvent::Key(key, action, modifiers));
                 }
+                glutin::WindowEvent::ReceivedCharacter(c) => {
+                    let _ = out_events.send(WindowEvent::Char(c));
+                }
                 _ => {}
             },
             _ => {}

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -138,6 +138,7 @@ impl AbstractCanvas for WebGLCanvas {
                 Action::Press,
                 translate_key_modifiers(&e),
             ));
+            let _ = edata.pending_events.push(WindowEvent::Char(translate_char(&e)));
             edata.key_states[key as usize] = Action::Press;
         });
 
@@ -264,6 +265,14 @@ fn translate_mouse_button<E: IMouseEvent>(event: &E) -> MouseButton {
         webevent::MouseButton::Wheel => MouseButton::Button3,
         webevent::MouseButton::Button4 => MouseButton::Button4,
         webevent::MouseButton::Button5 => MouseButton::Button5,
+    }
+}
+
+fn translate_char<E: IKeyboardEvent>(event: &E) -> char {
+    let key = event.key();
+    match key.len() {
+        1 => key.chars().nth(0).unwrap_or(' '),
+        _ => ' '
     }
 }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -765,6 +765,7 @@ impl Window {
                         Key::Right => CKey::Right,
                         Key::Down => CKey::Down,
                         Key::Return => CKey::Return,
+                        Key::Back => CKey::Backspace,
                         Key::Space => CKey::Space,
                         Key::Caret => CKey::Caret,
                         Key::Numpad0 => CKey::NumPad0,
@@ -816,6 +817,14 @@ impl Window {
                     match action {
                         Action::Press => Some(Input::Press(Button::Keyboard(key))),
                         Action::Release => Some(Input::Release(Button::Keyboard(key))),
+                    }
+                }
+                WindowEvent::Char(c) => {
+                    if c < ' ' {
+                        None
+
+                    } else {
+                        Some(Input::Text(c.to_string()))
                     }
                 }
                 _ => None


### PR DESCRIPTION
The Conrod TextBox Widget uses `WindowEvent::Char` for inputting characters and also depend on `Key::Back`  being mapped to `CKey::Backspace`.

These additions make the widget work when being used with Conrod UI inside of kiss3d.