### PR TITLE
Update conrod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ name = "kiss3d"
 path = "src/lib.rs"
 
 [features]
-conrod = [ "kiss3d_conrod" ]
+conrod = [ "conrod_core" ]
 
 
 [dependencies]
@@ -43,7 +43,7 @@ serde        = "1"
 serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "stdweb" ]}
-kiss3d_conrod = { version = "0.64", features = [ "stdweb" ], optional = true }
+conrod_core = { version = "0.69", features = [ "stdweb" ], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
 gl = "0.14"

--- a/examples/wasm/src/main.rs
+++ b/examples/wasm/src/main.rs
@@ -167,6 +167,8 @@ pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
     const TITLE: &'static str = "All Widgets";
     widget::Canvas::new()
         .pad(MARGIN)
+        .align_bottom()
+        .h(ui.win_h / 2.0)
         .scroll_kids_vertically()
 //        .color(conrod::Color::Rgba(0.5, 0.5, 0.5, 0.2))
         .set(ids.canvas, ui);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,9 +152,9 @@ extern crate stdweb;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 #[macro_use]
 extern crate stdweb_derive;
-extern crate instant;
 #[cfg(feature = "conrod")]
-pub extern crate kiss3d_conrod as conrod;
+pub extern crate conrod_core as conrod;
+extern crate instant;
 #[cfg(feature = "conrod")]
 pub use conrod::widget_ids;
 

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -143,7 +143,9 @@ impl AbstractCanvas for GLCanvas {
                     delta, modifiers, ..
                 } => {
                     let (x, y) = match delta {
-                        glutin::MouseScrollDelta::LineDelta(dx, dy) => (dx as f64, dy as f64),
+                        glutin::MouseScrollDelta::LineDelta(dx, dy) => {
+                            (dx as f64 * 10.0, dy as f64 * 10.0)
+                        }
                         glutin::MouseScrollDelta::PixelDelta(delta) => delta.into(),
                     };
                     let modifiers = translate_modifiers(modifiers);

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -323,6 +323,23 @@ impl AbstractCanvas for WebGLCanvas {
                 .try_into()
                 .ok()
                 .unwrap_or(0.0);
+                // The values of deltaMode:
+                // 0x00 => DOM_DELTA_PIXEL
+                // 0x01 => DOM_DELTA_LINE
+                // 0x02 => DOM_DELTA_PAGE
+                let delta_mode = js!(
+                    return @{e.as_ref()}.deltaMode;
+                )
+                .try_into()
+                .ok()
+                .unwrap_or(0u32);
+                let (delta_x, delta_y) = match delta_mode {
+                    // It doesn't really make much sense to scroll a "page" in
+                    // case of scrolling the cameras so we treat DOM_DELTA_PAGE
+                    // the same way as DOM_DELTA_LINE.
+                    0x01 | 0x02 => (delta_x * 10.0, delta_y * 10.0),
+                    _ => (delta_x, delta_y),
+                };
                 let mut edata = edata.borrow_mut();
                 let _ = edata.pending_events.push(WindowEvent::Scroll(
                     delta_x / 10.0,


### PR DESCRIPTION
Update conrod to the latest upstream version 0.69 instead of using `kiss3d_conrod`. Tested with the `ui` example on Windows and the wasm example using cargo-web on Firefox.