### PR TITLE
Proof-of-concept of splitting Conrod UI into separate crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ include = [
 name = "kiss3d"
 path = "src/lib.rs"
 
-[features]
-conrod = [ "conrod_core" ]
-
 
 [dependencies]
 either       = "1"
@@ -44,7 +41,6 @@ serde        = "1"
 serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "stdweb" ]}
-conrod_core = { version = "0.69", features = [ "stdweb" ], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
 gl = "0.14"
@@ -67,3 +63,8 @@ stdweb-derive = "0.5"
 [dev-dependencies]
 rand = "0.7"
 ncollide2d = "0.23"
+
+[workspace]
+members = [
+    "gui/conrod",
+]

--- a/gui/conrod/Cargo.toml
+++ b/gui/conrod/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "kiss3d_conrod"
+version = "0.69.0"
+authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+edition = "2018"
+
+license = "BSD-3-Clause"
+
+[dependencies]
+conrod_core = { version = "0.69", features = [ "stdweb" ] }
+kiss3d = { version = "0.24", path = "../.." }
+nalgebra = "0.21"
+rusttype = { version = "0.8", features = [ "gpu_cache" ] }
+
+[dev-dependencies]
+rand = "0.7"

--- a/gui/conrod/examples/ui.rs
+++ b/gui/conrod/examples/ui.rs
@@ -1,0 +1,374 @@
+use kiss3d::light::Light;
+use kiss3d::window::Window;
+use kiss3d_conrod::conrod;
+use kiss3d_conrod::conrod::widget_ids;
+use std::path::Path;
+
+fn main() {
+    let mut window: Window<kiss3d_conrod::ConrodContext> = Window::new_with_ui("Kiss3d: UI", ());
+    window.set_background_color(1.0, 1.0, 1.0);
+    let mut c = window.add_cube(0.1, 0.1, 0.1);
+    c.set_color(1.0, 0.0, 0.0);
+
+    window.set_light(Light::StickToCamera);
+
+    // Generate the widget identifiers.
+    let ids = Ids::new(window.ui_mut().conrod_ui_mut().widget_id_generator());
+    window.ui_mut().conrod_ui_mut().theme = theme();
+    window.add_texture(&Path::new("./examples/media/kitten.png"), "cat");
+    let cat_texture = window.ui_mut().conrod_texture_id("cat").unwrap();
+
+    let mut app = DemoApp::new(cat_texture);
+
+    // Render loop.
+    while window.render() {
+        let mut ui = window.ui_mut().conrod_ui_mut().set_widgets();
+        gui(&mut ui, &ids, &mut app)
+    }
+}
+
+/*
+ *
+ * This is he example taken from conrods' repository.
+ *
+ */
+/// A set of reasonable stylistic defaults that works for the `gui` below.
+pub fn theme() -> conrod::Theme {
+    use conrod::position::{Align, Direction, Padding, Position, Relative};
+    conrod::Theme {
+        name: "Demo Theme".to_string(),
+        padding: Padding::none(),
+        x_position: Position::Relative(Relative::Align(Align::Start), None),
+        y_position: Position::Relative(Relative::Direction(Direction::Backwards, 20.0), None),
+        background_color: conrod::color::DARK_CHARCOAL,
+        shape_color: conrod::color::LIGHT_CHARCOAL,
+        border_color: conrod::color::BLACK,
+        border_width: 0.0,
+        label_color: conrod::color::WHITE,
+        font_id: None,
+        font_size_large: 26,
+        font_size_medium: 18,
+        font_size_small: 12,
+        widget_styling: conrod::theme::StyleMap::default(),
+        mouse_drag_threshold: 0.0,
+        double_click_threshold: std::time::Duration::from_millis(500),
+    }
+}
+
+// Generate a unique `WidgetId` for each widget.
+widget_ids! {
+    pub struct Ids {
+        // The scrollable canvas.
+        canvas,
+        // The title and introduction widgets.
+        title,
+        introduction,
+        // Shapes.
+        shapes_canvas,
+        rounded_rectangle,
+        shapes_left_col,
+        shapes_right_col,
+        shapes_title,
+        line,
+        point_path,
+        rectangle_fill,
+        rectangle_outline,
+        trapezoid,
+        oval_fill,
+        oval_outline,
+        circle,
+        // Image.
+        image_title,
+        cat,
+        // Button, XyPad, Toggle.
+        button_title,
+        button,
+        xy_pad,
+        toggle,
+        ball,
+        // NumberDialer, PlotPath
+        dialer_title,
+        number_dialer,
+        plot_path,
+        // Scrollbar
+        canvas_scrollbar,
+    }
+}
+
+pub const WIN_W: u32 = 600;
+pub const WIN_H: u32 = 420;
+
+/// A demonstration of some application state we want to control with a conrod GUI.
+pub struct DemoApp {
+    ball_xy: conrod::Point,
+    ball_color: conrod::Color,
+    sine_frequency: f32,
+    cat: conrod::image::Id,
+}
+
+impl DemoApp {
+    /// Simple constructor for the `DemoApp`.
+    pub fn new(cat: conrod::image::Id) -> Self {
+        DemoApp {
+            ball_xy: [0.0, 0.0],
+            ball_color: conrod::color::WHITE,
+            sine_frequency: 1.0,
+            cat,
+        }
+    }
+}
+
+/// Instantiate a GUI demonstrating every widget available in conrod.
+pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
+    use conrod::{widget, Colorable, Labelable, Positionable, Sizeable, Widget};
+    use std::iter::once;
+
+    const MARGIN: conrod::Scalar = 30.0;
+    const SHAPE_GAP: conrod::Scalar = 50.0;
+    const TITLE_SIZE: conrod::FontSize = 42;
+    const SUBTITLE_SIZE: conrod::FontSize = 32;
+
+    // `Canvas` is a widget that provides some basic functionality for laying out children widgets.
+    // By default, its size is the size of the window. We'll use this as a background for the
+    // following widgets, as well as a scrollable container for the children widgets.
+    const TITLE: &'static str = "All Widgets";
+    widget::Canvas::new()
+        .pad(MARGIN)
+        .align_bottom()
+        .h(300.0)
+        .scroll_kids_vertically()
+        .set(ids.canvas, ui);
+
+    ////////////////
+    ///// TEXT /////
+    ////////////////
+
+    // We'll demonstrate the `Text` primitive widget by using it to draw a title and an
+    // introduction to the example.
+    widget::Text::new(TITLE)
+        .font_size(TITLE_SIZE)
+        .mid_top_of(ids.canvas)
+        .set(ids.title, ui);
+    const INTRODUCTION: &'static str =
+        "This example aims to demonstrate some widgets that are provided by conrod.\
+        \n\nScroll down to see more widgets!";
+    widget::Text::new(INTRODUCTION)
+        .padded_w_of(ids.canvas, MARGIN)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .center_justify()
+        .line_spacing(5.0)
+        .set(ids.introduction, ui);
+
+    //return;
+    ////////////////////////////
+    ///// Lines and Shapes /////
+    ////////////////////////////
+
+    widget::Text::new("Lines and Shapes")
+        .down(70.0)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.shapes_title, ui);
+
+    // Lay out the shapes in two horizontal columns.
+    //
+    // TODO: Have conrod provide an auto-flowing, fluid-list widget that is more adaptive for these
+    // sorts of situations.
+    widget::Canvas::new()
+        .down(0.0)
+        .align_middle_x_of(ids.canvas)
+        .kid_area_w_of(ids.canvas)
+        .h(360.0)
+        .color(conrod::color::TRANSPARENT)
+        .pad(MARGIN)
+        .flow_down(&[
+            (ids.shapes_left_col, widget::Canvas::new()),
+            (ids.shapes_right_col, widget::Canvas::new()),
+        ])
+        .set(ids.shapes_canvas, ui);
+
+    let shapes_canvas_rect = ui.rect_of(ids.shapes_canvas).unwrap();
+    let w = shapes_canvas_rect.w();
+    let h = shapes_canvas_rect.h() * 5.0 / 6.0;
+    let radius = 10.0;
+    widget::RoundedRectangle::fill([w, h], radius)
+        .color(conrod::color::CHARCOAL.alpha(0.25))
+        .middle_of(ids.shapes_canvas)
+        .set(ids.rounded_rectangle, ui);
+
+    let start = [-40.0, -40.0];
+    let end = [40.0, 40.0];
+    widget::Line::centred(start, end)
+        .mid_left_of(ids.shapes_left_col)
+        .set(ids.line, ui);
+
+    let left = [-40.0, -40.0];
+    let top = [0.0, 40.0];
+    let right = [40.0, -40.0];
+    let points = once(left).chain(once(top)).chain(once(right));
+    widget::PointPath::centred(points)
+        .right(SHAPE_GAP)
+        .set(ids.point_path, ui);
+
+    widget::Rectangle::fill([80.0, 80.0])
+        .right(SHAPE_GAP)
+        .set(ids.rectangle_fill, ui);
+
+    widget::Rectangle::outline([80.0, 80.0])
+        .right(SHAPE_GAP)
+        .set(ids.rectangle_outline, ui);
+
+    let bl = [-40.0, -40.0];
+    let tl = [-20.0, 40.0];
+    let tr = [20.0, 40.0];
+    let br = [40.0, -40.0];
+    let points = once(bl).chain(once(tl)).chain(once(tr)).chain(once(br));
+    widget::Polygon::centred_fill(points)
+        .mid_left_of(ids.shapes_right_col)
+        .set(ids.trapezoid, ui);
+
+    widget::Oval::fill([40.0, 80.0])
+        .right(SHAPE_GAP + 20.0)
+        .align_middle_y()
+        .set(ids.oval_fill, ui);
+
+    widget::Oval::outline([80.0, 40.0])
+        .right(SHAPE_GAP + 20.0)
+        .align_middle_y()
+        .set(ids.oval_outline, ui);
+
+    widget::Circle::fill(40.0)
+        .right(SHAPE_GAP)
+        .align_middle_y()
+        .set(ids.circle, ui);
+
+    /////////////////
+    ///// Image /////
+    /////////////////
+
+    widget::Text::new("Image")
+        .down_from(ids.shapes_canvas, MARGIN)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.image_title, ui);
+
+    const LOGO_SIDE: conrod::Scalar = 144.0;
+    widget::Image::new(app.cat)
+        .w_h(LOGO_SIDE, LOGO_SIDE)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .set(ids.cat, ui);
+
+    /////////////////////////////////
+    ///// Button, XYPad, Toggle /////
+    /////////////////////////////////
+
+    widget::Text::new("Button, XYPad and Toggle")
+        .down_from(ids.cat, 60.0)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.button_title, ui);
+
+    let ball_x_range = ui.kid_area_of(ids.canvas).unwrap().w();
+    let ball_y_range = ui.h_of(ui.window).unwrap() * 0.5;
+    let min_x = -ball_x_range / 3.0;
+    let max_x = ball_x_range / 3.0;
+    let min_y = -ball_y_range / 3.0;
+    let max_y = ball_y_range / 3.0;
+    let side = 130.0;
+
+    for _press in widget::Button::new()
+        .label("PRESS ME")
+        .mid_left_with_margin_on(ids.canvas, MARGIN)
+        .down_from(ids.button_title, 60.0)
+        .w_h(side, side)
+        .set(ids.button, ui)
+    {
+        let x = rand::random::<conrod::Scalar>() * (max_x - min_x) - max_x;
+        let y = rand::random::<conrod::Scalar>() * (max_y - min_y) - max_y;
+        app.ball_xy = [x, y];
+    }
+
+    for (x, y) in widget::XYPad::new(app.ball_xy[0], min_x, max_x, app.ball_xy[1], min_y, max_y)
+        .label("BALL XY")
+        .wh_of(ids.button)
+        .align_middle_y_of(ids.button)
+        .align_middle_x_of(ids.canvas)
+        .parent(ids.canvas)
+        .set(ids.xy_pad, ui)
+    {
+        app.ball_xy = [x, y];
+    }
+
+    let is_white = app.ball_color == conrod::color::WHITE;
+    let label = if is_white { "WHITE" } else { "BLACK" };
+    for is_white in widget::Toggle::new(is_white)
+        .label(label)
+        .label_color(if is_white {
+            conrod::color::WHITE
+        } else {
+            conrod::color::LIGHT_CHARCOAL
+        })
+        .mid_right_with_margin_on(ids.canvas, MARGIN)
+        .align_middle_y_of(ids.button)
+        .set(ids.toggle, ui)
+    {
+        app.ball_color = if is_white {
+            conrod::color::WHITE
+        } else {
+            conrod::color::BLACK
+        };
+    }
+
+    let ball_x = app.ball_xy[0];
+    let ball_y = app.ball_xy[1] - max_y - side * 0.5 - MARGIN;
+    widget::Circle::fill(20.0)
+        .color(app.ball_color)
+        .x_y_relative_to(ids.xy_pad, ball_x, ball_y)
+        .set(ids.ball, ui);
+
+    //////////////////////////////////
+    ///// NumberDialer, PlotPath /////
+    //////////////////////////////////
+
+    widget::Text::new("NumberDialer and PlotPath")
+        .down_from(ids.xy_pad, max_y - min_y + side * 0.5 + MARGIN)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.dialer_title, ui);
+
+    // Use a `NumberDialer` widget to adjust the frequency of the sine wave below.
+    let min = 0.5;
+    let max = 200.0;
+    let decimal_precision = 1;
+    for new_freq in widget::NumberDialer::new(app.sine_frequency, min, max, decimal_precision)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .w_h(160.0, 40.0)
+        .label("F R E Q")
+        .set(ids.number_dialer, ui)
+    {
+        app.sine_frequency = new_freq;
+    }
+
+    // Use the `PlotPath` widget to display a sine wave.
+    let min_x = 0.0;
+    let max_x = std::f32::consts::PI * 2.0 * app.sine_frequency;
+    let min_y = -1.0;
+    let max_y = 1.0;
+    widget::PlotPath::new(min_x, max_x, min_y, max_y, f32::sin)
+        .kid_area_w_of(ids.canvas)
+        .h(240.0)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .set(ids.plot_path, ui);
+
+    /////////////////////
+    ///// Scrollbar /////
+    /////////////////////
+
+    widget::Scrollbar::y_axis(ids.canvas)
+        .auto_hide(true)
+        .set(ids.canvas_scrollbar, ui);
+}

