### PR TITLE
webgl_canvas: Add some cleanup code and change to listen Key and Wheel events on the canvas element only

### DIFF
--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -52,6 +52,14 @@ impl Drop for WebGLCanvas {
         for listener in event_listeners {
             listener.remove();
         }
+        // Clear the remnants of the last frame:
+        // HACK: This uses the global context.
+        let ctxt = Context::get();
+        verify!(ctxt.active_texture(Context::TEXTURE0));
+        verify!(ctxt.clear_color(1.0, 1.0, 1.0, 1.0));
+        verify!(ctxt.clear(Context::COLOR_BUFFER_BIT));
+        verify!(ctxt.clear(Context::DEPTH_BUFFER_BIT));
+        // TODO: Free other resources such as textures?
     }
 }
 


### PR DESCRIPTION
This PR does the following:

- Remove event listeners when Kiss3d context is closed.
- Clear canvas frame to all white when Kiss3d context is closed.
- Change to add the key and wheel event listeners on the canvas element and make the canvas focusable.

These are part of the changes in #207. Note that this PR excludes changing the MouseEvent and TouchEvent listeners because properly fixing them requires more than just changing the listener target.