### PR TITLE
Change "line" to "point" in the documentation

### DIFF
--- a/src/renderer/point_renderer.rs
+++ b/src/renderer/point_renderer.rs
@@ -48,8 +48,8 @@ impl PointRenderer {
         self.point_size = pt_size;
     }
 
-    /// Adds a line to be drawn during the next frame. Lines are not persistent between frames.
-    /// This method must be called for each line to draw, and at each update loop iteration.
+    /// Adds a point to be drawn during the next frame. Points are not persistent between frames.
+    /// This method must be called for each point to draw, and at each update loop iteration.
     pub fn draw_point(&mut self, pt: Point3<f32>, color: Point3<f32>) {
         for points in self.points.data_mut().iter_mut() {
             points.push(pt);
@@ -87,9 +87,9 @@ impl Renderer for PointRenderer {
     }
 }
 
-/// Vertex shader used by the material to display line.
+/// Vertex shader used by the material to display point.
 pub static POINTS_VERTEX_SRC: &'static str = A_VERY_LONG_STRING;
-/// Fragment shader used by the material to display line.
+/// Fragment shader used by the material to display point.
 pub static POINTS_FRAGMENT_SRC: &'static str = ANOTHER_VERY_LONG_STRING;
 
 const A_VERY_LONG_STRING: &'static str = "#version 100


### PR DESCRIPTION
The documentation for Point Rendered has some "line" mentions that seem to come from the LineRenderer.