--- a/gui/conrod/src/conrod_renderer.rs
+++ b/gui/conrod/src/conrod_renderer.rs
@@ -1,0 +1,695 @@
+//! A renderer for Conrod primitives.
+
+use conrod::position::Rect;
+use conrod::text::GlyphCache;
+use conrod::{render::PrimitiveKind, Ui};
+use conrod_core as conrod;
+use kiss3d::context::{Context, Texture};
+use kiss3d::resource::{
+    AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform,
+};
+use kiss3d::text::Font;
+use nalgebra::{Point2, Point3, Point4, Vector2};
+use rusttype::gpu_cache::Cache;
+use std::rc::Rc;
+
+macro_rules! verify(
+    ($e: expr) => {
+        {
+            let res = $e;
+            #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+            { assert_eq!(kiss3d::context::Context::get().get_error(), 0); }
+            res
+        }
+    }
+);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum RenderMode {
+    Image {
+        color: Point4<f32>,
+        texture: conrod::image::Id,
+    },
+    Shape,
+    Text {
+        color: Point4<f32>,
+    },
+    Unknown,
+}
+
+/// Structure which manages the display of short-living points.
+pub struct ConrodRenderer {
+    ui: Ui,
+    triangle_shader: Effect,
+    triangle_window_size: ShaderUniform<Vector2<f32>>,
+    triangle_pos: ShaderAttribute<Point2<f32>>,
+    triangle_color: ShaderAttribute<Point4<f32>>,
+    text_shader: Effect,
+    text_window_size: ShaderUniform<Vector2<f32>>,
+    text_color: ShaderUniform<Point4<f32>>,
+    text_pos: ShaderAttribute<Point2<f32>>,
+    text_uvs: ShaderAttribute<Point2<f32>>,
+    text_texture: ShaderUniform<i32>,
+    image_shader: Effect,
+    image_window_size: ShaderUniform<Vector2<f32>>,
+    image_color: ShaderUniform<Point4<f32>>,
+    image_pos: ShaderAttribute<Point2<f32>>,
+    image_uvs: ShaderAttribute<Point2<f32>>,
+    image_texture: ShaderUniform<i32>,
+    points: GPUVec<f32>,
+    indices: GPUVec<Point3<u16>>,
+    cache: GlyphCache<'static>,
+    texture: Texture,
+    resized_once: bool,
+}
+
+impl ConrodRenderer {
+    /// Creates a new points manager.
+    pub fn new(width: f64, height: f64) -> ConrodRenderer {
+        //
+        // Create shaders.
+        //
+        let triangle_shader = Effect::new_from_str(TRIANGLES_VERTEX_SRC, TRIANGLES_FRAGMENT_SRC);
+        let text_shader = Effect::new_from_str(TEXT_VERTEX_SRC, TEXT_FRAGMENT_SRC);
+        let image_shader = Effect::new_from_str(IMAGE_VERTEX_SRC, IMAGE_FRAGMENT_SRC);
+
+        //
+        // Initialize UI with the default font.
+        //
+        let mut ui = conrod::UiBuilder::new([width, height]).build();
+        let _ = ui.fonts.insert(Font::default().font().clone());
+
+        //
+        // Create cache or text.
+        //
+        let atlas_width = 1024;
+        let atlas_height = 1024;
+        let cache = Cache::builder()
+            .dimensions(atlas_width, atlas_height)
+            .build();
+
+        //
+        // Create texture for text
+        //
+        let ctxt = Context::get();
+
+        /* We're using 1 byte alignment buffering. */
+        verify!(ctxt.pixel_storei(Context::UNPACK_ALIGNMENT, 1));
+
+        let texture = verify!(ctxt
+            .create_texture()
+            .expect("Font texture creation failed."));
+        verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture)));
+        verify!(ctxt.tex_image2d(
+            Context::TEXTURE_2D,
+            0,
+            Context::RED as i32,
+            atlas_width as i32,
+            atlas_height as i32,
+            0,
+            Context::RED,
+            None
+        ));
+
+        /* Clamp to the edge to avoid artifacts when scaling. */
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_WRAP_S,
+            Context::CLAMP_TO_EDGE as i32
+        ));
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_WRAP_T,
+            Context::CLAMP_TO_EDGE as i32
+        ));
+
+        /* Linear filtering usually looks best for text. */
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_MIN_FILTER,
+            Context::LINEAR as i32
+        ));
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_MAG_FILTER,
+            Context::LINEAR as i32
+        ));
+
+        ConrodRenderer {
+            ui,
+            points: GPUVec::new(Vec::new(), BufferType::Array, AllocationType::StreamDraw),
+            indices: GPUVec::new(
+                Vec::new(),
+                BufferType::ElementArray,
+                AllocationType::StreamDraw,
+            ),
+            triangle_window_size: triangle_shader.get_uniform("window_size").unwrap(),
+            triangle_pos: triangle_shader.get_attrib("position").unwrap(),
+            triangle_color: triangle_shader.get_attrib("color").unwrap(),
+            triangle_shader,
+            text_window_size: text_shader
+                .get_uniform::<Vector2<f32>>("window_size")
+                .unwrap(),
+            text_color: text_shader.get_uniform::<Point4<f32>>("color").unwrap(),
+            text_pos: text_shader.get_attrib("pos").unwrap(),
+            text_uvs: text_shader.get_attrib("uvs").unwrap(),
+            text_texture: text_shader.get_uniform("tex0").unwrap(),
+            text_shader,
+            image_window_size: image_shader
+                .get_uniform::<Vector2<f32>>("window_size")
+                .unwrap(),
+            image_color: image_shader.get_uniform::<Point4<f32>>("color").unwrap(),
+            image_pos: image_shader.get_attrib("pos").unwrap(),
+            image_uvs: image_shader.get_attrib("uvs").unwrap(),
+            image_texture: image_shader.get_uniform("tex0").unwrap(),
+            image_shader,
+            cache,
+            texture,
+            resized_once: false,
+        }
+    }
+
+    /// The mutable UI to be displayed.
+    pub fn ui_mut(&mut self) -> &mut Ui {
+        &mut self.ui
+    }
+
+    /// The UI to be displayed.
+    pub fn ui(&self) -> &Ui {
+        &self.ui
+    }
+
+    /// Actually draws the points.
+    pub fn render(
+        &mut self,
+        width: f32,
+        height: f32,
+        hidpi_factor: f32,
+        texture_map: &conrod::image::Map<(Rc<Texture>, (u32, u32))>,
+    ) {
+        // NOTE: this seems necessary for WASM.
+        if !self.resized_once {
+            self.ui.handle_event(conrod::event::Input::Resize(
+                width as f64 / hidpi_factor as f64,
+                height as f64 / hidpi_factor as f64,
+            ));
+            self.resized_once = true;
+        }
+
+        let mut primitives = self.ui.draw();
+        let ctxt = Context::get();
+        let mut mode = RenderMode::Unknown;
+        let mut curr_scizzor = Rect::from_corners([0.0, 0.0], [0.0, 0.0]);
+
+        let mut vid = 0;
+
+        verify!(ctxt.disable(Context::CULL_FACE));
+        let _ = verify!(ctxt.polygon_mode(Context::FRONT_AND_BACK, Context::FILL));
+        verify!(ctxt.enable(Context::BLEND));
+        verify!(ctxt.blend_func_separate(
+            Context::SRC_ALPHA,
+            Context::ONE_MINUS_SRC_ALPHA,
+            Context::ONE,
+            Context::ONE_MINUS_SRC_ALPHA,
+        ));
+        verify!(ctxt.disable(Context::DEPTH_TEST));
+        verify!(ctxt.enable(Context::SCISSOR_TEST));
+
+        let rect_to_gl_rect = |rect: Rect| {
+            let (w, h) = rect.w_h();
+            let l = rect.left() as f32 * hidpi_factor + width / 2.0;
+            let b = rect.bottom() as f32 * hidpi_factor + height / 2.0;
+            let w = w as f32 * hidpi_factor;
+            let h = h as f32 * hidpi_factor;
+
+            (l.max(0.0), b.max(0.0), w.min(width), h.min(height))
+        };
+
+        loop {
+            let primitive = primitives.next();
+
+            let render = if let Some(ref primitive) = primitive {
+                curr_scizzor != primitive.scizzor
+                    || match primitive.kind {
+                        PrimitiveKind::TrianglesSingleColor { .. } => mode != RenderMode::Shape,
+                        PrimitiveKind::TrianglesMultiColor { .. } => mode != RenderMode::Shape,
+                        PrimitiveKind::Rectangle { .. } => mode != RenderMode::Shape,
+                        PrimitiveKind::Image {
+                            color, image_id, ..
+                        } => {
+                            let rgba = color.unwrap_or(conrod::color::WHITE).to_rgb();
+                            mode != RenderMode::Image {
+                                color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3),
+                                texture: image_id,
+                            }
+                        }
+                        PrimitiveKind::Text { color, .. } => {
+                            let rgba = color.to_rgb();
+                            mode != RenderMode::Text {
+                                color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3),
+                            }
+                        }
+                        PrimitiveKind::Other(_) => false,
+                    }
+            } else {
+                true
+            };
+
+            if render {
+                let (x, y, w, h) = rect_to_gl_rect(curr_scizzor);
+                ctxt.scissor(x as i32, y as i32, w as i32, h as i32);
+                match mode {
+                    RenderMode::Shape => {
+                        self.triangle_shader.use_program();
+                        self.triangle_pos.enable();
+                        self.triangle_color.enable();
+
+                        self.triangle_window_size
+                            .upload(&Vector2::new(width, height));
+                        unsafe {
+                            self.triangle_color
+                                .bind_sub_buffer_generic(&mut self.points, 5, 2)
+                        };
+                        unsafe {
+                            self.triangle_pos
+                                .bind_sub_buffer_generic(&mut self.points, 5, 0)
+                        };
+                        self.indices.bind();
+
+                        verify!(ctxt.draw_elements(
+                            Context::TRIANGLES,
+                            self.indices.len() as i32 * 3,
+                            Context::UNSIGNED_SHORT,
+                            0
+                        ));
+
+                        self.triangle_pos.disable();
+                        self.triangle_color.disable();
+                    }
+                    RenderMode::Text { color } => {
+                        self.text_shader.use_program();
+                        self.text_pos.enable();
+                        self.text_uvs.enable();
+                        self.text_texture.upload(&0);
+                        self.text_color.upload(&color);
+                        self.text_window_size.upload(&Vector2::new(width, height));
+                        verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
+                        unsafe {
+                            self.text_pos
+                                .bind_sub_buffer_generic(&mut self.points, 3, 0)
+                        };
+                        unsafe {
+                            self.text_uvs
+                                .bind_sub_buffer_generic(&mut self.points, 3, 2)
+                        };
+
+                        verify!(ctxt.draw_arrays(
+                            Context::TRIANGLES,
+                            0,
+                            (self.points.len() / 4) as i32
+                        ));
+
+                        self.text_pos.disable();
+                        self.text_uvs.disable();
+                    }
+                    RenderMode::Image { color, texture } => {
+                        if let Some(texture) = texture_map.get(&texture) {
+                            self.image_shader.use_program();
+                            self.image_pos.enable();
+                            self.image_uvs.enable();
+
+                            self.image_texture.upload(&0);
+                            self.image_color.upload(&color);
+                            self.image_window_size.upload(&Vector2::new(width, height));
+                            verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture.0)));
+                            unsafe {
+                                self.image_pos
+                                    .bind_sub_buffer_generic(&mut self.points, 3, 0)
+                            };
+                            unsafe {
+                                self.image_uvs
+                                    .bind_sub_buffer_generic(&mut self.points, 3, 2)
+                            };
+
+                            verify!(ctxt.draw_arrays(
+                                Context::TRIANGLES,
+                                0,
+                                (self.points.len() / 4) as i32
+                            ));
+
+                            self.image_pos.disable();
+                            self.image_uvs.disable();
+                        }
+                    }
+                    RenderMode::Unknown => {}
+                }
+
+                vid = 0;
+                mode = RenderMode::Unknown;
+                self.points.data_mut().as_mut().unwrap().clear();
+                self.indices.data_mut().as_mut().unwrap().clear();
+            }
+
+            if primitive.is_none() {
+                break;
+            }
+
+            let primitive = primitive.unwrap();
+            let vertices = self.points.data_mut().as_mut().unwrap();
+            let indices = self.indices.data_mut().as_mut().unwrap();
+            curr_scizzor = primitive.scizzor;
+
+            match primitive.kind {
+                PrimitiveKind::Rectangle { color } => {
+                    mode = RenderMode::Shape;
+
+                    let color = color.to_rgb();
+                    let tl = (primitive.rect.x.start, primitive.rect.y.end);
+                    let bl = (primitive.rect.x.start, primitive.rect.y.start);
+                    let br = (primitive.rect.x.end, primitive.rect.y.start);
+                    let tr = (primitive.rect.x.end, primitive.rect.y.end);
+
+                    vertices.extend_from_slice(&[
+                        tl.0 as f32 * hidpi_factor,
+                        tl.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                        bl.0 as f32 * hidpi_factor,
+                        bl.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                        br.0 as f32 * hidpi_factor,
+                        br.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                        tr.0 as f32 * hidpi_factor,
+                        tr.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                    ]);
+
+                    indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+                    indices.push(Point3::new(vid + 2, vid + 3, vid + 0));
+
+                    vid += 4;
+                }
+                PrimitiveKind::TrianglesSingleColor { color, triangles } => {
+                    mode = RenderMode::Shape;
+
+                    for triangle in triangles {
+                        let pts = triangle.points();
+
+                        vertices.extend_from_slice(&[
+                            pts[0][0] as f32 * hidpi_factor,
+                            pts[0][1] as f32 * hidpi_factor,
+                            color.0,
+                            color.1,
+                            color.2,
+                            color.3,
+                            pts[1][0] as f32 * hidpi_factor,
+                            pts[1][1] as f32 * hidpi_factor,
+                            color.0,
+                            color.1,
+                            color.2,
+                            color.3,
+                            pts[2][0] as f32 * hidpi_factor,
+                            pts[2][1] as f32 * hidpi_factor,
+                            color.0,
+                            color.1,
+                            color.2,
+                            color.3,
+                        ]);
+                        indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+
+                        vid += 3;
+                    }
+                }
+                PrimitiveKind::TrianglesMultiColor { triangles } => {
+                    mode = RenderMode::Shape;
+
+                    for triangle in triangles {
+                        let ((a, ca), (b, cb), (c, cc)) =
+                            (triangle.0[0], triangle.0[1], triangle.0[2]);
+                        vertices.extend_from_slice(&[
+                            a[0] as f32 * hidpi_factor,
+                            a[1] as f32 * hidpi_factor,
+                            ca.0,
+                            ca.1,
+                            ca.2,
+                            ca.3,
+                            b[0] as f32 * hidpi_factor,
+                            b[1] as f32 * hidpi_factor,
+                            cb.0,
+                            cb.1,
+                            cb.2,
+                            cb.3,
+                            c[0] as f32 * hidpi_factor,
+                            c[1] as f32 * hidpi_factor,
+                            cc.0,
+                            cc.1,
+                            cc.2,
+                            cc.3,
+                        ]);
+                        indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+
+                        vid += 3;
+                    }
+                }
+                PrimitiveKind::Image {
+                    image_id,
+                    color,
+                    source_rect,
+                } => {
+                    if let Some(texture) = texture_map.get(&image_id) {
+                        let color = color.unwrap_or(conrod::color::WHITE).to_rgb();
+                        mode = RenderMode::Image {
+                            color: Point4::new(color.0, color.1, color.2, color.3),
+                            texture: image_id,
+                        };
+
+                        let min_px = primitive.rect.x.start as f32 * hidpi_factor;
+                        let min_py = primitive.rect.y.start as f32 * hidpi_factor;
+                        let max_px = primitive.rect.x.end as f32 * hidpi_factor;
+                        let max_py = primitive.rect.y.end as f32 * hidpi_factor;
+
+                        let w = (texture.1).0 as f64;
+                        let h = (texture.1).1 as f64;
+                        let mut tex = source_rect
+                            .unwrap_or(conrod::position::Rect::from_corners([0.0, 0.0], [w, h]));
+                        tex.x.start /= w;
+                        tex.x.end /= w;
+                        // Because opengl textures are loaded upside down.
+                        tex.y.start = (h - tex.y.start) / h;
+                        tex.y.end = (h - tex.y.end) / h;
+
+                        vertices.extend_from_slice(&[
+                            min_px,
+                            min_py,
+                            tex.x.start as f32,
+                            tex.y.start as f32,
+                            min_px,
+                            max_py,
+                            tex.x.start as f32,
+                            tex.y.end as f32,
+                            max_px,
+                            min_py,
+                            tex.x.end as f32,
+                            tex.y.start as f32,
+                            max_px,
+                            min_py,
+                            tex.x.end as f32,
+                            tex.y.start as f32,
+                            min_px,
+                            max_py,
+                            tex.x.start as f32,
+                            tex.y.end as f32,
+                            max_px,
+                            max_py,
+                            tex.x.end as f32,
+                            tex.y.end as f32,
+                        ]);
+                    }
+                }
+                PrimitiveKind::Other(_) => {}
+                PrimitiveKind::Text {
+                    color,
+                    text,
+                    font_id,
+                } => {
+                    let rgba = color.to_rgb();
+                    mode = RenderMode::Text {
+                        color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3),
+                    };
+
+                    verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
+                    verify!(ctxt.tex_parameteri(
+                        Context::TEXTURE_2D,
+                        Context::TEXTURE_WRAP_S,
+                        Context::CLAMP_TO_EDGE as i32
+                    ));
+                    verify!(ctxt.tex_parameteri(
+                        Context::TEXTURE_2D,
+                        Context::TEXTURE_WRAP_T,
+                        Context::CLAMP_TO_EDGE as i32
+                    ));
+
+                    /*
+                     * Update the text image.
+                     */
+                    let positioned_glyphs = text.positioned_glyphs(hidpi_factor);
+                    for glyph in positioned_glyphs.iter() {
+                        self.cache.queue_glyph(font_id.index(), glyph.clone());
+                    }
+
+                    let _ = self.cache.cache_queued(|rect, data| {
+                        verify!(ctxt.tex_sub_image2d(
+                            Context::TEXTURE_2D,
+                            0,
+                            rect.min.x as i32,
+                            rect.min.y as i32,
+                            rect.width() as i32,
+                            rect.height() as i32,
+                            Context::RED,
+                            Some(&data)
+                        ));
+                    });
+
+                    /*
+                     * Build the vertex buffer.
+                     */
+                    for glyph in positioned_glyphs {
+                        if let Some(Some((tex, rect))) =
+                            self.cache.rect_for(font_id.index(), &glyph).ok()
+                        {
+                            let min_px = rect.min.x as f32;
+                            let min_py = rect.min.y as f32;
+                            let max_px = rect.max.x as f32;
+                            let max_py = rect.max.y as f32;
+
+                            vertices.extend_from_slice(&[
+                                min_px, min_py, tex.min.x, tex.min.y, min_px, max_py, tex.min.x,
+                                tex.max.y, max_px, min_py, tex.max.x, tex.min.y, max_px, min_py,
+                                tex.max.x, tex.min.y, min_px, max_py, tex.min.x, tex.max.y, max_px,
+                                max_py, tex.max.x, tex.max.y,
+                            ]);
+                        }
+                    }
+                }
+            }
+        }
+
+        verify!(ctxt.enable(Context::DEPTH_TEST));
+        verify!(ctxt.disable(Context::BLEND));
+        ctxt.scissor(0, 0, width as i32, height as i32);
+    }
+}
+
+static TRIANGLES_VERTEX_SRC: &'static str = "#version 100
+attribute vec2 position;
+attribute vec4 color;
+
+uniform vec2 window_size;
+
+varying vec4 v_color;
+
+void main(){
+    gl_Position = vec4(position / window_size * 2.0, 0.0, 1.0);
+    v_color = color;
+}";
+
+static TRIANGLES_FRAGMENT_SRC: &'static str = "#version 100
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+varying vec4 v_color;
+
+void main() {
+  gl_FragColor = v_color;
+}";
+
+const TEXT_VERTEX_SRC: &'static str = "
+#version 100
+
+uniform vec2 window_size;
+uniform vec4 color;
+
+attribute vec2 pos;
+attribute vec2 uvs;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_Position = vec4((pos.x / window_size.x - 0.5) * 2.0, (0.5 - pos.y / window_size.y) * 2.0, 0.0, 1.0);
+    v_uvs       = uvs;
+    v_color     = color;
+}
+";
+
+const TEXT_FRAGMENT_SRC: &'static str = "
+#version 100
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+uniform sampler2D tex0;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = vec4(v_color.rgb, v_color.a * texture2D(tex0, v_uvs).r);
+}
+";
+
+const IMAGE_VERTEX_SRC: &'static str = "
+#version 100
+
+uniform vec2 window_size;
+uniform vec4 color;
+
+attribute vec2 pos;
+attribute vec2 uvs;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_Position = vec4(pos / window_size * 2.0, 0.0, 1.0);
+    v_uvs       = uvs;
+    v_color     = color;
+}
+";
+
+const IMAGE_FRAGMENT_SRC: &'static str = "
+#version 100
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+uniform sampler2D tex0;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = texture2D(tex0, v_uvs) * v_color;
+}
+";

