### PR TITLE
Improve webgl_canvas mouse event handling and fix mouse coordinates

### DIFF
--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -225,13 +225,13 @@ impl AbstractCanvas for WebGLCanvas {
                 }
             }
             let hidpi_factor = edata.hidpi_factor;
-            edata.cursor_pos = Some((
-                e.offset_x() as f64 * hidpi_factor,
-                e.offset_y() as f64 * hidpi_factor,
-            ));
+            let bounding_client_rect = edata.canvas.get_bounding_client_rect();
+            let x = (e.client_x() as f64 - bounding_client_rect.get_x()) * hidpi_factor;
+            let y = (e.client_y() as f64 - bounding_client_rect.get_y()) * hidpi_factor;
+            edata.cursor_pos = Some((x, y));
             let _ = edata.pending_events.push(WindowEvent::CursorPos(
-                e.offset_x() as f64 * hidpi_factor,
-                e.offset_y() as f64 * hidpi_factor,
+                x,
+                y,
                 translate_mouse_modifiers(&e),
             ));
         });


### PR DESCRIPTION
A previous version of this PR narrowed the event listeners target, introduced the use of pointer events to enable pointer capturing via `setPointerCapture` and added some cleanup code. Following the comments, part of this PR was split into another PR #219. The current PR focuses on improving the mouse event handling without using pointer event.