### PR TITLE
Fix input for TextBox and TextEdit widgets.

### DIFF
--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -110,6 +110,9 @@ widget_ids! {
         dialer_title,
         number_dialer,
         plot_path,
+        // TextBox and TextEdit
+        text_box,
+        text_edit,
         // Scrollbar
         canvas_scrollbar,
     }
@@ -125,6 +128,8 @@ pub struct DemoApp {
     ball_color: conrod::Color,
     sine_frequency: f32,
     cat: conrod::image::Id,
+    text_box: String,
+    text_edit: String,
 }
 
 #[cfg(feature = "conrod")]
@@ -136,6 +141,8 @@ impl DemoApp {
             ball_color: conrod::color::WHITE,
             sine_frequency: 1.0,
             cat,
+            text_box: "Hello".to_string(),
+            text_edit: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\nUt enim ad minim veniam...".to_string(),
         }
     }
 }
@@ -143,7 +150,7 @@ impl DemoApp {
 /// Instantiate a GUI demonstrating every widget available in conrod.
 #[cfg(feature = "conrod")]
 pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
-    use conrod::{widget, Colorable, Labelable, Positionable, Sizeable, Widget};
+    use conrod::{widget, Colorable, Labelable, Sizeable, Widget};
     use std::iter::once;
 
     const MARGIN: conrod::Scalar = 30.0;
@@ -386,6 +393,36 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
         .down(60.0)
         .align_middle_x_of(ids.canvas)
         .set(ids.plot_path, ui);
+
+    ////////////////////////////////
+    ///// TextBox and TextEdit /////
+    ////////////////////////////////
+
+    for event in widget::TextBox::new(&app.text_box)
+        .down_from(ids.plot_path, 60.0)
+        .align_middle_x_of(ids.canvas)
+        .padded_w_of(ids.canvas, MARGIN)
+        .h(40.0)
+        .set(ids.text_box, ui)
+    {
+        use conrod::widget::text_box::Event;
+        match event {
+            Event::Enter => {}
+            Event::Update(s) => {
+                app.text_box = s;
+            }
+        }
+    }
+
+    for string in widget::TextEdit::new(&app.text_edit)
+        .down_from(ids.text_box, 60.0)
+        .align_middle_x_of(ids.canvas)
+        .padded_w_of(ids.canvas, MARGIN)
+        .h(100.0)
+        .set(ids.text_edit, ui)
+    {
+        app.text_edit = string;
+    }
 
     /////////////////////
     ///// Scrollbar /////

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -164,8 +164,8 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
     const TITLE: &'static str = "All Widgets";
     widget::Canvas::new()
         .pad(MARGIN)
-        .align_bottom()
-        .h(300.0)
+        .align_right()
+        .w(600.0)
         .scroll_kids_vertically()
         .set(ids.canvas, ui);
 

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -156,6 +156,9 @@ impl AbstractCanvas for GLCanvas {
                     key_states[key as usize] = action;
                     let _ = out_events.send(WindowEvent::Key(key, action, modifiers));
                 }
+                glutin::WindowEvent::ReceivedCharacter(c) => {
+                    let _ = out_events.send(WindowEvent::Char(c));
+                }
                 _ => {}
             },
             _ => {}

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -782,6 +782,7 @@ impl Window {
                         Key::Up => CKey::Up,
                         Key::Right => CKey::Right,
                         Key::Down => CKey::Down,
+                        Key::Back => CKey::Backspace,
                         Key::Return => CKey::Return,
                         Key::Space => CKey::Space,
                         Key::Caret => CKey::Caret,
@@ -835,6 +836,18 @@ impl Window {
                         Action::Press => Some(Input::Press(Button::Keyboard(key))),
                         Action::Release => Some(Input::Release(Button::Keyboard(key))),
                     }
+                }
+                WindowEvent::Char(ch) => {
+                    // Shamelessly taken from kiss3d_conrod/backends/conrod_winit/src/macros.rs:175.
+                    let string = match ch {
+                        // Ignore control characters and return ascii for Text event (like sdl2).
+                        '\u{7f}' | // Delete
+                        '\u{1b}' | // Escape
+                        '\u{8}'  | // Backspace
+                        '\r' | '\n' | '\t' => "".to_string(),
+                        _ => ch.to_string()
+                    };
+                    Some(Input::Text(string))
                 }
                 _ => None,
             }


### PR DESCRIPTION
Fixes #210.

Tested on ArchLinux x86_64.

I'm not sure how to build for wasm to test this PR on that platform.  The Rust WebAssembly book \[[1](https://rustwasm.github.io/book/introduction.html)] recommends using `wasm-pack` which complains about `crate-type = ["cdylib", "rlib"]` missing from the `Config.toml`, so I haven't wandered down that rabbit hole, yet.