--- a/gui/conrod/src/lib.rs
+++ b/gui/conrod/src/lib.rs
@@ -1,0 +1,271 @@
+use conrod::{
+    event::Input,
+    input::{Button, Key as CKey, Motion, MouseButton},
+};
+use conrod_renderer::ConrodRenderer;
+use kiss3d::{
+    event::{Action, Key, WindowEvent},
+    resource::{Texture, TextureManager},
+    window::UiContext,
+};
+use nalgebra::Vector2;
+use std::{collections::HashMap, rc::Rc};
+
+pub use conrod_core as conrod;
+
+mod conrod_renderer;
+
+pub struct ConrodContext {
+    renderer: ConrodRenderer,
+    textures: conrod::image::Map<(Rc<Texture>, (u32, u32))>,
+    texture_ids: HashMap<String, conrod::image::Id>,
+}
+
+impl ConrodContext {
+    pub fn conrod_ui(&self) -> &conrod::Ui {
+        self.renderer.ui()
+    }
+
+    pub fn conrod_ui_mut(&mut self) -> &mut conrod::Ui {
+        self.renderer.ui_mut()
+    }
+
+    /// Attributes a conrod ID to the given texture and returns it if it exists.
+    pub fn conrod_texture_id(&mut self, name: &str) -> Option<conrod::image::Id> {
+        let tex = TextureManager::get_global_manager(|tm| tm.get_with_size(name))?;
+        let textures = &mut self.textures;
+        Some(
+            *self
+                .texture_ids
+                .entry(name.to_string())
+                .or_insert_with(|| textures.insert(tex)),
+        )
+    }
+
+    /// Returns `true` if the keyboard is currently interacting with a Conrod widget.
+    pub fn is_conrod_ui_capturing_keyboard(&self) -> bool {
+        let ui = self.renderer.ui();
+        let state = &ui.global_input().current;
+        let window_id = Some(ui.window);
+
+        state.widget_capturing_keyboard.is_some() && state.widget_capturing_keyboard != window_id
+    }
+}
+
+impl UiContext for ConrodContext {
+    type Init = ();
+
+    fn new(width: u32, height: u32, _ui_init: Self::Init) -> Self {
+        Self {
+            renderer: ConrodRenderer::new(width as f64, height as f64),
+            textures: conrod::image::Map::new(),
+            texture_ids: HashMap::new(),
+        }
+    }
+
+    fn handle_event(&mut self, event: &WindowEvent, size: Vector2<u32>, hidpi: f64) -> bool {
+        let conrod_ui = self.renderer.ui_mut();
+        if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
+            conrod_ui.handle_event(input);
+        }
+
+        let state = &conrod_ui.global_input().current;
+        let window_id = Some(conrod_ui.window);
+
+        if event.is_keyboard_event()
+            && state.widget_capturing_keyboard.is_some()
+            && state.widget_capturing_keyboard != window_id
+        {
+            return true;
+        }
+
+        if event.is_mouse_event()
+            && state.widget_capturing_mouse.is_some()
+            && state.widget_capturing_mouse != window_id
+        {
+            return true;
+        }
+
+        false
+    }
+
+    fn render(&mut self, width: u32, height: u32, hidpi_factor: f64) {
+        self.renderer.render(
+            width as f32,
+            height as f32,
+            hidpi_factor as f32,
+            &self.textures,
+        )
+    }
+}
+
+fn window_event_to_conrod_input(
+    event: WindowEvent,
+    size: Vector2<u32>,
+    hidpi: f64,
+) -> Option<Input> {
+    let transform_coords = |x: f64, y: f64| {
+        (
+            (x - size.x as f64 / 2.0) / hidpi,
+            -(y - size.y as f64 / 2.0) / hidpi,
+        )
+    };
+
+    match event {
+        WindowEvent::FramebufferSize(w, h) => {
+            Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi))
+        }
+        WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
+        WindowEvent::CursorPos(x, y, _) => {
+            let (x, y) = transform_coords(x, y);
+            Some(Input::Motion(Motion::MouseCursor { x, y }))
+        }
+        WindowEvent::Scroll(x, y, _) => Some(Input::Motion(Motion::Scroll { x, y: -y })),
+        WindowEvent::MouseButton(button, action, _) => {
+            let button = match button {
+                kiss3d::event::MouseButton::Button1 => MouseButton::Left,
+                kiss3d::event::MouseButton::Button2 => MouseButton::Right,
+                kiss3d::event::MouseButton::Button3 => MouseButton::Middle,
+                kiss3d::event::MouseButton::Button4 => MouseButton::X1,
+                kiss3d::event::MouseButton::Button5 => MouseButton::X2,
+                kiss3d::event::MouseButton::Button6 => MouseButton::Button6,
+                kiss3d::event::MouseButton::Button7 => MouseButton::Button7,
+                kiss3d::event::MouseButton::Button8 => MouseButton::Button8,
+            };
+
+            match action {
+                Action::Press => Some(Input::Press(Button::Mouse(button))),
+                Action::Release => Some(Input::Release(Button::Mouse(button))),
+            }
+        }
+        WindowEvent::Key(key, action, _) => {
+            let key = match key {
+                Key::Key1 => CKey::D1,
+                Key::Key2 => CKey::D2,
+                Key::Key3 => CKey::D3,
+                Key::Key4 => CKey::D4,
+                Key::Key5 => CKey::D5,
+                Key::Key6 => CKey::D6,
+                Key::Key7 => CKey::D7,
+                Key::Key8 => CKey::D8,
+                Key::Key9 => CKey::D9,
+                Key::Key0 => CKey::D0,
+                Key::A => CKey::A,
+                Key::B => CKey::B,
+                Key::C => CKey::C,
+                Key::D => CKey::D,
+                Key::E => CKey::E,
+                Key::F => CKey::F,
+                Key::G => CKey::G,
+                Key::H => CKey::H,
+                Key::I => CKey::I,
+                Key::J => CKey::J,
+                Key::K => CKey::K,
+                Key::L => CKey::L,
+                Key::M => CKey::M,
+                Key::N => CKey::N,
+                Key::O => CKey::O,
+                Key::P => CKey::P,
+                Key::Q => CKey::Q,
+                Key::R => CKey::R,
+                Key::S => CKey::S,
+                Key::T => CKey::T,
+                Key::U => CKey::U,
+                Key::V => CKey::V,
+                Key::W => CKey::W,
+                Key::X => CKey::X,
+                Key::Y => CKey::Y,
+                Key::Z => CKey::Z,
+                Key::Escape => CKey::Escape,
+                Key::F1 => CKey::F1,
+                Key::F2 => CKey::F2,
+                Key::F3 => CKey::F3,
+                Key::F4 => CKey::F4,
+                Key::F5 => CKey::F5,
+                Key::F6 => CKey::F6,
+                Key::F7 => CKey::F7,
+                Key::F8 => CKey::F8,
+                Key::F9 => CKey::F9,
+                Key::F10 => CKey::F10,
+                Key::F11 => CKey::F11,
+                Key::F12 => CKey::F12,
+                Key::F13 => CKey::F13,
+                Key::F14 => CKey::F14,
+                Key::F15 => CKey::F15,
+                Key::F16 => CKey::F16,
+                Key::F17 => CKey::F17,
+                Key::F18 => CKey::F18,
+                Key::F19 => CKey::F19,
+                Key::F20 => CKey::F20,
+                Key::F21 => CKey::F21,
+                Key::F22 => CKey::F22,
+                Key::F23 => CKey::F23,
+                Key::F24 => CKey::F24,
+                Key::Pause => CKey::Pause,
+                Key::Insert => CKey::Insert,
+                Key::Home => CKey::Home,
+                Key::Delete => CKey::Delete,
+                Key::End => CKey::End,
+                Key::PageDown => CKey::PageDown,
+                Key::PageUp => CKey::PageUp,
+                Key::Left => CKey::Left,
+                Key::Up => CKey::Up,
+                Key::Right => CKey::Right,
+                Key::Down => CKey::Down,
+                Key::Return => CKey::Return,
+                Key::Space => CKey::Space,
+                Key::Caret => CKey::Caret,
+                Key::Numpad0 => CKey::NumPad0,
+                Key::Numpad1 => CKey::NumPad1,
+                Key::Numpad2 => CKey::NumPad2,
+                Key::Numpad3 => CKey::NumPad3,
+                Key::Numpad4 => CKey::NumPad4,
+                Key::Numpad5 => CKey::NumPad5,
+                Key::Numpad6 => CKey::NumPad6,
+                Key::Numpad7 => CKey::NumPad7,
+                Key::Numpad8 => CKey::NumPad8,
+                Key::Numpad9 => CKey::NumPad9,
+                Key::Add => CKey::Plus,
+                Key::At => CKey::At,
+                Key::Backslash => CKey::Backslash,
+                Key::Calculator => CKey::Calculator,
+                Key::Colon => CKey::Colon,
+                Key::Comma => CKey::Comma,
+                Key::Equals => CKey::Equals,
+                Key::LBracket => CKey::LeftBracket,
+                Key::LControl => CKey::LCtrl,
+                Key::LShift => CKey::LShift,
+                Key::Mail => CKey::Mail,
+                Key::MediaSelect => CKey::MediaSelect,
+                Key::Minus => CKey::Minus,
+                Key::Mute => CKey::Mute,
+                Key::NumpadComma => CKey::NumPadComma,
+                Key::NumpadEnter => CKey::NumPadEnter,
+                Key::NumpadEquals => CKey::NumPadEquals,
+                Key::Period => CKey::Period,
+                Key::Power => CKey::Power,
+                Key::RAlt => CKey::RAlt,
+                Key::RBracket => CKey::RightBracket,
+                Key::RControl => CKey::RCtrl,
+                Key::RShift => CKey::RShift,
+                Key::Semicolon => CKey::Semicolon,
+                Key::Slash => CKey::Slash,
+                Key::Sleep => CKey::Sleep,
+                Key::Stop => CKey::Stop,
+                Key::Tab => CKey::Tab,
+                Key::VolumeDown => CKey::VolumeDown,
+                Key::VolumeUp => CKey::VolumeUp,
+                Key::Copy => CKey::Copy,
+                Key::Paste => CKey::Paste,
+                Key::Cut => CKey::Cut,
+                _ => CKey::Unknown,
+            };
+
+            match action {
+                Action::Press => Some(Input::Press(Button::Keyboard(key))),
+                Action::Release => Some(Input::Release(Button::Keyboard(key))),
+            }
+        }
+        _ => None,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,11 +149,7 @@ extern crate stdweb;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 #[macro_use]
 extern crate stdweb_derive;
