### PR TITLE
Added set_cursor_position and hide_cursor functions

### DIFF
--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -114,6 +114,14 @@ impl Canvas {
         self.canvas.set_cursor_grab(grab);
     }
 
+    pub fn set_cursor_position(&self, x: f64, y: f64) {
+        self.canvas.set_cursor_position(x, y);
+    }
+
+    pub fn hide_cursor(&self, hide: bool) {
+        self.canvas.hide_cursor(hide);
+    }
+
     /// Hide the window.
     pub fn hide(&mut self) {
         self.canvas.hide()
@@ -154,6 +162,8 @@ pub(crate) trait AbstractCanvas {
     fn set_title(&mut self, title: &str);
     fn set_icon(&mut self, icon: impl GenericImage<Pixel = impl Pixel<Subpixel = u8>>);
     fn set_cursor_grab(&self, grab: bool);
+    fn set_cursor_position(&self, x: f64, y: f64);
+    fn hide_cursor(&self, hide: bool);
     fn hide(&mut self);
     fn show(&mut self);
 

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -182,6 +182,16 @@ impl AbstractCanvas for GLCanvas {
         let _ = self.window.window().grab_cursor(grab);
     }
 
+    fn set_cursor_position(&self, x: f64, y: f64) {
+        let dpi = self.window.get_hidpi_factor();
+        self.window.set_cursor_position(glutin::dpi::LogicalPosition::new(x / dpi, y / dpi)).unwrap();
+    }
+
+
+    fn hide_cursor(&self, hide: bool) {
+        self.window.hide_cursor(hide);
+    }
+
     fn hide(&mut self) {
         self.window.hide()
     }

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -112,6 +112,7 @@ impl Window {
         Vector2::new(w, h)
     }
 
+
     /// Sets the maximum number of frames per second. Cannot be 0. `None` means there is no limit.
     #[inline]
     pub fn set_framerate_limit(&mut self, fps: Option<u64>) {
@@ -149,6 +150,16 @@ impl Window {
     /// Does nothing on web platforms.
     pub fn set_cursor_grab(&self, grab: bool) {
         self.canvas.set_cursor_grab(grab);
+    }
+
+    #[inline]
+    pub fn set_cursor_position(&self, x: f64, y: f64) {
+        self.canvas.set_cursor_position(x, y);
+    }
+
+    #[inline]
+    pub fn hide_cursor(&self, hide: bool) {
+        self.canvas.hide_cursor(hide);
     }
 
     /// Closes the window.


### PR DESCRIPTION
Hello, I am trying to develop a simple 3d first person shooter game, and I need these two functions.

**The problem:**
I cannot use the `set_cursor_grab` on its own, because if the mouse is already on a edge of the window (e.g. 0-300), and I move the mouse left, the `WindowEvent::CursorPos` will still return 0-300  so i canont detect the fact that the user is trying to move the mouse left (am I wrong?).

Using `set_cursor_position` in conjunction with `set_cursor_grab` solves the problem as I'm now able to center the mouse.