-#[cfg(feature = "conrod")]
-pub extern crate conrod_core as conrod;
 extern crate instant;
-#[cfg(feature = "conrod")]
-pub use conrod::widget_ids;
 
 pub use nalgebra;
 pub use ncollide3d;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,13 +1,9 @@
 //! Structures responsible for rendering elements other than kiss3d's meshes.
 
-#[cfg(feature = "conrod")]
-pub use self::conrod_renderer::ConrodRenderer;
 pub use self::line_renderer::LineRenderer;
 pub use self::point_renderer::PointRenderer;
 pub use self::renderer::Renderer;
 
-#[cfg(feature = "conrod")]
-mod conrod_renderer;
 pub mod line_renderer;
 pub mod point_renderer;
 mod renderer;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -7,7 +7,7 @@ pub use self::gl_canvas::GLCanvas;
 pub use self::state::State;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 pub use self::webgl_canvas::WebGLCanvas;
-pub use self::window::Window;
+pub use self::window::{NullUiContext, UiContext, Window};
 
 mod canvas;
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -2,16 +2,16 @@ use crate::camera::Camera;
 use crate::planar_camera::PlanarCamera;
 use crate::post_processing::PostProcessingEffect;
 use crate::renderer::Renderer;
-use crate::window::Window;
+use crate::window::{NullUiContext, UiContext, Window};
 
 /// Trait implemented by objects describing state of an application.
 ///
 /// It is passed to the window's render loop. Its methods are called at each
 /// render loop to update the application state, and customize the cameras and
 /// post-processing effects to be used by the renderer.
-pub trait State: 'static {
+pub trait State<Ui: UiContext = NullUiContext>: 'static {
     /// Method called at each render loop before a rendering.
-    fn step(&mut self, window: &mut Window);
+    fn step(&mut self, window: &mut Window<Ui>);
 
     /// Unless `cameras_and_effect_and_renderer` is implemented, this method called at each render loop to retrieve
     /// the cameras and post-processing effects to be used for the next render.
@@ -43,6 +43,6 @@ pub trait State: 'static {
     }
 }
 
-impl State for () {
-    fn step(&mut self, _: &mut Window) {}
+impl<Ui: UiContext> State<Ui> for () {
+    fn step(&mut self, _: &mut Window<Ui>) {}
 }

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -16,51 +16,55 @@ use na::{Point2, Point3, Vector2, Vector3};
 use crate::camera::{ArcBall, Camera};
 use crate::context::Context;
 use crate::event::{Action, EventManager, Key, WindowEvent};
-use image::imageops;
-use image::{GenericImage, Pixel};
-use image::{ImageBuffer, Rgb};
 use crate::light::Light;
-use ncollide3d::procedural::TriMesh;
 use crate::planar_camera::{FixedView, PlanarCamera};
 use crate::planar_line_renderer::PlanarLineRenderer;
 use crate::post_processing::PostProcessingEffect;
-#[cfg(feature = "conrod")]
-use crate::renderer::ConrodRenderer;
 use crate::renderer::{LineRenderer, PointRenderer, Renderer};
-use crate::resource::{FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager};
+use crate::resource::{
+    FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager,
+};
 use crate::scene::{PlanarSceneNode, SceneNode};
 use crate::text::{Font, TextRenderer};
 use crate::window::canvas::CanvasSetup;
 use crate::window::{Canvas, State};
-
-#[cfg(feature = "conrod")]
-use std::collections::HashMap;
+use image::imageops;
+use image::{GenericImage, Pixel};
+use image::{ImageBuffer, Rgb};
+use ncollide3d::procedural::TriMesh;
 
 static DEFAULT_WIDTH: u32 = 800u32;
 static DEFAULT_HEIGHT: u32 = 600u32;
 
-#[cfg(feature = "conrod")]
-struct ConrodContext {
-    renderer: ConrodRenderer,
-    textures: conrod::image::Map<(Rc<Texture>, (u32, u32))>,
-    texture_ids: HashMap<String, conrod::image::Id>,
+pub trait UiContext: 'static {
+    type Init;
+    fn new(width: u32, height: u32, init: Self::Init) -> Self;
+    fn handle_event(&mut self, event: &WindowEvent, size: Vector2<u32>, hidpi_factor: f64) -> bool;
+    fn render(&mut self, width: u32, height: u32, hidpi_factor: f64);
 }
 
-#[cfg(feature = "conrod")]
-impl ConrodContext {
-    fn new(width: f64, height: f64) -> Self {
-        Self {
-            renderer: ConrodRenderer::new(width, height),
-            textures: conrod::image::Map::new(),
-            texture_ids: HashMap::new(),
-        }
+pub struct NullUiContext;
+
+impl UiContext for NullUiContext {
+    type Init = ();
+    fn new(_width: u32, _height: u32, _init: Self::Init) -> Self {
+        Self
     }
+    fn handle_event(
+        &mut self,
+        _event: &WindowEvent,
+        _size: Vector2<u32>,
+        _hidpi_factor: f64,
+    ) -> bool {
+        false
+    }
+    fn render(&mut self, _width: u32, _height: u32, _hidpi_factor: f64) {}
 }
 
 /// Structure representing a window and a 3D scene.
 ///
 /// This is the main interface with the 3d engine.
-pub struct Window {
+pub struct Window<Ui: UiContext = NullUiContext> {
     events: Rc<Receiver<WindowEvent>>,
     unhandled_events: Rc<RefCell<Vec<WindowEvent>>>,
     canvas: Canvas,
@@ -80,11 +84,42 @@ pub struct Window {
     planar_camera: Rc<RefCell<FixedView>>,
     camera: Rc<RefCell<ArcBall>>,
     should_close: bool,
-    #[cfg(feature = "conrod")]
-    conrod_context: ConrodContext,
+    ui_context: Ui,
 }
 
-impl Window {
+impl Window<NullUiContext> {
+    /// Opens a window, hide it then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title
+    pub fn new_hidden(title: &str) -> Self {
+        Self::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ())
+    }
+
+    /// Opens a window then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title
+    pub fn new(title: &str) -> Self {
+        Self::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ())
+    }
+
+    /// Opens a window with a custom size then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title.
+    /// * `width` - the window width.
+    /// * `height` - the window height.
+    pub fn new_with_size(title: &str, width: u32, height: u32) -> Self {
+        Self::do_new(title, false, width, height, None, ())
+    }
+
+    pub fn new_with_setup(title: &str, width: u32, height: u32, setup: CanvasSetup) -> Self {
+        Self::do_new(title, false, width, height, Some(setup), ())
+    }
+}
+
+impl<Ui: UiContext> Window<Ui> {
     /// Indicates whether this window should be closed.
     #[inline]
     pub fn should_close(&self) -> bool {
@@ -420,66 +455,30 @@ impl Window {
         self.light_mode = pos;
     }
 
-    /// Retrieve a mutable reference to the UI based on Conrod.
-    #[cfg(feature = "conrod")]
-    pub fn conrod_ui_mut(&mut self) -> &mut conrod::Ui {
-        self.conrod_context.renderer.ui_mut()
+    /// Retrieve a reference to the UI.
+    pub fn ui(&self) -> &Ui {
+        &self.ui_context
     }
 
-    /// Attributes a conrod ID to the given texture and returns it if it exists.
-    #[cfg(feature = "conrod")]
-    pub fn conrod_texture_id(&mut self, name: &str) -> Option<conrod::image::Id> {
-        let tex = TextureManager::get_global_manager(|tm| tm.get_with_size(name))?;
-        let textures = &mut self.conrod_context.textures;
-        Some(
-            *self
-                .conrod_context
-                .texture_ids
-                .entry(name.to_string())
-                .or_insert_with(|| textures.insert(tex)),
-        )
-    }
-
-    /// Retrieve a reference to the UI based on Conrod.
-    #[cfg(feature = "conrod")]
-    pub fn conrod_ui(&self) -> &conrod::Ui {
-        self.conrod_context.renderer.ui()
-    }
-
-    /// Returns `true` if the mouse is currently interacting with a Conrod widget.
-    #[cfg(feature = "conrod")]
-    pub fn is_conrod_ui_capturing_mouse(&self) -> bool {
-        let ui = self.conrod_ui();
-        let state = &ui.global_input().current;
-        let window_id = Some(ui.window);
-
-        state.widget_capturing_mouse.is_some() && state.widget_capturing_mouse != window_id
-    }
-
-    /// Returns `true` if the keyboard is currently interacting with a Conrod widget.
-    #[cfg(feature = "conrod")]
-    pub fn is_conrod_ui_capturing_keyboard(&self) -> bool {
-        let ui = self.conrod_ui();
-        let state = &ui.global_input().current;
-        let window_id = Some(ui.window);
-
-        state.widget_capturing_keyboard.is_some() && state.widget_capturing_keyboard != window_id
+    /// Retrieve a mutable reference to the UI.
+    pub fn ui_mut(&mut self) -> &mut Ui {
+        &mut self.ui_context
     }
 
     /// Opens a window, hide it then calls a user-defined procedure.
     ///
     /// # Arguments
     /// * `title` - the window title
-    pub fn new_hidden(title: &str) -> Window {
-        Window::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None)
+    pub fn new_hidden_with_ui(title: &str, ui_init: Ui::Init) -> Self {
+        Self::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ui_init)
     }
 
     /// Opens a window then calls a user-defined procedure.
     ///
     /// # Arguments
     /// * `title` - the window title
-    pub fn new(title: &str) -> Window {
-        Window::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None)
+    pub fn new_with_ui(title: &str, ui_init: Ui::Init) -> Self {
+        Self::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ui_init)
     }
 
     /// Opens a window with a custom size then calls a user-defined procedure.
@@ -488,12 +487,18 @@ impl Window {
     /// * `title` - the window title.
     /// * `width` - the window width.
     /// * `height` - the window height.
-    pub fn new_with_size(title: &str, width: u32, height: u32) -> Window {
-        Window::do_new(title, false, width, height, None)
+    pub fn new_with_size_and_ui(title: &str, width: u32, height: u32, ui_init: Ui::Init) -> Self {
+        Self::do_new(title, false, width, height, None, ui_init)
     }
 
-    pub fn new_with_setup(title: &str, width: u32, height: u32, setup: CanvasSetup) -> Window {
-        Window::do_new(title, false, width, height, Some(setup))
+    pub fn new_with_setup_and_ui(
+        title: &str,
+        width: u32,
+        height: u32,
+        setup: CanvasSetup,
+        ui_init: Ui::Init,
+    ) -> Self {
+        Self::do_new(title, false, width, height, Some(setup), ui_init)
     }
 
     // FIXME: make this pub?
@@ -503,13 +508,14 @@ impl Window {
         width: u32,
         height: u32,
         setup: Option<CanvasSetup>,
-    ) -> Window {
+        ui_init: Ui::Init,
+    ) -> Self {
         let (event_send, event_receive) = mpsc::channel();
         let canvas = Canvas::open(title, hide, width, height, setup, event_send);
 
         init_gl();
 
-        let mut usr_window = Window {
+        let mut usr_window = Self {
             should_close: false,
             max_dur_per_frame: None,
             canvas: canvas,
@@ -523,8 +529,6 @@ impl Window {
             planar_line_renderer: PlanarLineRenderer::new(),
             point_renderer: PointRenderer::new(),
             text_renderer: TextRenderer::new(),
-            #[cfg(feature = "conrod")]
-            conrod_context: ConrodContext::new(width as f64, height as f64),
             post_process_render_target: FramebufferManager::new_render_target(
                 width as usize,
                 height as usize,
@@ -538,6 +542,7 @@ impl Window {
                 Point3::new(0.0f32, 0.0, -1.0),
                 Point3::origin(),
             ))),
+            ui_context: Ui::new(width, height, ui_init),
         };
 
         if hide {
@@ -665,203 +670,10 @@ impl Window {
             _ => {}
         }
 
-        #[cfg(feature = "conrod")]
-        fn window_event_to_conrod_input(
-            event: WindowEvent,
-            size: Vector2<u32>,
-            hidpi: f64,
-        ) -> Option<conrod::event::Input> {
-            use conrod::event::Input;
-            use conrod::input::{Button, Key as CKey, Motion, MouseButton};
-
-            let transform_coords = |x: f64, y: f64| {
-                (
-                    (x - size.x as f64 / 2.0) / hidpi,
-                    -(y - size.y as f64 / 2.0) / hidpi,
-                )
-            };
-
-            match event {
-                WindowEvent::FramebufferSize(w, h) => {
-                    Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi))
-                }
-                WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
-                WindowEvent::CursorPos(x, y, _) => {
-                    let (x, y) = transform_coords(x, y);
-                    Some(Input::Motion(Motion::MouseCursor { x, y }))
-                }
-                WindowEvent::Scroll(x, y, _) => Some(Input::Motion(Motion::Scroll { x, y: -y })),
-                WindowEvent::MouseButton(button, action, _) => {
-                    let button = match button {
-                        crate::event::MouseButton::Button1 => MouseButton::Left,
-                        crate::event::MouseButton::Button2 => MouseButton::Right,
-                        crate::event::MouseButton::Button3 => MouseButton::Middle,
-                        crate::event::MouseButton::Button4 => MouseButton::X1,
-                        crate::event::MouseButton::Button5 => MouseButton::X2,
-                        crate::event::MouseButton::Button6 => MouseButton::Button6,
-                        crate::event::MouseButton::Button7 => MouseButton::Button7,
-                        crate::event::MouseButton::Button8 => MouseButton::Button8,
-                    };
-
-                    match action {
-                        Action::Press => Some(Input::Press(Button::Mouse(button))),
-                        Action::Release => Some(Input::Release(Button::Mouse(button))),
-                    }
-                }
-                WindowEvent::Key(key, action, _) => {
-                    let key = match key {
-                        Key::Key1 => CKey::D1,
-                        Key::Key2 => CKey::D2,
-                        Key::Key3 => CKey::D3,
-                        Key::Key4 => CKey::D4,
-                        Key::Key5 => CKey::D5,
-                        Key::Key6 => CKey::D6,
-                        Key::Key7 => CKey::D7,
-                        Key::Key8 => CKey::D8,
-                        Key::Key9 => CKey::D9,
-                        Key::Key0 => CKey::D0,
-                        Key::A => CKey::A,
-                        Key::B => CKey::B,
-                        Key::C => CKey::C,
-                        Key::D => CKey::D,
-                        Key::E => CKey::E,
-                        Key::F => CKey::F,
-                        Key::G => CKey::G,
-                        Key::H => CKey::H,
-                        Key::I => CKey::I,
-                        Key::J => CKey::J,
-                        Key::K => CKey::K,
-                        Key::L => CKey::L,
-                        Key::M => CKey::M,
-                        Key::N => CKey::N,
-                        Key::O => CKey::O,
-                        Key::P => CKey::P,
-                        Key::Q => CKey::Q,
-                        Key::R => CKey::R,
-                        Key::S => CKey::S,
-                        Key::T => CKey::T,
-                        Key::U => CKey::U,
-                        Key::V => CKey::V,
-                        Key::W => CKey::W,
-                        Key::X => CKey::X,
-                        Key::Y => CKey::Y,
-                        Key::Z => CKey::Z,
-                        Key::Escape => CKey::Escape,
-                        Key::F1 => CKey::F1,
-                        Key::F2 => CKey::F2,
-                        Key::F3 => CKey::F3,
-                        Key::F4 => CKey::F4,
-                        Key::F5 => CKey::F5,
-                        Key::F6 => CKey::F6,
-                        Key::F7 => CKey::F7,
-                        Key::F8 => CKey::F8,
-                        Key::F9 => CKey::F9,
-                        Key::F10 => CKey::F10,
-                        Key::F11 => CKey::F11,
-                        Key::F12 => CKey::F12,
-                        Key::F13 => CKey::F13,
-                        Key::F14 => CKey::F14,
-                        Key::F15 => CKey::F15,
-                        Key::F16 => CKey::F16,
-                        Key::F17 => CKey::F17,
-                        Key::F18 => CKey::F18,
-                        Key::F19 => CKey::F19,
-                        Key::F20 => CKey::F20,
-                        Key::F21 => CKey::F21,
-                        Key::F22 => CKey::F22,
-                        Key::F23 => CKey::F23,
-                        Key::F24 => CKey::F24,
-                        Key::Pause => CKey::Pause,
-                        Key::Insert => CKey::Insert,
-                        Key::Home => CKey::Home,
-                        Key::Delete => CKey::Delete,
-                        Key::End => CKey::End,
-                        Key::PageDown => CKey::PageDown,
-                        Key::PageUp => CKey::PageUp,
-                        Key::Left => CKey::Left,
-                        Key::Up => CKey::Up,
-                        Key::Right => CKey::Right,
-                        Key::Down => CKey::Down,
-                        Key::Return => CKey::Return,
-                        Key::Space => CKey::Space,
-                        Key::Caret => CKey::Caret,
-                        Key::Numpad0 => CKey::NumPad0,
-                        Key::Numpad1 => CKey::NumPad1,
-                        Key::Numpad2 => CKey::NumPad2,
-                        Key::Numpad3 => CKey::NumPad3,
-                        Key::Numpad4 => CKey::NumPad4,
-                        Key::Numpad5 => CKey::NumPad5,
-                        Key::Numpad6 => CKey::NumPad6,
-                        Key::Numpad7 => CKey::NumPad7,
-                        Key::Numpad8 => CKey::NumPad8,
-                        Key::Numpad9 => CKey::NumPad9,
-                        Key::Add => CKey::Plus,
-                        Key::At => CKey::At,
-                        Key::Backslash => CKey::Backslash,
-                        Key::Calculator => CKey::Calculator,
-                        Key::Colon => CKey::Colon,
-                        Key::Comma => CKey::Comma,
-                        Key::Equals => CKey::Equals,
-                        Key::LBracket => CKey::LeftBracket,
-                        Key::LControl => CKey::LCtrl,
-                        Key::LShift => CKey::LShift,
-                        Key::Mail => CKey::Mail,
-                        Key::MediaSelect => CKey::MediaSelect,
-                        Key::Minus => CKey::Minus,
-                        Key::Mute => CKey::Mute,
-                        Key::NumpadComma => CKey::NumPadComma,
-                        Key::NumpadEnter => CKey::NumPadEnter,
-                        Key::NumpadEquals => CKey::NumPadEquals,
-                        Key::Period => CKey::Period,
-                        Key::Power => CKey::Power,
-                        Key::RAlt => CKey::RAlt,
-                        Key::RBracket => CKey::RightBracket,
-                        Key::RControl => CKey::RCtrl,
-                        Key::RShift => CKey::RShift,
-                        Key::Semicolon => CKey::Semicolon,
-                        Key::Slash => CKey::Slash,
-                        Key::Sleep => CKey::Sleep,
-                        Key::Stop => CKey::Stop,
-                        Key::Tab => CKey::Tab,
-                        Key::VolumeDown => CKey::VolumeDown,
-                        Key::VolumeUp => CKey::VolumeUp,
-                        Key::Copy => CKey::Copy,
-                        Key::Paste => CKey::Paste,
-                        Key::Cut => CKey::Cut,
-                        _ => CKey::Unknown,
-                    };
-
-                    match action {
-                        Action::Press => Some(Input::Press(Button::Keyboard(key))),
-                        Action::Release => Some(Input::Release(Button::Keyboard(key))),
-                    }
-                }
-                _ => None,
-            }
-        }
-
-        #[cfg(feature = "conrod")]
         {
             let (size, hidpi) = (self.size(), self.hidpi_factor());
-            let conrod_ui = self.conrod_ui_mut();
-            if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
-                conrod_ui.handle_event(input);
-            }
-
-            let state = &conrod_ui.global_input().current;
-            let window_id = Some(conrod_ui.window);
-
-            if event.is_keyboard_event()
-                && state.widget_capturing_keyboard.is_some()
-                && state.widget_capturing_keyboard != window_id
-            {
-                return;
-            }
-
-            if event.is_mouse_event()
-                && state.widget_capturing_mouse.is_some()
-                && state.widget_capturing_mouse != window_id
-            {
+            let is_handled = self.ui_context.handle_event(event, size, hidpi);
+            if is_handled {
                 return;
             }
         }
@@ -878,17 +690,17 @@ impl Window {
     }
 
     /// Runs the render and event loop until the window is closed.
-    pub fn render_loop<S: State>(mut self, mut state: S) {
+    pub fn render_loop<S: State<Ui>>(mut self, mut state: S) {
         Canvas::render_loop(move |_| self.do_render_with_state(&mut state))
     }
 
     /// Render one frame using the specified state.
     #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
-    pub fn render_with_state<S: State>(&mut self, state: &mut S) -> bool {
+    pub fn render_with_state<S: State<Ui>>(&mut self, state: &mut S) -> bool {
         self.do_render_with_state(state)
     }
 
-    fn do_render_with_state<S: State>(&mut self, state: &mut S) -> bool {
+    fn do_render_with_state<S: State<Ui>>(&mut self, state: &mut S) -> bool {
         {
             let (camera, planar_camera, renderer, effect) = state.cameras_and_effect_and_renderer();
             self.should_close = !self.do_render_with(camera, planar_camera, renderer, effect);
@@ -1074,13 +886,7 @@ impl Window {
         }
 
         self.text_renderer.render(w as f32, h as f32);
-        #[cfg(feature = "conrod")]
-        self.conrod_context.renderer.render(
-            w as f32,
-            h as f32,
-            self.canvas.hidpi_factor() as f32,
-            &self.conrod_context.textures,
-        );
+        self.ui_context.render(w, h, self.canvas.hidpi_factor());
 
         // We are done: swap buffers
         self.canvas.swap_buffers();


### PR DESCRIPTION
I tried adding hooks for GUI support and splitting the Conrod UI integration code into a separate crate. The idea is that it might allow integration with other UI libraries to be written and that they can be conveniently plugged in. Here is a proof-of-concept.

- I added a trait `window::UiContext` which replaces the existing `ConrodContext` struct inside `kiss3d`.
- The actual Conrod code (including the `ConrodContext` struct and `conrod_renderer`) are moved to a separate crate `kiss3d_conrod`
    - This has the same name as the previously-vendored `conrod_core` crate. I figured that since it is no longer needed, perhaps the name can be reused?
- In the [non-generic version](https://github.com/alvinhochun/kiss3d/compare/master...alvinhochun:split-ui-crate-non-generic) the UI as a field in `Window` has the type `Option<Rc<RefCell<dyn UiContext>>>`. ~~I have tried to make it the `UiContext` a generic parameter of `Window` (with a dummy context as default), but the generic parameter would leak into `window::State`~~ [This](https://github.com/alvinhochun/kiss3d/compare/master...alvinhochun:split-ui-crate-generic-2) is what it would look like if a generic parameter is used and I am not sure if it is really a good idea. What is your opinion @sebcrozet?

Run `cargo run -p kiss3d_conrod --example ui` to run the example.

(I might want to try implementing a UI integration with [`iced`](https://github.com/hecrj/iced) using this as a basis.)