### PR TITLE
Attempt to integrate iced_native UI for use with Kiss3d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ include = [
 name = "kiss3d"
 path = "src/lib.rs"
 
-[features]
-conrod = [ "conrod_core" ]
-
 
 [dependencies]
 either       = "1"
@@ -44,7 +41,6 @@ serde        = "1"
 serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "stdweb" ]}
-conrod_core = { version = "0.69", features = [ "stdweb" ], optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
 gl = "0.14"
@@ -67,3 +63,8 @@ stdweb-derive = "0.5"
 [dev-dependencies]
 rand = "0.7"
 ncollide2d = "0.23"
+
+[workspace]
+members = [
+    "gui/conrod",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde        = "1"
 serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "stdweb" ]}
+glow = "0.4"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))'.dependencies]
 gl = "0.14"
@@ -67,4 +68,5 @@ ncollide2d = "0.23"
 [workspace]
 members = [
     "gui/conrod",
+    "gui/iced",
 ]

--- a/gui/conrod/Cargo.toml
+++ b/gui/conrod/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "kiss3d_conrod"
+version = "0.69.0"
+authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+edition = "2018"
+
+license = "BSD-3-Clause"
+
+[dependencies]
+conrod_core = { version = "0.69", features = [ "stdweb" ] }
+kiss3d = { version = "0.24", path = "../.." }
+nalgebra = "0.21"
+rusttype = { version = "0.8", features = [ "gpu_cache" ] }
+
+[dev-dependencies]
+rand = "0.7"

--- a/gui/conrod/examples/ui.rs
+++ b/gui/conrod/examples/ui.rs
@@ -1,0 +1,374 @@
+use kiss3d::light::Light;
+use kiss3d::window::Window;
+use kiss3d_conrod::conrod;
+use kiss3d_conrod::conrod::widget_ids;
+use std::path::Path;
+
+fn main() {
+    let mut window: Window<kiss3d_conrod::ConrodContext> = Window::new_with_ui("Kiss3d: UI", ());
+    window.set_background_color(1.0, 1.0, 1.0);
+    let mut c = window.add_cube(0.1, 0.1, 0.1);
+    c.set_color(1.0, 0.0, 0.0);
+
+    window.set_light(Light::StickToCamera);
+
+    // Generate the widget identifiers.
+    let ids = Ids::new(window.ui_mut().conrod_ui_mut().widget_id_generator());
+    window.ui_mut().conrod_ui_mut().theme = theme();
+    window.add_texture(&Path::new("./examples/media/kitten.png"), "cat");
+    let cat_texture = window.ui_mut().conrod_texture_id("cat").unwrap();
+
+    let mut app = DemoApp::new(cat_texture);
+
+    // Render loop.
+    while window.render() {
+        let mut ui = window.ui_mut().conrod_ui_mut().set_widgets();
+        gui(&mut ui, &ids, &mut app)
+    }
+}
+
+/*
+ *
+ * This is he example taken from conrods' repository.
+ *
+ */
+/// A set of reasonable stylistic defaults that works for the `gui` below.
+pub fn theme() -> conrod::Theme {
+    use conrod::position::{Align, Direction, Padding, Position, Relative};
+    conrod::Theme {
+        name: "Demo Theme".to_string(),
+        padding: Padding::none(),
+        x_position: Position::Relative(Relative::Align(Align::Start), None),
+        y_position: Position::Relative(Relative::Direction(Direction::Backwards, 20.0), None),
+        background_color: conrod::color::DARK_CHARCOAL,
+        shape_color: conrod::color::LIGHT_CHARCOAL,
+        border_color: conrod::color::BLACK,
+        border_width: 0.0,
+        label_color: conrod::color::WHITE,
+        font_id: None,
+        font_size_large: 26,
+        font_size_medium: 18,
+        font_size_small: 12,
+        widget_styling: conrod::theme::StyleMap::default(),
+        mouse_drag_threshold: 0.0,
+        double_click_threshold: std::time::Duration::from_millis(500),
+    }
+}
+
+// Generate a unique `WidgetId` for each widget.
+widget_ids! {
+    pub struct Ids {
+        // The scrollable canvas.
+        canvas,
+        // The title and introduction widgets.
+        title,
+        introduction,
+        // Shapes.
+        shapes_canvas,
+        rounded_rectangle,
+        shapes_left_col,
+        shapes_right_col,
+        shapes_title,
+        line,
+        point_path,
+        rectangle_fill,
+        rectangle_outline,
+        trapezoid,
+        oval_fill,
+        oval_outline,
+        circle,
+        // Image.
+        image_title,
+        cat,
+        // Button, XyPad, Toggle.
+        button_title,
+        button,
+        xy_pad,
+        toggle,
+        ball,
+        // NumberDialer, PlotPath
+        dialer_title,
+        number_dialer,
+        plot_path,
+        // Scrollbar
+        canvas_scrollbar,
+    }
+}
+
+pub const WIN_W: u32 = 600;
+pub const WIN_H: u32 = 420;
+
+/// A demonstration of some application state we want to control with a conrod GUI.
+pub struct DemoApp {
+    ball_xy: conrod::Point,
+    ball_color: conrod::Color,
+    sine_frequency: f32,
+    cat: conrod::image::Id,
+}
+
+impl DemoApp {
+    /// Simple constructor for the `DemoApp`.
+    pub fn new(cat: conrod::image::Id) -> Self {
+        DemoApp {
+            ball_xy: [0.0, 0.0],
+            ball_color: conrod::color::WHITE,
+            sine_frequency: 1.0,
+            cat,
+        }
+    }
+}
+
+/// Instantiate a GUI demonstrating every widget available in conrod.
+pub fn gui(ui: &mut conrod::UiCell, ids: &Ids, app: &mut DemoApp) {
+    use conrod::{widget, Colorable, Labelable, Positionable, Sizeable, Widget};
+    use std::iter::once;
+
+    const MARGIN: conrod::Scalar = 30.0;
+    const SHAPE_GAP: conrod::Scalar = 50.0;
+    const TITLE_SIZE: conrod::FontSize = 42;
+    const SUBTITLE_SIZE: conrod::FontSize = 32;
+
+    // `Canvas` is a widget that provides some basic functionality for laying out children widgets.
+    // By default, its size is the size of the window. We'll use this as a background for the
+    // following widgets, as well as a scrollable container for the children widgets.
+    const TITLE: &'static str = "All Widgets";
+    widget::Canvas::new()
+        .pad(MARGIN)
+        .align_bottom()
+        .h(300.0)
+        .scroll_kids_vertically()
+        .set(ids.canvas, ui);
+
+    ////////////////
+    ///// TEXT /////
+    ////////////////
+
+    // We'll demonstrate the `Text` primitive widget by using it to draw a title and an
+    // introduction to the example.
+    widget::Text::new(TITLE)
+        .font_size(TITLE_SIZE)
+        .mid_top_of(ids.canvas)
+        .set(ids.title, ui);
+    const INTRODUCTION: &'static str =
+        "This example aims to demonstrate some widgets that are provided by conrod.\
+        \n\nScroll down to see more widgets!";
+    widget::Text::new(INTRODUCTION)
+        .padded_w_of(ids.canvas, MARGIN)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .center_justify()
+        .line_spacing(5.0)
+        .set(ids.introduction, ui);
+
+    //return;
+    ////////////////////////////
+    ///// Lines and Shapes /////
+    ////////////////////////////
+
+    widget::Text::new("Lines and Shapes")
+        .down(70.0)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.shapes_title, ui);
+
+    // Lay out the shapes in two horizontal columns.
+    //
+    // TODO: Have conrod provide an auto-flowing, fluid-list widget that is more adaptive for these
+    // sorts of situations.
+    widget::Canvas::new()
+        .down(0.0)
+        .align_middle_x_of(ids.canvas)
+        .kid_area_w_of(ids.canvas)
+        .h(360.0)
+        .color(conrod::color::TRANSPARENT)
+        .pad(MARGIN)
+        .flow_down(&[
+            (ids.shapes_left_col, widget::Canvas::new()),
+            (ids.shapes_right_col, widget::Canvas::new()),
+        ])
+        .set(ids.shapes_canvas, ui);
+
+    let shapes_canvas_rect = ui.rect_of(ids.shapes_canvas).unwrap();
+    let w = shapes_canvas_rect.w();
+    let h = shapes_canvas_rect.h() * 5.0 / 6.0;
+    let radius = 10.0;
+    widget::RoundedRectangle::fill([w, h], radius)
+        .color(conrod::color::CHARCOAL.alpha(0.25))
+        .middle_of(ids.shapes_canvas)
+        .set(ids.rounded_rectangle, ui);
+
+    let start = [-40.0, -40.0];
+    let end = [40.0, 40.0];
+    widget::Line::centred(start, end)
+        .mid_left_of(ids.shapes_left_col)
+        .set(ids.line, ui);
+
+    let left = [-40.0, -40.0];
+    let top = [0.0, 40.0];
+    let right = [40.0, -40.0];
+    let points = once(left).chain(once(top)).chain(once(right));
+    widget::PointPath::centred(points)
+        .right(SHAPE_GAP)
+        .set(ids.point_path, ui);
+
+    widget::Rectangle::fill([80.0, 80.0])
+        .right(SHAPE_GAP)
+        .set(ids.rectangle_fill, ui);
+
+    widget::Rectangle::outline([80.0, 80.0])
+        .right(SHAPE_GAP)
+        .set(ids.rectangle_outline, ui);
+
+    let bl = [-40.0, -40.0];
+    let tl = [-20.0, 40.0];
+    let tr = [20.0, 40.0];
+    let br = [40.0, -40.0];
+    let points = once(bl).chain(once(tl)).chain(once(tr)).chain(once(br));
+    widget::Polygon::centred_fill(points)
+        .mid_left_of(ids.shapes_right_col)
+        .set(ids.trapezoid, ui);
+
+    widget::Oval::fill([40.0, 80.0])
+        .right(SHAPE_GAP + 20.0)
+        .align_middle_y()
+        .set(ids.oval_fill, ui);
+
+    widget::Oval::outline([80.0, 40.0])
+        .right(SHAPE_GAP + 20.0)
+        .align_middle_y()
+        .set(ids.oval_outline, ui);
+
+    widget::Circle::fill(40.0)
+        .right(SHAPE_GAP)
+        .align_middle_y()
+        .set(ids.circle, ui);
+
+    /////////////////
+    ///// Image /////
+    /////////////////
+
+    widget::Text::new("Image")
+        .down_from(ids.shapes_canvas, MARGIN)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.image_title, ui);
+
+    const LOGO_SIDE: conrod::Scalar = 144.0;
+    widget::Image::new(app.cat)
+        .w_h(LOGO_SIDE, LOGO_SIDE)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .set(ids.cat, ui);
+
+    /////////////////////////////////
+    ///// Button, XYPad, Toggle /////
+    /////////////////////////////////
+
+    widget::Text::new("Button, XYPad and Toggle")
+        .down_from(ids.cat, 60.0)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.button_title, ui);
+
+    let ball_x_range = ui.kid_area_of(ids.canvas).unwrap().w();
+    let ball_y_range = ui.h_of(ui.window).unwrap() * 0.5;
+    let min_x = -ball_x_range / 3.0;
+    let max_x = ball_x_range / 3.0;
+    let min_y = -ball_y_range / 3.0;
+    let max_y = ball_y_range / 3.0;
+    let side = 130.0;
+
+    for _press in widget::Button::new()
+        .label("PRESS ME")
+        .mid_left_with_margin_on(ids.canvas, MARGIN)
+        .down_from(ids.button_title, 60.0)
+        .w_h(side, side)
+        .set(ids.button, ui)
+    {
+        let x = rand::random::<conrod::Scalar>() * (max_x - min_x) - max_x;
+        let y = rand::random::<conrod::Scalar>() * (max_y - min_y) - max_y;
+        app.ball_xy = [x, y];
+    }
+
+    for (x, y) in widget::XYPad::new(app.ball_xy[0], min_x, max_x, app.ball_xy[1], min_y, max_y)
+        .label("BALL XY")
+        .wh_of(ids.button)
+        .align_middle_y_of(ids.button)
+        .align_middle_x_of(ids.canvas)
+        .parent(ids.canvas)
+        .set(ids.xy_pad, ui)
+    {
+        app.ball_xy = [x, y];
+    }
+
+    let is_white = app.ball_color == conrod::color::WHITE;
+    let label = if is_white { "WHITE" } else { "BLACK" };
+    for is_white in widget::Toggle::new(is_white)
+        .label(label)
+        .label_color(if is_white {
+            conrod::color::WHITE
+        } else {
+            conrod::color::LIGHT_CHARCOAL
+        })
+        .mid_right_with_margin_on(ids.canvas, MARGIN)
+        .align_middle_y_of(ids.button)
+        .set(ids.toggle, ui)
+    {
+        app.ball_color = if is_white {
+            conrod::color::WHITE
+        } else {
+            conrod::color::BLACK
+        };
+    }
+
+    let ball_x = app.ball_xy[0];
+    let ball_y = app.ball_xy[1] - max_y - side * 0.5 - MARGIN;
+    widget::Circle::fill(20.0)
+        .color(app.ball_color)
+        .x_y_relative_to(ids.xy_pad, ball_x, ball_y)
+        .set(ids.ball, ui);
+
+    //////////////////////////////////
+    ///// NumberDialer, PlotPath /////
+    //////////////////////////////////
+
+    widget::Text::new("NumberDialer and PlotPath")
+        .down_from(ids.xy_pad, max_y - min_y + side * 0.5 + MARGIN)
+        .align_middle_x_of(ids.canvas)
+        .font_size(SUBTITLE_SIZE)
+        .set(ids.dialer_title, ui);
+
+    // Use a `NumberDialer` widget to adjust the frequency of the sine wave below.
+    let min = 0.5;
+    let max = 200.0;
+    let decimal_precision = 1;
+    for new_freq in widget::NumberDialer::new(app.sine_frequency, min, max, decimal_precision)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .w_h(160.0, 40.0)
+        .label("F R E Q")
+        .set(ids.number_dialer, ui)
+    {
+        app.sine_frequency = new_freq;
+    }
+
+    // Use the `PlotPath` widget to display a sine wave.
+    let min_x = 0.0;
+    let max_x = std::f32::consts::PI * 2.0 * app.sine_frequency;
+    let min_y = -1.0;
+    let max_y = 1.0;
+    widget::PlotPath::new(min_x, max_x, min_y, max_y, f32::sin)
+        .kid_area_w_of(ids.canvas)
+        .h(240.0)
+        .down(60.0)
+        .align_middle_x_of(ids.canvas)
+        .set(ids.plot_path, ui);
+
+    /////////////////////
+    ///// Scrollbar /////
+    /////////////////////
+
+    widget::Scrollbar::y_axis(ids.canvas)
+        .auto_hide(true)
+        .set(ids.canvas_scrollbar, ui);
+}

--- a/gui/conrod/src/conrod_renderer.rs
+++ b/gui/conrod/src/conrod_renderer.rs
@@ -1,0 +1,695 @@
+//! A renderer for Conrod primitives.
+
+use conrod::position::Rect;
+use conrod::text::GlyphCache;
+use conrod::{render::PrimitiveKind, Ui};
+use conrod_core as conrod;
+use kiss3d::context::{Context, Texture};
+use kiss3d::resource::{
+    AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform,
+};
+use kiss3d::text::Font;
+use nalgebra::{Point2, Point3, Point4, Vector2};
+use rusttype::gpu_cache::Cache;
+use std::rc::Rc;
+
+macro_rules! verify(
+    ($e: expr) => {
+        {
+            let res = $e;
+            #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+            { assert_eq!(kiss3d::context::Context::get().get_error(), 0); }
+            res
+        }
+    }
+);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum RenderMode {
+    Image {
+        color: Point4<f32>,
+        texture: conrod::image::Id,
+    },
+    Shape,
+    Text {
+        color: Point4<f32>,
+    },
+    Unknown,
+}
+
+/// Structure which manages the display of short-living points.
+pub struct ConrodRenderer {
+    ui: Ui,
+    triangle_shader: Effect,
+    triangle_window_size: ShaderUniform<Vector2<f32>>,
+    triangle_pos: ShaderAttribute<Point2<f32>>,
+    triangle_color: ShaderAttribute<Point4<f32>>,
+    text_shader: Effect,
+    text_window_size: ShaderUniform<Vector2<f32>>,
+    text_color: ShaderUniform<Point4<f32>>,
+    text_pos: ShaderAttribute<Point2<f32>>,
+    text_uvs: ShaderAttribute<Point2<f32>>,
+    text_texture: ShaderUniform<i32>,
+    image_shader: Effect,
+    image_window_size: ShaderUniform<Vector2<f32>>,
+    image_color: ShaderUniform<Point4<f32>>,
+    image_pos: ShaderAttribute<Point2<f32>>,
+    image_uvs: ShaderAttribute<Point2<f32>>,
+    image_texture: ShaderUniform<i32>,
+    points: GPUVec<f32>,
+    indices: GPUVec<Point3<u16>>,
+    cache: GlyphCache<'static>,
+    texture: Texture,
+    resized_once: bool,
+}
+
+impl ConrodRenderer {
+    /// Creates a new points manager.
+    pub fn new(width: f64, height: f64) -> ConrodRenderer {
+        //
+        // Create shaders.
+        //
+        let triangle_shader = Effect::new_from_str(TRIANGLES_VERTEX_SRC, TRIANGLES_FRAGMENT_SRC);
+        let text_shader = Effect::new_from_str(TEXT_VERTEX_SRC, TEXT_FRAGMENT_SRC);
+        let image_shader = Effect::new_from_str(IMAGE_VERTEX_SRC, IMAGE_FRAGMENT_SRC);
+
+        //
+        // Initialize UI with the default font.
+        //
+        let mut ui = conrod::UiBuilder::new([width, height]).build();
+        let _ = ui.fonts.insert(Font::default().font().clone());
+
+        //
+        // Create cache or text.
+        //
+        let atlas_width = 1024;
+        let atlas_height = 1024;
+        let cache = Cache::builder()
+            .dimensions(atlas_width, atlas_height)
+            .build();
+
+        //
+        // Create texture for text
+        //
+        let ctxt = Context::get();
+
+        /* We're using 1 byte alignment buffering. */
+        verify!(ctxt.pixel_storei(Context::UNPACK_ALIGNMENT, 1));
+
+        let texture = verify!(ctxt
+            .create_texture()
+            .expect("Font texture creation failed."));
+        verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture)));
+        verify!(ctxt.tex_image2d(
+            Context::TEXTURE_2D,
+            0,
+            Context::RED as i32,
+            atlas_width as i32,
+            atlas_height as i32,
+            0,
+            Context::RED,
+            None
+        ));
+
+        /* Clamp to the edge to avoid artifacts when scaling. */
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_WRAP_S,
+            Context::CLAMP_TO_EDGE as i32
+        ));
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_WRAP_T,
+            Context::CLAMP_TO_EDGE as i32
+        ));
+
+        /* Linear filtering usually looks best for text. */
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_MIN_FILTER,
+            Context::LINEAR as i32
+        ));
+        verify!(ctxt.tex_parameteri(
+            Context::TEXTURE_2D,
+            Context::TEXTURE_MAG_FILTER,
+            Context::LINEAR as i32
+        ));
+
+        ConrodRenderer {
+            ui,
+            points: GPUVec::new(Vec::new(), BufferType::Array, AllocationType::StreamDraw),
+            indices: GPUVec::new(
+                Vec::new(),
+                BufferType::ElementArray,
+                AllocationType::StreamDraw,
+            ),
+            triangle_window_size: triangle_shader.get_uniform("window_size").unwrap(),
+            triangle_pos: triangle_shader.get_attrib("position").unwrap(),
+            triangle_color: triangle_shader.get_attrib("color").unwrap(),
+            triangle_shader,
+            text_window_size: text_shader
+                .get_uniform::<Vector2<f32>>("window_size")
+                .unwrap(),
+            text_color: text_shader.get_uniform::<Point4<f32>>("color").unwrap(),
+            text_pos: text_shader.get_attrib("pos").unwrap(),
+            text_uvs: text_shader.get_attrib("uvs").unwrap(),
+            text_texture: text_shader.get_uniform("tex0").unwrap(),
+            text_shader,
+            image_window_size: image_shader
+                .get_uniform::<Vector2<f32>>("window_size")
+                .unwrap(),
+            image_color: image_shader.get_uniform::<Point4<f32>>("color").unwrap(),
+            image_pos: image_shader.get_attrib("pos").unwrap(),
+            image_uvs: image_shader.get_attrib("uvs").unwrap(),
+            image_texture: image_shader.get_uniform("tex0").unwrap(),
+            image_shader,
+            cache,
+            texture,
+            resized_once: false,
+        }
+    }
+
+    /// The mutable UI to be displayed.
+    pub fn ui_mut(&mut self) -> &mut Ui {
+        &mut self.ui
+    }
+
+    /// The UI to be displayed.
+    pub fn ui(&self) -> &Ui {
+        &self.ui
+    }
+
+    /// Actually draws the points.
+    pub fn render(
+        &mut self,
+        width: f32,
+        height: f32,
+        hidpi_factor: f32,
+        texture_map: &conrod::image::Map<(Rc<Texture>, (u32, u32))>,
+    ) {
+        // NOTE: this seems necessary for WASM.
+        if !self.resized_once {
+            self.ui.handle_event(conrod::event::Input::Resize(
+                width as f64 / hidpi_factor as f64,
+                height as f64 / hidpi_factor as f64,
+            ));
+            self.resized_once = true;
+        }
+
+        let mut primitives = self.ui.draw();
+        let ctxt = Context::get();
+        let mut mode = RenderMode::Unknown;
+        let mut curr_scizzor = Rect::from_corners([0.0, 0.0], [0.0, 0.0]);
+
+        let mut vid = 0;
+
+        verify!(ctxt.disable(Context::CULL_FACE));
+        let _ = verify!(ctxt.polygon_mode(Context::FRONT_AND_BACK, Context::FILL));
+        verify!(ctxt.enable(Context::BLEND));
+        verify!(ctxt.blend_func_separate(
+            Context::SRC_ALPHA,
+            Context::ONE_MINUS_SRC_ALPHA,
+            Context::ONE,
+            Context::ONE_MINUS_SRC_ALPHA,
+        ));
+        verify!(ctxt.disable(Context::DEPTH_TEST));
+        verify!(ctxt.enable(Context::SCISSOR_TEST));
+
+        let rect_to_gl_rect = |rect: Rect| {
+            let (w, h) = rect.w_h();
+            let l = rect.left() as f32 * hidpi_factor + width / 2.0;
+            let b = rect.bottom() as f32 * hidpi_factor + height / 2.0;
+            let w = w as f32 * hidpi_factor;
+            let h = h as f32 * hidpi_factor;
+
+            (l.max(0.0), b.max(0.0), w.min(width), h.min(height))
+        };
+
+        loop {
+            let primitive = primitives.next();
+
+            let render = if let Some(ref primitive) = primitive {
+                curr_scizzor != primitive.scizzor
+                    || match primitive.kind {
+                        PrimitiveKind::TrianglesSingleColor { .. } => mode != RenderMode::Shape,
+                        PrimitiveKind::TrianglesMultiColor { .. } => mode != RenderMode::Shape,
+                        PrimitiveKind::Rectangle { .. } => mode != RenderMode::Shape,
+                        PrimitiveKind::Image {
+                            color, image_id, ..
+                        } => {
+                            let rgba = color.unwrap_or(conrod::color::WHITE).to_rgb();
+                            mode != RenderMode::Image {
+                                color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3),
+                                texture: image_id,
+                            }
+                        }
+                        PrimitiveKind::Text { color, .. } => {
+                            let rgba = color.to_rgb();
+                            mode != RenderMode::Text {
+                                color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3),
+                            }
+                        }
+                        PrimitiveKind::Other(_) => false,
+                    }
+            } else {
+                true
+            };
+
+            if render {
+                let (x, y, w, h) = rect_to_gl_rect(curr_scizzor);
+                ctxt.scissor(x as i32, y as i32, w as i32, h as i32);
+                match mode {
+                    RenderMode::Shape => {
+                        self.triangle_shader.use_program();
+                        self.triangle_pos.enable();
+                        self.triangle_color.enable();
+
+                        self.triangle_window_size
+                            .upload(&Vector2::new(width, height));
+                        unsafe {
+                            self.triangle_color
+                                .bind_sub_buffer_generic(&mut self.points, 5, 2)
+                        };
+                        unsafe {
+                            self.triangle_pos
+                                .bind_sub_buffer_generic(&mut self.points, 5, 0)
+                        };
+                        self.indices.bind();
+
+                        verify!(ctxt.draw_elements(
+                            Context::TRIANGLES,
+                            self.indices.len() as i32 * 3,
+                            Context::UNSIGNED_SHORT,
+                            0
+                        ));
+
+                        self.triangle_pos.disable();
+                        self.triangle_color.disable();
+                    }
+                    RenderMode::Text { color } => {
+                        self.text_shader.use_program();
+                        self.text_pos.enable();
+                        self.text_uvs.enable();
+                        self.text_texture.upload(&0);
+                        self.text_color.upload(&color);
+                        self.text_window_size.upload(&Vector2::new(width, height));
+                        verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
+                        unsafe {
+                            self.text_pos
+                                .bind_sub_buffer_generic(&mut self.points, 3, 0)
+                        };
+                        unsafe {
+                            self.text_uvs
+                                .bind_sub_buffer_generic(&mut self.points, 3, 2)
+                        };
+
+                        verify!(ctxt.draw_arrays(
+                            Context::TRIANGLES,
+                            0,
+                            (self.points.len() / 4) as i32
+                        ));
+
+                        self.text_pos.disable();
+                        self.text_uvs.disable();
+                    }
+                    RenderMode::Image { color, texture } => {
+                        if let Some(texture) = texture_map.get(&texture) {
+                            self.image_shader.use_program();
+                            self.image_pos.enable();
+                            self.image_uvs.enable();
+
+                            self.image_texture.upload(&0);
+                            self.image_color.upload(&color);
+                            self.image_window_size.upload(&Vector2::new(width, height));
+                            verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&texture.0)));
+                            unsafe {
+                                self.image_pos
+                                    .bind_sub_buffer_generic(&mut self.points, 3, 0)
+                            };
+                            unsafe {
+                                self.image_uvs
+                                    .bind_sub_buffer_generic(&mut self.points, 3, 2)
+                            };
+
+                            verify!(ctxt.draw_arrays(
+                                Context::TRIANGLES,
+                                0,
+                                (self.points.len() / 4) as i32
+                            ));
+
+                            self.image_pos.disable();
+                            self.image_uvs.disable();
+                        }
+                    }
+                    RenderMode::Unknown => {}
+                }
+
+                vid = 0;
+                mode = RenderMode::Unknown;
+                self.points.data_mut().as_mut().unwrap().clear();
+                self.indices.data_mut().as_mut().unwrap().clear();
+            }
+
+            if primitive.is_none() {
+                break;
+            }
+
+            let primitive = primitive.unwrap();
+            let vertices = self.points.data_mut().as_mut().unwrap();
+            let indices = self.indices.data_mut().as_mut().unwrap();
+            curr_scizzor = primitive.scizzor;
+
+            match primitive.kind {
+                PrimitiveKind::Rectangle { color } => {
+                    mode = RenderMode::Shape;
+
+                    let color = color.to_rgb();
+                    let tl = (primitive.rect.x.start, primitive.rect.y.end);
+                    let bl = (primitive.rect.x.start, primitive.rect.y.start);
+                    let br = (primitive.rect.x.end, primitive.rect.y.start);
+                    let tr = (primitive.rect.x.end, primitive.rect.y.end);
+
+                    vertices.extend_from_slice(&[
+                        tl.0 as f32 * hidpi_factor,
+                        tl.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                        bl.0 as f32 * hidpi_factor,
+                        bl.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                        br.0 as f32 * hidpi_factor,
+                        br.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                        tr.0 as f32 * hidpi_factor,
+                        tr.1 as f32 * hidpi_factor,
+                        color.0,
+                        color.1,
+                        color.2,
+                        color.3,
+                    ]);
+
+                    indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+                    indices.push(Point3::new(vid + 2, vid + 3, vid + 0));
+
+                    vid += 4;
+                }
+                PrimitiveKind::TrianglesSingleColor { color, triangles } => {
+                    mode = RenderMode::Shape;
+
+                    for triangle in triangles {
+                        let pts = triangle.points();
+
+                        vertices.extend_from_slice(&[
+                            pts[0][0] as f32 * hidpi_factor,
+                            pts[0][1] as f32 * hidpi_factor,
+                            color.0,
+                            color.1,
+                            color.2,
+                            color.3,
+                            pts[1][0] as f32 * hidpi_factor,
+                            pts[1][1] as f32 * hidpi_factor,
+                            color.0,
+                            color.1,
+                            color.2,
+                            color.3,
+                            pts[2][0] as f32 * hidpi_factor,
+                            pts[2][1] as f32 * hidpi_factor,
+                            color.0,
+                            color.1,
+                            color.2,
+                            color.3,
+                        ]);
+                        indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+
+                        vid += 3;
+                    }
+                }
+                PrimitiveKind::TrianglesMultiColor { triangles } => {
+                    mode = RenderMode::Shape;
+
+                    for triangle in triangles {
+                        let ((a, ca), (b, cb), (c, cc)) =
+                            (triangle.0[0], triangle.0[1], triangle.0[2]);
+                        vertices.extend_from_slice(&[
+                            a[0] as f32 * hidpi_factor,
+                            a[1] as f32 * hidpi_factor,
+                            ca.0,
+                            ca.1,
+                            ca.2,
+                            ca.3,
+                            b[0] as f32 * hidpi_factor,
+                            b[1] as f32 * hidpi_factor,
+                            cb.0,
+                            cb.1,
+                            cb.2,
+                            cb.3,
+                            c[0] as f32 * hidpi_factor,
+                            c[1] as f32 * hidpi_factor,
+                            cc.0,
+                            cc.1,
+                            cc.2,
+                            cc.3,
+                        ]);
+                        indices.push(Point3::new(vid + 0, vid + 1, vid + 2));
+
+                        vid += 3;
+                    }
+                }
+                PrimitiveKind::Image {
+                    image_id,
+                    color,
+                    source_rect,
+                } => {
+                    if let Some(texture) = texture_map.get(&image_id) {
+                        let color = color.unwrap_or(conrod::color::WHITE).to_rgb();
+                        mode = RenderMode::Image {
+                            color: Point4::new(color.0, color.1, color.2, color.3),
+                            texture: image_id,
+                        };
+
+                        let min_px = primitive.rect.x.start as f32 * hidpi_factor;
+                        let min_py = primitive.rect.y.start as f32 * hidpi_factor;
+                        let max_px = primitive.rect.x.end as f32 * hidpi_factor;
+                        let max_py = primitive.rect.y.end as f32 * hidpi_factor;
+
+                        let w = (texture.1).0 as f64;
+                        let h = (texture.1).1 as f64;
+                        let mut tex = source_rect
+                            .unwrap_or(conrod::position::Rect::from_corners([0.0, 0.0], [w, h]));
+                        tex.x.start /= w;
+                        tex.x.end /= w;
+                        // Because opengl textures are loaded upside down.
+                        tex.y.start = (h - tex.y.start) / h;
+                        tex.y.end = (h - tex.y.end) / h;
+
+                        vertices.extend_from_slice(&[
+                            min_px,
+                            min_py,
+                            tex.x.start as f32,
+                            tex.y.start as f32,
+                            min_px,
+                            max_py,
+                            tex.x.start as f32,
+                            tex.y.end as f32,
+                            max_px,
+                            min_py,
+                            tex.x.end as f32,
+                            tex.y.start as f32,
+                            max_px,
+                            min_py,
+                            tex.x.end as f32,
+                            tex.y.start as f32,
+                            min_px,
+                            max_py,
+                            tex.x.start as f32,
+                            tex.y.end as f32,
+                            max_px,
+                            max_py,
+                            tex.x.end as f32,
+                            tex.y.end as f32,
+                        ]);
+                    }
+                }
+                PrimitiveKind::Other(_) => {}
+                PrimitiveKind::Text {
+                    color,
+                    text,
+                    font_id,
+                } => {
+                    let rgba = color.to_rgb();
+                    mode = RenderMode::Text {
+                        color: Point4::new(rgba.0, rgba.1, rgba.2, rgba.3),
+                    };
+
+                    verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
+                    verify!(ctxt.tex_parameteri(
+                        Context::TEXTURE_2D,
+                        Context::TEXTURE_WRAP_S,
+                        Context::CLAMP_TO_EDGE as i32
+                    ));
+                    verify!(ctxt.tex_parameteri(
+                        Context::TEXTURE_2D,
+                        Context::TEXTURE_WRAP_T,
+                        Context::CLAMP_TO_EDGE as i32
+                    ));
+
+                    /*
+                     * Update the text image.
+                     */
+                    let positioned_glyphs = text.positioned_glyphs(hidpi_factor);
+                    for glyph in positioned_glyphs.iter() {
+                        self.cache.queue_glyph(font_id.index(), glyph.clone());
+                    }
+
+                    let _ = self.cache.cache_queued(|rect, data| {
+                        verify!(ctxt.tex_sub_image2d(
+                            Context::TEXTURE_2D,
+                            0,
+                            rect.min.x as i32,
+                            rect.min.y as i32,
+                            rect.width() as i32,
+                            rect.height() as i32,
+                            Context::RED,
+                            Some(&data)
+                        ));
+                    });
+
+                    /*
+                     * Build the vertex buffer.
+                     */
+                    for glyph in positioned_glyphs {
+                        if let Some(Some((tex, rect))) =
+                            self.cache.rect_for(font_id.index(), &glyph).ok()
+                        {
+                            let min_px = rect.min.x as f32;
+                            let min_py = rect.min.y as f32;
+                            let max_px = rect.max.x as f32;
+                            let max_py = rect.max.y as f32;
+
+                            vertices.extend_from_slice(&[
+                                min_px, min_py, tex.min.x, tex.min.y, min_px, max_py, tex.min.x,
+                                tex.max.y, max_px, min_py, tex.max.x, tex.min.y, max_px, min_py,
+                                tex.max.x, tex.min.y, min_px, max_py, tex.min.x, tex.max.y, max_px,
+                                max_py, tex.max.x, tex.max.y,
+                            ]);
+                        }
+                    }
+                }
+            }
+        }
+
+        verify!(ctxt.enable(Context::DEPTH_TEST));
+        verify!(ctxt.disable(Context::BLEND));
+        ctxt.scissor(0, 0, width as i32, height as i32);
+    }
+}
+
+static TRIANGLES_VERTEX_SRC: &'static str = "#version 100
+attribute vec2 position;
+attribute vec4 color;
+
+uniform vec2 window_size;
+
+varying vec4 v_color;
+
+void main(){
+    gl_Position = vec4(position / window_size * 2.0, 0.0, 1.0);
+    v_color = color;
+}";
+
+static TRIANGLES_FRAGMENT_SRC: &'static str = "#version 100
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+varying vec4 v_color;
+
+void main() {
+  gl_FragColor = v_color;
+}";
+
+const TEXT_VERTEX_SRC: &'static str = "
+#version 100
+
+uniform vec2 window_size;
+uniform vec4 color;
+
+attribute vec2 pos;
+attribute vec2 uvs;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_Position = vec4((pos.x / window_size.x - 0.5) * 2.0, (0.5 - pos.y / window_size.y) * 2.0, 0.0, 1.0);
+    v_uvs       = uvs;
+    v_color     = color;
+}
+";
+
+const TEXT_FRAGMENT_SRC: &'static str = "
+#version 100
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+uniform sampler2D tex0;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = vec4(v_color.rgb, v_color.a * texture2D(tex0, v_uvs).r);
+}
+";
+
+const IMAGE_VERTEX_SRC: &'static str = "
+#version 100
+
+uniform vec2 window_size;
+uniform vec4 color;
+
+attribute vec2 pos;
+attribute vec2 uvs;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_Position = vec4(pos / window_size * 2.0, 0.0, 1.0);
+    v_uvs       = uvs;
+    v_color     = color;
+}
+";
+
+const IMAGE_FRAGMENT_SRC: &'static str = "
+#version 100
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+   precision highp float;
+#else
+   precision mediump float;
+#endif
+
+uniform sampler2D tex0;
+
+varying vec2 v_uvs;
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = texture2D(tex0, v_uvs) * v_color;
+}
+";

--- a/gui/conrod/src/lib.rs
+++ b/gui/conrod/src/lib.rs
@@ -1,0 +1,271 @@
+use conrod::{
+    event::Input,
+    input::{Button, Key as CKey, Motion, MouseButton},
+};
+use conrod_renderer::ConrodRenderer;
+use kiss3d::{
+    event::{Action, Key, WindowEvent},
+    resource::{Texture, TextureManager},
+    window::UiContext,
+};
+use nalgebra::Vector2;
+use std::{collections::HashMap, rc::Rc};
+
+pub use conrod_core as conrod;
+
+mod conrod_renderer;
+
+pub struct ConrodContext {
+    renderer: ConrodRenderer,
+    textures: conrod::image::Map<(Rc<Texture>, (u32, u32))>,
+    texture_ids: HashMap<String, conrod::image::Id>,
+}
+
+impl ConrodContext {
+    pub fn conrod_ui(&self) -> &conrod::Ui {
+        self.renderer.ui()
+    }
+
+    pub fn conrod_ui_mut(&mut self) -> &mut conrod::Ui {
+        self.renderer.ui_mut()
+    }
+
+    /// Attributes a conrod ID to the given texture and returns it if it exists.
+    pub fn conrod_texture_id(&mut self, name: &str) -> Option<conrod::image::Id> {
+        let tex = TextureManager::get_global_manager(|tm| tm.get_with_size(name))?;
+        let textures = &mut self.textures;
+        Some(
+            *self
+                .texture_ids
+                .entry(name.to_string())
+                .or_insert_with(|| textures.insert(tex)),
+        )
+    }
+
+    /// Returns `true` if the keyboard is currently interacting with a Conrod widget.
+    pub fn is_conrod_ui_capturing_keyboard(&self) -> bool {
+        let ui = self.renderer.ui();
+        let state = &ui.global_input().current;
+        let window_id = Some(ui.window);
+
+        state.widget_capturing_keyboard.is_some() && state.widget_capturing_keyboard != window_id
+    }
+}
+
+impl UiContext for ConrodContext {
+    type Init = ();
+
+    fn new(width: u32, height: u32, _ui_init: Self::Init) -> Self {
+        Self {
+            renderer: ConrodRenderer::new(width as f64, height as f64),
+            textures: conrod::image::Map::new(),
+            texture_ids: HashMap::new(),
+        }
+    }
+
+    fn handle_event(&mut self, event: &WindowEvent, size: Vector2<u32>, hidpi: f64) -> bool {
+        let conrod_ui = self.renderer.ui_mut();
+        if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
+            conrod_ui.handle_event(input);
+        }
+
+        let state = &conrod_ui.global_input().current;
+        let window_id = Some(conrod_ui.window);
+
+        if event.is_keyboard_event()
+            && state.widget_capturing_keyboard.is_some()
+            && state.widget_capturing_keyboard != window_id
+        {
+            return true;
+        }
+
+        if event.is_mouse_event()
+            && state.widget_capturing_mouse.is_some()
+            && state.widget_capturing_mouse != window_id
+        {
+            return true;
+        }
+
+        false
+    }
+
+    fn render(&mut self, width: u32, height: u32, hidpi_factor: f64) {
+        self.renderer.render(
+            width as f32,
+            height as f32,
+            hidpi_factor as f32,
+            &self.textures,
+        )
+    }
+}
+
+fn window_event_to_conrod_input(
+    event: WindowEvent,
+    size: Vector2<u32>,
+    hidpi: f64,
+) -> Option<Input> {
+    let transform_coords = |x: f64, y: f64| {
+        (
+            (x - size.x as f64 / 2.0) / hidpi,
+            -(y - size.y as f64 / 2.0) / hidpi,
+        )
+    };
+
+    match event {
+        WindowEvent::FramebufferSize(w, h) => {
+            Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi))
+        }
+        WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
+        WindowEvent::CursorPos(x, y, _) => {
+            let (x, y) = transform_coords(x, y);
+            Some(Input::Motion(Motion::MouseCursor { x, y }))
+        }
+        WindowEvent::Scroll(x, y, _) => Some(Input::Motion(Motion::Scroll { x, y: -y })),
+        WindowEvent::MouseButton(button, action, _) => {
+            let button = match button {
+                kiss3d::event::MouseButton::Button1 => MouseButton::Left,
+                kiss3d::event::MouseButton::Button2 => MouseButton::Right,
+                kiss3d::event::MouseButton::Button3 => MouseButton::Middle,
+                kiss3d::event::MouseButton::Button4 => MouseButton::X1,
+                kiss3d::event::MouseButton::Button5 => MouseButton::X2,
+                kiss3d::event::MouseButton::Button6 => MouseButton::Button6,
+                kiss3d::event::MouseButton::Button7 => MouseButton::Button7,
+                kiss3d::event::MouseButton::Button8 => MouseButton::Button8,
+            };
+
+            match action {
+                Action::Press => Some(Input::Press(Button::Mouse(button))),
+                Action::Release => Some(Input::Release(Button::Mouse(button))),
+            }
+        }
+        WindowEvent::Key(key, action, _) => {
+            let key = match key {
+                Key::Key1 => CKey::D1,
+                Key::Key2 => CKey::D2,
+                Key::Key3 => CKey::D3,
+                Key::Key4 => CKey::D4,
+                Key::Key5 => CKey::D5,
+                Key::Key6 => CKey::D6,
+                Key::Key7 => CKey::D7,
+                Key::Key8 => CKey::D8,
+                Key::Key9 => CKey::D9,
+                Key::Key0 => CKey::D0,
+                Key::A => CKey::A,
+                Key::B => CKey::B,
+                Key::C => CKey::C,
+                Key::D => CKey::D,
+                Key::E => CKey::E,
+                Key::F => CKey::F,
+                Key::G => CKey::G,
+                Key::H => CKey::H,
+                Key::I => CKey::I,
+                Key::J => CKey::J,
+                Key::K => CKey::K,
+                Key::L => CKey::L,
+                Key::M => CKey::M,
+                Key::N => CKey::N,
+                Key::O => CKey::O,
+                Key::P => CKey::P,
+                Key::Q => CKey::Q,
+                Key::R => CKey::R,
+                Key::S => CKey::S,
+                Key::T => CKey::T,
+                Key::U => CKey::U,
+                Key::V => CKey::V,
+                Key::W => CKey::W,
+                Key::X => CKey::X,
+                Key::Y => CKey::Y,
+                Key::Z => CKey::Z,
+                Key::Escape => CKey::Escape,
+                Key::F1 => CKey::F1,
+                Key::F2 => CKey::F2,
+                Key::F3 => CKey::F3,
+                Key::F4 => CKey::F4,
+                Key::F5 => CKey::F5,
+                Key::F6 => CKey::F6,
+                Key::F7 => CKey::F7,
+                Key::F8 => CKey::F8,
+                Key::F9 => CKey::F9,
+                Key::F10 => CKey::F10,
+                Key::F11 => CKey::F11,
+                Key::F12 => CKey::F12,
+                Key::F13 => CKey::F13,
+                Key::F14 => CKey::F14,
+                Key::F15 => CKey::F15,
+                Key::F16 => CKey::F16,
+                Key::F17 => CKey::F17,
+                Key::F18 => CKey::F18,
+                Key::F19 => CKey::F19,
+                Key::F20 => CKey::F20,
+                Key::F21 => CKey::F21,
+                Key::F22 => CKey::F22,
+                Key::F23 => CKey::F23,
+                Key::F24 => CKey::F24,
+                Key::Pause => CKey::Pause,
+                Key::Insert => CKey::Insert,
+                Key::Home => CKey::Home,
+                Key::Delete => CKey::Delete,
+                Key::End => CKey::End,
+                Key::PageDown => CKey::PageDown,
+                Key::PageUp => CKey::PageUp,
+                Key::Left => CKey::Left,
+                Key::Up => CKey::Up,
+                Key::Right => CKey::Right,
+                Key::Down => CKey::Down,
+                Key::Return => CKey::Return,
+                Key::Space => CKey::Space,
+                Key::Caret => CKey::Caret,
+                Key::Numpad0 => CKey::NumPad0,
+                Key::Numpad1 => CKey::NumPad1,
+                Key::Numpad2 => CKey::NumPad2,
+                Key::Numpad3 => CKey::NumPad3,
+                Key::Numpad4 => CKey::NumPad4,
+                Key::Numpad5 => CKey::NumPad5,
+                Key::Numpad6 => CKey::NumPad6,
+                Key::Numpad7 => CKey::NumPad7,
+                Key::Numpad8 => CKey::NumPad8,
+                Key::Numpad9 => CKey::NumPad9,
+                Key::Add => CKey::Plus,
+                Key::At => CKey::At,
+                Key::Backslash => CKey::Backslash,
+                Key::Calculator => CKey::Calculator,
+                Key::Colon => CKey::Colon,
+                Key::Comma => CKey::Comma,
+                Key::Equals => CKey::Equals,
+                Key::LBracket => CKey::LeftBracket,
+                Key::LControl => CKey::LCtrl,
+                Key::LShift => CKey::LShift,
+                Key::Mail => CKey::Mail,
+                Key::MediaSelect => CKey::MediaSelect,
+                Key::Minus => CKey::Minus,
+                Key::Mute => CKey::Mute,
+                Key::NumpadComma => CKey::NumPadComma,
+                Key::NumpadEnter => CKey::NumPadEnter,
+                Key::NumpadEquals => CKey::NumPadEquals,
+                Key::Period => CKey::Period,
+                Key::Power => CKey::Power,
+                Key::RAlt => CKey::RAlt,
+                Key::RBracket => CKey::RightBracket,
+                Key::RControl => CKey::RCtrl,
+                Key::RShift => CKey::RShift,
+                Key::Semicolon => CKey::Semicolon,
+                Key::Slash => CKey::Slash,
+                Key::Sleep => CKey::Sleep,
+                Key::Stop => CKey::Stop,
+                Key::Tab => CKey::Tab,
+                Key::VolumeDown => CKey::VolumeDown,
+                Key::VolumeUp => CKey::VolumeUp,
+                Key::Copy => CKey::Copy,
+                Key::Paste => CKey::Paste,
+                Key::Cut => CKey::Cut,
+                _ => CKey::Unknown,
+            };
+
+            match action {
+                Action::Press => Some(Input::Press(Button::Keyboard(key))),
+                Action::Release => Some(Input::Release(Button::Keyboard(key))),
+            }
+        }
+        _ => None,
+    }
+}

--- a/gui/iced/Cargo.toml
+++ b/gui/iced/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name    = "kiss3d_iced"
+version = "0.0.1"
+authors = [ "Alvin Wong <alvinhochun@gmail.com>" ]
+edition = "2018"
+
+[dependencies]
+bytemuck = "1.2"
+# chrono = { version = "0.4" }
+glow = "0.4"
+glow_glyph = "0.2"
+glyph_brush = "0.7"
+iced_graphics = { version = "0.1", path = "D:\\dev\\experiments\\rust-fiddle\\iced\\graphics", features = ["font-fallback", "font-icons"] }
+iced_native = { version = "0.2", path = "D:\\dev\\experiments\\rust-fiddle\\iced\\native" }
+kiss3d = { version = "0.24", path = "../.." }
+nalgebra = "0.21"

--- a/gui/iced/examples/demo/controls.rs
+++ b/gui/iced/examples/demo/controls.rs
@@ -1,0 +1,117 @@
+// use iced_wgpu::Renderer;
+use iced_native::{Align, Color, Command, Element, Length, Program};
+use kiss3d_iced::{
+    widget::{slider, Column, Row, Slider, Text},
+    Renderer,
+};
+
+pub struct Controls {
+    background_color: Color,
+    sliders: [slider::State; 3],
+    test: String,
+    test_state: kiss3d_iced::widget::text_input::State,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    BackgroundColorChanged(Color),
+    TestEdited(String),
+}
+
+impl Controls {
+    pub fn new() -> Controls {
+        Controls {
+            background_color: Color::BLACK,
+            sliders: Default::default(),
+            test: String::new(),
+            test_state: Default::default(),
+        }
+    }
+
+    pub fn background_color(&self) -> Color {
+        self.background_color
+    }
+}
+
+impl Program for Controls {
+    type Renderer = Renderer;
+    type Message = Message;
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::BackgroundColorChanged(color) => {
+                self.background_color = color;
+            }
+            Message::TestEdited(s) => {
+                self.test = s;
+            }
+        }
+
+        Command::none()
+    }
+
+    fn view(&mut self) -> Element<Message, Renderer> {
+        let [r, g, b] = &mut self.sliders;
+        let background_color = self.background_color;
+
+        let sliders = Row::new()
+            .width(Length::Units(500))
+            .spacing(20)
+            .push(
+                Slider::new(r, 0.0..=1.0, background_color.r, move |r| {
+                    Message::BackgroundColorChanged(Color {
+                        r,
+                        ..background_color
+                    })
+                })
+                .step(0.01),
+            )
+            .push(
+                Slider::new(g, 0.0..=1.0, background_color.g, move |g| {
+                    Message::BackgroundColorChanged(Color {
+                        g,
+                        ..background_color
+                    })
+                })
+                .step(0.01),
+            )
+            .push(
+                Slider::new(b, 0.0..=1.0, background_color.b, move |b| {
+                    Message::BackgroundColorChanged(Color {
+                        b,
+                        ..background_color
+                    })
+                })
+                .step(0.01),
+            );
+
+        Row::new()
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .align_items(Align::End)
+            .push(
+                Column::new()
+                    .width(Length::Fill)
+                    .align_items(Align::End)
+                    .push(
+                        Column::new()
+                            .padding(10)
+                            .spacing(10)
+                            .push(Text::new("Background color").color(Color::WHITE))
+                            .push(sliders)
+                            .push(
+                                Text::new(format!("{:?}", background_color))
+                                    .size(14)
+                                    .color(Color::WHITE),
+                            )
+                            .push(kiss3d_iced::widget::TextInput::new(
+                                &mut self.test_state,
+                                "TextInput for test",
+                                &self.test,
+                                Message::TestEdited,
+                            )),
+                    ),
+            )
+            .into()
+    }
+}

--- a/gui/iced/examples/demo/main.rs
+++ b/gui/iced/examples/demo/main.rs
@@ -1,0 +1,24 @@
+use controls::Controls;
+use iced_graphics::{Point, Size};
+use iced_native::{program, Debug};
+use kiss3d::light::Light;
+use kiss3d::window::Window;
+use kiss3d_iced::{Backend, IcedContext, Renderer, Settings, Viewport};
+
+mod controls;
+
+fn main() {
+    let controls = Controls::new();
+    let mut window: Window<IcedContext<_>> = Window::new_with_ui("Kiss3d: UI", controls);
+    window.set_background_color(1.0, 1.0, 1.0);
+    let mut c = window.add_cube(0.1, 0.1, 0.1);
+    c.set_color(1.0, 0.0, 0.0);
+
+    window.set_light(Light::StickToCamera);
+
+    // Render loop.
+    while window.render() {
+        let color = window.ui().program().background_color();
+        window.set_background_color(color.r, color.g, color.b);
+    }
+}

--- a/gui/iced/src/backend.rs
+++ b/gui/iced/src/backend.rs
@@ -1,0 +1,199 @@
+use crate::quad;
+use crate::text;
+use crate::triangle;
+use crate::{Settings, Transformation, Viewport};
+use iced_graphics::backend;
+use iced_graphics::font;
+use iced_graphics::Layer;
+use iced_graphics::Primitive;
+use iced_native::mouse;
+use iced_native::{Font, HorizontalAlignment, Size, VerticalAlignment};
+use kiss3d::context::Context;
+
+/// A [`glow`] graphics backend for [`iced`].
+///
+/// [`glow`]: https://github.com/grovesNL/glow
+/// [`iced`]: https://github.com/hecrj/iced
+// #[derive(Debug)]
+pub struct Backend {
+    quad_pipeline: quad::Pipeline,
+    text_pipeline: text::Pipeline,
+    triangle_pipeline: triangle::Pipeline,
+    default_text_size: u16,
+}
+
+impl Backend {
+    /// Creates a new [`Backend`].
+    ///
+    /// [`Backend`]: struct.Backend.html
+    pub fn new(settings: Settings) -> Self {
+        let ctxt = Context::get();
+        let gl = ctxt.get_glow();
+        let text_pipeline = text::Pipeline::new(gl, settings.default_font);
+        let quad_pipeline = quad::Pipeline::new(gl);
+        let triangle_pipeline = triangle::Pipeline::new(gl);
+
+        Self {
+            quad_pipeline,
+            text_pipeline,
+            triangle_pipeline,
+            default_text_size: settings.default_text_size,
+        }
+    }
+
+    /// Draws the provided primitives in the default framebuffer.
+    ///
+    /// The text provided as overlay will be rendered on top of the primitives.
+    /// This is useful for rendering debug information.
+    pub fn draw<T: AsRef<str>>(
+        &mut self,
+        gl: &glow::Context,
+        viewport: &Viewport,
+        (primitive, mouse_interaction): &(Primitive, mouse::Interaction),
+        overlay_text: &[T],
+    ) -> mouse::Interaction {
+        let viewport_size = viewport.physical_size();
+        let scale_factor = viewport.scale_factor() as f32;
+        let projection = viewport.projection();
+
+        let mut layers = Layer::generate(primitive, viewport);
+        layers.push(Layer::overlay(overlay_text, viewport));
+
+        for layer in layers {
+            self.flush(gl, scale_factor, projection, &layer, viewport_size.height);
+        }
+
+        *mouse_interaction
+    }
+
+    fn flush(
+        &mut self,
+        gl: &glow::Context,
+        scale_factor: f32,
+        transformation: Transformation,
+        layer: &Layer<'_>,
+        target_height: u32,
+    ) {
+        let mut bounds = (layer.bounds * scale_factor).snap();
+        // bounds.height = bounds.height.min(target_height);
+        bounds.height = target_height.min(bounds.height);
+
+        if !layer.quads.is_empty() {
+            self.quad_pipeline.draw(
+                gl,
+                target_height,
+                &layer.quads,
+                transformation,
+                scale_factor,
+                bounds,
+            );
+        }
+
+        if !layer.meshes.is_empty() {
+            let scaled = transformation * Transformation::scale(scale_factor, scale_factor);
+
+            self.triangle_pipeline
+                .draw(gl, target_height, scaled, scale_factor, &layer.meshes);
+        }
+
+        if !layer.text.is_empty() {
+            for text in layer.text.iter() {
+                // Target physical coordinates directly to avoid blurry text
+                let text = glow_glyph::Section {
+                    // TODO: We `round` here to avoid rerasterizing text when
+                    // its position changes slightly. This can make text feel a
+                    // bit "jumpy". We may be able to do better once we improve
+                    // our text rendering/caching pipeline.
+                    screen_position: (
+                        (text.bounds.x * scale_factor).round(),
+                        (text.bounds.y * scale_factor).round(),
+                    ),
+                    // TODO: Fix precision issues with some scale factors.
+                    //
+                    // The `ceil` here can cause some words to render on the
+                    // same line when they should not.
+                    //
+                    // Ideally, `wgpu_glyph` should be able to compute layout
+                    // using logical positions, and then apply the proper
+                    // scaling when rendering. This would ensure that both
+                    // measuring and rendering follow the same layout rules.
+                    bounds: (
+                        (text.bounds.width * scale_factor).ceil(),
+                        (text.bounds.height * scale_factor).ceil(),
+                    ),
+                    text: vec![glow_glyph::Text {
+                        text: text.content,
+                        scale: glow_glyph::ab_glyph::PxScale {
+                            x: text.size * scale_factor,
+                            y: text.size * scale_factor,
+                        },
+                        font_id: self.text_pipeline.find_font(text.font),
+                        extra: glow_glyph::Extra {
+                            color: text.color,
+                            z: 0.0,
+                        },
+                    }],
+                    layout: glow_glyph::Layout::default()
+                        .h_align(match text.horizontal_alignment {
+                            HorizontalAlignment::Left => glow_glyph::HorizontalAlign::Left,
+                            HorizontalAlignment::Center => glow_glyph::HorizontalAlign::Center,
+                            HorizontalAlignment::Right => glow_glyph::HorizontalAlign::Right,
+                        })
+                        .v_align(match text.vertical_alignment {
+                            VerticalAlignment::Top => glow_glyph::VerticalAlign::Top,
+                            VerticalAlignment::Center => glow_glyph::VerticalAlign::Center,
+                            VerticalAlignment::Bottom => glow_glyph::VerticalAlign::Bottom,
+                        }),
+                    ..Default::default()
+                };
+
+                self.text_pipeline.queue(text);
+            }
+
+            self.text_pipeline.draw_queued(
+                gl,
+                transformation,
+                glow_glyph::Region {
+                    x: bounds.x,
+                    y: target_height - (bounds.y + bounds.height),
+                    width: bounds.width,
+                    height: bounds.height,
+                },
+            );
+        }
+    }
+}
+
+impl iced_graphics::Backend for Backend {
+    fn trim_measurements(&mut self) {
+        self.text_pipeline.trim_measurement_cache()
+    }
+}
+
+impl backend::Text for Backend {
+    const ICON_FONT: Font = font::ICONS;
+    const CHECKMARK_ICON: char = font::CHECKMARK_ICON;
+    const ARROW_DOWN_ICON: char = font::ARROW_DOWN_ICON;
+
+    fn default_size(&self) -> u16 {
+        self.default_text_size
+    }
+
+    fn measure(&self, contents: &str, size: f32, font: Font, bounds: Size) -> (f32, f32) {
+        self.text_pipeline.measure(contents, size, font, bounds)
+    }
+}
+
+#[cfg(feature = "image")]
+impl backend::Image for Backend {
+    fn dimensions(&self, _handle: &iced_native::image::Handle) -> (u32, u32) {
+        (50, 50)
+    }
+}
+
+#[cfg(feature = "svg")]
+impl backend::Svg for Backend {
+    fn viewport_dimensions(&self, _handle: &iced_native::svg::Handle) -> (u32, u32) {
+        (50, 50)
+    }
+}

--- a/gui/iced/src/lib.rs
+++ b/gui/iced/src/lib.rs
@@ -1,0 +1,403 @@
+use glow::HasContext;
+use iced_native::{keyboard, mouse, window, Debug, Event, Program};
+use kiss3d::{context::Context, event::WindowEvent, window::UiContext};
+use nalgebra::Vector2;
+
+mod backend;
+mod program;
+mod quad;
+mod text;
+mod triangle;
+
+pub mod settings;
+pub mod widget;
+
+pub use backend::Backend;
+pub use iced_graphics::Viewport;
+pub use settings::Settings;
+
+pub(crate) use iced_graphics::{Point, Size, Transformation};
+
+pub type Renderer = iced_graphics::Renderer<Backend>;
+
+pub struct IcedContext<P>
+where
+    P: Program<Renderer = Renderer> + 'static,
+{
+    // pending_program: Option<P>,
+    state: iced_native::program::State<P>,
+    debug: Debug,
+    renderer: Renderer,
+    viewport: Viewport,
+    cursor_position: (f64, f64),
+    // TODO
+}
+
+impl<P> IcedContext<P>
+where
+    P: Program<Renderer = Renderer> + 'static,
+{
+    pub fn program(&self) -> &P {
+        self.state.program()
+    }
+}
+
+impl<P> UiContext for IcedContext<P>
+where
+    P: Program<Renderer = Renderer> + 'static,
+{
+    type Init = P;
+
+    fn new(width: u32, height: u32, ui_init: Self::Init) -> Self {
+        let mut debug = Debug::new();
+        let mut renderer = Renderer::new(Backend::new(Settings::default()));
+        let viewport = Viewport::with_physical_size(Size::new(width, height), 1.0);
+        let state = iced_native::program::State::new(
+            ui_init,
+            viewport.logical_size(),
+            Point::new(-1.0, -1.0),
+            &mut renderer,
+            &mut debug,
+        );
+        Self {
+            // pending_program: None,
+            state,
+            debug,
+            renderer,
+            viewport,
+            cursor_position: (0.0, 0.0),
+        }
+    }
+
+    fn handle_event(&mut self, event: &WindowEvent, size: Vector2<u32>, hidpi_factor: f64) -> bool {
+        // if let Some(viewport) = &self.cached_viewport {
+        if self.viewport.physical_width() != size.x
+            || self.viewport.physical_height() != size.y
+            || self.viewport.scale_factor() != hidpi_factor
+        {
+            self.viewport = Viewport::with_physical_size(Size::new(size.x, size.y), hidpi_factor)
+        }
+        // }
+        // let viewport = self
+        //     .cached_viewport
+        //     .get_or_insert_with(|| Viewport::with_physical_size(Size::new(size.x, size.y), hidpi));
+
+        // if let Some(program) = self.pending_program.take() {
+        //     self.state = Some(program::State::new(
+        //         program,
+        //         self.viewport.logical_size(),
+        //         // conversion::cursor_position(cursor_position, viewport.scale_factor()),
+        //         Point::new(-1.0, -1.0), // TODO
+        //         &mut self.renderer,
+        //         &mut self.debug,
+        //     ))
+        // }
+
+        match event {
+            WindowEvent::CursorPos(x, y, mods) => {
+                self.cursor_position = (x / hidpi_factor, y / hidpi_factor);
+            }
+            _ => {}
+        }
+
+        if let Some(event) = window_event_to_iced_event(*event, size, hidpi_factor) {
+            self.state.queue_event(event);
+        }
+        // TODO
+        // todo!()
+        false
+    }
+
+    fn render(&mut self, width: u32, height: u32, hidpi_factor: f64) {
+        // let viewport = match &self.cached_viewport {
+        //     Some(x) => x,
+        //     None => return,
+        // };
+        if self.viewport.physical_width() != width
+            || self.viewport.physical_height() != height
+            || self.viewport.scale_factor() != hidpi_factor
+        {
+            self.viewport = Viewport::with_physical_size(Size::new(width, height), hidpi_factor)
+        }
+
+        // We update iced
+        let _ = self.state.update(
+            self.viewport.logical_size(),
+            Point::new(self.cursor_position.0 as f32, self.cursor_position.1 as f32),
+            None,
+            &mut self.renderer,
+            &mut self.debug,
+        );
+
+        // Then draw iced on top
+        let ctxt = Context::get();
+        let gl = ctxt.get_glow();
+
+        // Enable auto-conversion from/to sRGB
+        unsafe { gl.enable(glow::FRAMEBUFFER_SRGB) };
+
+        // Enable alpha blending
+        unsafe { gl.enable(glow::BLEND) };
+        unsafe { gl.blend_func(glow::SRC_ALPHA, glow::ONE_MINUS_SRC_ALPHA) };
+
+        // Disable multisampling by default
+        unsafe { gl.disable(glow::MULTISAMPLE) };
+
+        let mouse_interaction = self.renderer.backend_mut().draw(
+            gl,
+            &self.viewport,
+            self.state.primitive(),
+            &self.debug.overlay(),
+        );
+
+        unsafe { gl.enable(glow::MULTISAMPLE) };
+        unsafe { gl.disable(glow::BLEND) };
+        unsafe { gl.disable(glow::FRAMEBUFFER_SRGB) };
+
+        // // And update the mouse cursor
+        // window.set_cursor_icon(
+        //     iced_winit::conversion::mouse_interaction(
+        //         mouse_interaction,
+        //     ),
+        // );
+    }
+}
+
+fn window_event_to_iced_event(event: WindowEvent, size: Vector2<u32>, hidpi: f64) -> Option<Event> {
+    match event {
+        WindowEvent::FramebufferSize(w, h) => Some(Event::Window(window::Event::Resized {
+            width: (w as f64 / hidpi) as u32,
+            height: (h as f64 / hidpi) as u32,
+        })),
+        // WindowEvent::Size(w, h) => {}
+        // WindowEvent::CursorEnter(_) => {}
+        WindowEvent::CursorPos(x, y, mods) => Some(Event::Mouse(mouse::Event::CursorMoved {
+            x: (x / hidpi) as f32,
+            y: (y / hidpi) as f32,
+        })),
+        WindowEvent::MouseButton(btn, act, mods) => {
+            let button = match btn {
+                kiss3d::event::MouseButton::Button1 => mouse::Button::Left,
+                kiss3d::event::MouseButton::Button2 => mouse::Button::Right,
+                kiss3d::event::MouseButton::Button3 => mouse::Button::Middle,
+                kiss3d::event::MouseButton::Button4 => mouse::Button::Other(4),
+                kiss3d::event::MouseButton::Button5 => mouse::Button::Other(5),
+                kiss3d::event::MouseButton::Button6 => mouse::Button::Other(6),
+                kiss3d::event::MouseButton::Button7 => mouse::Button::Other(7),
+                kiss3d::event::MouseButton::Button8 => mouse::Button::Other(8),
+            };
+            Some(Event::Mouse(match act {
+                kiss3d::event::Action::Press => mouse::Event::ButtonPressed(button),
+                kiss3d::event::Action::Release => mouse::Event::ButtonReleased(button),
+            }))
+        }
+        WindowEvent::Scroll(dx, dy, mods) => {
+            // TODO: ScrollDelta::Lines?
+            Some(Event::Mouse(mouse::Event::WheelScrolled {
+                delta: mouse::ScrollDelta::Pixels {
+                    x: dx as f32,
+                    y: dy as f32,
+                },
+            }))
+        }
+        WindowEvent::Key(key, act, mods) => {
+            let key_code = conv_key_code(key)?;
+            let modifiers = conv_modifiers(mods);
+            Some(Event::Keyboard(match act {
+                kiss3d::event::Action::Press => keyboard::Event::KeyPressed {
+                    key_code,
+                    modifiers,
+                },
+                kiss3d::event::Action::Release => keyboard::Event::KeyReleased {
+                    key_code,
+                    modifiers,
+                },
+            }))
+        }
+        WindowEvent::Char(c) => Some(Event::Keyboard(keyboard::Event::CharacterReceived(c))),
+        // WindowEvent::CharModifiers(_, _) => {}
+        // WindowEvent::Pos(_, _) => {}
+        // WindowEvent::Close => {}
+        // WindowEvent::Refresh => {}
+        // WindowEvent::Focus(_) => {}
+        // WindowEvent::Iconify(_) => {}
+        // WindowEvent::Touch(_, _, _, _, _) => {}
+        _ => None,
+    }
+}
+
+fn conv_modifiers(mods: kiss3d::event::Modifiers) -> iced_native::keyboard::ModifiersState {
+    iced_native::keyboard::ModifiersState {
+        shift: mods.contains(kiss3d::event::Modifiers::Shift),
+        control: mods.contains(kiss3d::event::Modifiers::Control),
+        alt: mods.contains(kiss3d::event::Modifiers::Alt),
+        logo: mods.contains(kiss3d::event::Modifiers::Super),
+    }
+}
+
+fn conv_key_code(key: kiss3d::event::Key) -> Option<iced_native::keyboard::KeyCode> {
+    Some(match key {
+        kiss3d::event::Key::Key1 => iced_native::keyboard::KeyCode::Key1,
+        kiss3d::event::Key::Key2 => iced_native::keyboard::KeyCode::Key2,
+        kiss3d::event::Key::Key3 => iced_native::keyboard::KeyCode::Key3,
+        kiss3d::event::Key::Key4 => iced_native::keyboard::KeyCode::Key4,
+        kiss3d::event::Key::Key5 => iced_native::keyboard::KeyCode::Key5,
+        kiss3d::event::Key::Key6 => iced_native::keyboard::KeyCode::Key6,
+        kiss3d::event::Key::Key7 => iced_native::keyboard::KeyCode::Key7,
+        kiss3d::event::Key::Key8 => iced_native::keyboard::KeyCode::Key8,
+        kiss3d::event::Key::Key9 => iced_native::keyboard::KeyCode::Key9,
+        kiss3d::event::Key::Key0 => iced_native::keyboard::KeyCode::Key0,
+        kiss3d::event::Key::A => iced_native::keyboard::KeyCode::A,
+        kiss3d::event::Key::B => iced_native::keyboard::KeyCode::B,
+        kiss3d::event::Key::C => iced_native::keyboard::KeyCode::C,
+        kiss3d::event::Key::D => iced_native::keyboard::KeyCode::D,
+        kiss3d::event::Key::E => iced_native::keyboard::KeyCode::E,
+        kiss3d::event::Key::F => iced_native::keyboard::KeyCode::F,
+        kiss3d::event::Key::G => iced_native::keyboard::KeyCode::G,
+        kiss3d::event::Key::H => iced_native::keyboard::KeyCode::H,
+        kiss3d::event::Key::I => iced_native::keyboard::KeyCode::I,
+        kiss3d::event::Key::J => iced_native::keyboard::KeyCode::J,
+        kiss3d::event::Key::K => iced_native::keyboard::KeyCode::K,
+        kiss3d::event::Key::L => iced_native::keyboard::KeyCode::L,
+        kiss3d::event::Key::M => iced_native::keyboard::KeyCode::M,
+        kiss3d::event::Key::N => iced_native::keyboard::KeyCode::N,
+        kiss3d::event::Key::O => iced_native::keyboard::KeyCode::O,
+        kiss3d::event::Key::P => iced_native::keyboard::KeyCode::P,
+        kiss3d::event::Key::Q => iced_native::keyboard::KeyCode::Q,
+        kiss3d::event::Key::R => iced_native::keyboard::KeyCode::R,
+        kiss3d::event::Key::S => iced_native::keyboard::KeyCode::S,
+        kiss3d::event::Key::T => iced_native::keyboard::KeyCode::T,
+        kiss3d::event::Key::U => iced_native::keyboard::KeyCode::U,
+        kiss3d::event::Key::V => iced_native::keyboard::KeyCode::V,
+        kiss3d::event::Key::W => iced_native::keyboard::KeyCode::W,
+        kiss3d::event::Key::X => iced_native::keyboard::KeyCode::X,
+        kiss3d::event::Key::Y => iced_native::keyboard::KeyCode::Y,
+        kiss3d::event::Key::Z => iced_native::keyboard::KeyCode::Z,
+        kiss3d::event::Key::Escape => iced_native::keyboard::KeyCode::Escape,
+        kiss3d::event::Key::F1 => iced_native::keyboard::KeyCode::F1,
+        kiss3d::event::Key::F2 => iced_native::keyboard::KeyCode::F2,
+        kiss3d::event::Key::F3 => iced_native::keyboard::KeyCode::F3,
+        kiss3d::event::Key::F4 => iced_native::keyboard::KeyCode::F4,
+        kiss3d::event::Key::F5 => iced_native::keyboard::KeyCode::F5,
+        kiss3d::event::Key::F6 => iced_native::keyboard::KeyCode::F6,
+        kiss3d::event::Key::F7 => iced_native::keyboard::KeyCode::F7,
+        kiss3d::event::Key::F8 => iced_native::keyboard::KeyCode::F8,
+        kiss3d::event::Key::F9 => iced_native::keyboard::KeyCode::F9,
+        kiss3d::event::Key::F10 => iced_native::keyboard::KeyCode::F10,
+        kiss3d::event::Key::F11 => iced_native::keyboard::KeyCode::F11,
+        kiss3d::event::Key::F12 => iced_native::keyboard::KeyCode::F12,
+        kiss3d::event::Key::F13 => iced_native::keyboard::KeyCode::F13,
+        kiss3d::event::Key::F14 => iced_native::keyboard::KeyCode::F14,
+        kiss3d::event::Key::F15 => iced_native::keyboard::KeyCode::F15,
+        kiss3d::event::Key::F16 => iced_native::keyboard::KeyCode::F16,
+        kiss3d::event::Key::F17 => iced_native::keyboard::KeyCode::F17,
+        kiss3d::event::Key::F18 => iced_native::keyboard::KeyCode::F18,
+        kiss3d::event::Key::F19 => iced_native::keyboard::KeyCode::F19,
+        kiss3d::event::Key::F20 => iced_native::keyboard::KeyCode::F20,
+        kiss3d::event::Key::F21 => iced_native::keyboard::KeyCode::F21,
+        kiss3d::event::Key::F22 => iced_native::keyboard::KeyCode::F22,
+        kiss3d::event::Key::F23 => iced_native::keyboard::KeyCode::F23,
+        kiss3d::event::Key::F24 => iced_native::keyboard::KeyCode::F24,
+        kiss3d::event::Key::Snapshot => iced_native::keyboard::KeyCode::Snapshot,
+        kiss3d::event::Key::Scroll => iced_native::keyboard::KeyCode::Scroll,
+        kiss3d::event::Key::Pause => iced_native::keyboard::KeyCode::Pause,
+        kiss3d::event::Key::Insert => iced_native::keyboard::KeyCode::Insert,
+        kiss3d::event::Key::Home => iced_native::keyboard::KeyCode::Home,
+        kiss3d::event::Key::Delete => iced_native::keyboard::KeyCode::Delete,
+        kiss3d::event::Key::End => iced_native::keyboard::KeyCode::End,
+        kiss3d::event::Key::PageDown => iced_native::keyboard::KeyCode::PageDown,
+        kiss3d::event::Key::PageUp => iced_native::keyboard::KeyCode::PageUp,
+        kiss3d::event::Key::Left => iced_native::keyboard::KeyCode::Left,
+        kiss3d::event::Key::Up => iced_native::keyboard::KeyCode::Up,
+        kiss3d::event::Key::Right => iced_native::keyboard::KeyCode::Right,
+        kiss3d::event::Key::Down => iced_native::keyboard::KeyCode::Down,
+        kiss3d::event::Key::Back => iced_native::keyboard::KeyCode::Backspace,
+        kiss3d::event::Key::Return => iced_native::keyboard::KeyCode::Enter,
+        kiss3d::event::Key::Space => iced_native::keyboard::KeyCode::Space,
+        kiss3d::event::Key::Compose => iced_native::keyboard::KeyCode::Compose,
+        kiss3d::event::Key::Caret => iced_native::keyboard::KeyCode::Caret,
+        kiss3d::event::Key::Numlock => iced_native::keyboard::KeyCode::Numlock,
+        kiss3d::event::Key::Numpad0 => iced_native::keyboard::KeyCode::Numpad0,
+        kiss3d::event::Key::Numpad1 => iced_native::keyboard::KeyCode::Numpad1,
+        kiss3d::event::Key::Numpad2 => iced_native::keyboard::KeyCode::Numpad2,
+        kiss3d::event::Key::Numpad3 => iced_native::keyboard::KeyCode::Numpad3,
+        kiss3d::event::Key::Numpad4 => iced_native::keyboard::KeyCode::Numpad4,
+        kiss3d::event::Key::Numpad5 => iced_native::keyboard::KeyCode::Numpad5,
+        kiss3d::event::Key::Numpad6 => iced_native::keyboard::KeyCode::Numpad6,
+        kiss3d::event::Key::Numpad7 => iced_native::keyboard::KeyCode::Numpad7,
+        kiss3d::event::Key::Numpad8 => iced_native::keyboard::KeyCode::Numpad8,
+        kiss3d::event::Key::Numpad9 => iced_native::keyboard::KeyCode::Numpad9,
+        kiss3d::event::Key::AbntC1 => iced_native::keyboard::KeyCode::AbntC1,
+        kiss3d::event::Key::AbntC2 => iced_native::keyboard::KeyCode::AbntC2,
+        kiss3d::event::Key::Add => iced_native::keyboard::KeyCode::Add,
+        kiss3d::event::Key::Apostrophe => iced_native::keyboard::KeyCode::Apostrophe,
+        kiss3d::event::Key::Apps => iced_native::keyboard::KeyCode::Apps,
+        kiss3d::event::Key::At => iced_native::keyboard::KeyCode::At,
+        kiss3d::event::Key::Ax => iced_native::keyboard::KeyCode::Ax,
+        kiss3d::event::Key::Backslash => iced_native::keyboard::KeyCode::Backslash,
+        kiss3d::event::Key::Calculator => iced_native::keyboard::KeyCode::Calculator,
+        kiss3d::event::Key::Capital => iced_native::keyboard::KeyCode::Capital,
+        kiss3d::event::Key::Colon => iced_native::keyboard::KeyCode::Colon,
+        kiss3d::event::Key::Comma => iced_native::keyboard::KeyCode::Comma,
+        kiss3d::event::Key::Convert => iced_native::keyboard::KeyCode::Convert,
+        kiss3d::event::Key::Decimal => iced_native::keyboard::KeyCode::Decimal,
+        kiss3d::event::Key::Divide => iced_native::keyboard::KeyCode::Divide,
+        kiss3d::event::Key::Equals => iced_native::keyboard::KeyCode::Equals,
+        kiss3d::event::Key::Grave => iced_native::keyboard::KeyCode::Grave,
+        kiss3d::event::Key::Kana => iced_native::keyboard::KeyCode::Kana,
+        kiss3d::event::Key::Kanji => iced_native::keyboard::KeyCode::Kanji,
+        kiss3d::event::Key::LAlt => iced_native::keyboard::KeyCode::LAlt,
+        kiss3d::event::Key::LBracket => iced_native::keyboard::KeyCode::LBracket,
+        kiss3d::event::Key::LControl => iced_native::keyboard::KeyCode::LControl,
+        kiss3d::event::Key::LShift => iced_native::keyboard::KeyCode::LShift,
+        kiss3d::event::Key::LWin => iced_native::keyboard::KeyCode::LWin,
+        kiss3d::event::Key::Mail => iced_native::keyboard::KeyCode::Mail,
+        kiss3d::event::Key::MediaSelect => iced_native::keyboard::KeyCode::MediaSelect,
+        kiss3d::event::Key::MediaStop => iced_native::keyboard::KeyCode::MediaStop,
+        kiss3d::event::Key::Minus => iced_native::keyboard::KeyCode::Minus,
+        kiss3d::event::Key::Multiply => iced_native::keyboard::KeyCode::Multiply,
+        kiss3d::event::Key::Mute => iced_native::keyboard::KeyCode::Mute,
+        kiss3d::event::Key::MyComputer => iced_native::keyboard::KeyCode::MyComputer,
+        kiss3d::event::Key::NavigateForward => iced_native::keyboard::KeyCode::NavigateForward,
+        kiss3d::event::Key::NavigateBackward => iced_native::keyboard::KeyCode::NavigateBackward,
+        kiss3d::event::Key::NextTrack => iced_native::keyboard::KeyCode::NextTrack,
+        kiss3d::event::Key::NoConvert => iced_native::keyboard::KeyCode::NoConvert,
+        kiss3d::event::Key::NumpadComma => iced_native::keyboard::KeyCode::NumpadComma,
+        kiss3d::event::Key::NumpadEnter => iced_native::keyboard::KeyCode::NumpadEnter,
+        kiss3d::event::Key::NumpadEquals => iced_native::keyboard::KeyCode::NumpadEquals,
+        kiss3d::event::Key::OEM102 => iced_native::keyboard::KeyCode::OEM102,
+        kiss3d::event::Key::Period => iced_native::keyboard::KeyCode::Period,
+        kiss3d::event::Key::PlayPause => iced_native::keyboard::KeyCode::PlayPause,
+        kiss3d::event::Key::Power => iced_native::keyboard::KeyCode::Power,
+        kiss3d::event::Key::PrevTrack => iced_native::keyboard::KeyCode::PrevTrack,
+        kiss3d::event::Key::RAlt => iced_native::keyboard::KeyCode::RAlt,
+        kiss3d::event::Key::RBracket => iced_native::keyboard::KeyCode::RBracket,
+        kiss3d::event::Key::RControl => iced_native::keyboard::KeyCode::RControl,
+        kiss3d::event::Key::RShift => iced_native::keyboard::KeyCode::RShift,
+        kiss3d::event::Key::RWin => iced_native::keyboard::KeyCode::RWin,
+        kiss3d::event::Key::Semicolon => iced_native::keyboard::KeyCode::Semicolon,
+        kiss3d::event::Key::Slash => iced_native::keyboard::KeyCode::Slash,
+        kiss3d::event::Key::Sleep => iced_native::keyboard::KeyCode::Sleep,
+        kiss3d::event::Key::Stop => iced_native::keyboard::KeyCode::Stop,
+        kiss3d::event::Key::Subtract => iced_native::keyboard::KeyCode::Subtract,
+        kiss3d::event::Key::Sysrq => iced_native::keyboard::KeyCode::Sysrq,
+        kiss3d::event::Key::Tab => iced_native::keyboard::KeyCode::Tab,
+        kiss3d::event::Key::Underline => iced_native::keyboard::KeyCode::Underline,
+        kiss3d::event::Key::Unlabeled => iced_native::keyboard::KeyCode::Unlabeled,
+        kiss3d::event::Key::VolumeDown => iced_native::keyboard::KeyCode::VolumeDown,
+        kiss3d::event::Key::VolumeUp => iced_native::keyboard::KeyCode::VolumeUp,
+        kiss3d::event::Key::Wake => iced_native::keyboard::KeyCode::Wake,
+        kiss3d::event::Key::WebBack => iced_native::keyboard::KeyCode::WebBack,
+        kiss3d::event::Key::WebFavorites => iced_native::keyboard::KeyCode::WebFavorites,
+        kiss3d::event::Key::WebForward => iced_native::keyboard::KeyCode::WebForward,
+        kiss3d::event::Key::WebHome => iced_native::keyboard::KeyCode::WebHome,
+        kiss3d::event::Key::WebRefresh => iced_native::keyboard::KeyCode::WebRefresh,
+        kiss3d::event::Key::WebSearch => iced_native::keyboard::KeyCode::WebSearch,
+        kiss3d::event::Key::WebStop => iced_native::keyboard::KeyCode::WebStop,
+        kiss3d::event::Key::Yen => iced_native::keyboard::KeyCode::Yen,
+        kiss3d::event::Key::Copy => iced_native::keyboard::KeyCode::Copy,
+        kiss3d::event::Key::Paste => iced_native::keyboard::KeyCode::Paste,
+        kiss3d::event::Key::Cut => iced_native::keyboard::KeyCode::Cut,
+        kiss3d::event::Key::Unknown => return None,
+    })
+}

--- a/gui/iced/src/program.rs
+++ b/gui/iced/src/program.rs
@@ -1,0 +1,39 @@
+use glow::HasContext;
+
+pub unsafe fn create(
+    gl: &glow::Context,
+    shader_sources: &[(u32, &str)],
+) -> <glow::Context as HasContext>::Program {
+    let program = gl.create_program().expect("Cannot create program");
+
+    let mut shaders = Vec::with_capacity(shader_sources.len());
+
+    for (shader_type, shader_source) in shader_sources.iter() {
+        let shader = gl
+            .create_shader(*shader_type)
+            .expect("Cannot create shader");
+
+        gl.shader_source(shader, shader_source);
+        gl.compile_shader(shader);
+
+        if !gl.get_shader_compile_status(shader) {
+            panic!(gl.get_shader_info_log(shader));
+        }
+
+        gl.attach_shader(program, shader);
+
+        shaders.push(shader);
+    }
+
+    gl.link_program(program);
+    if !gl.get_program_link_status(program) {
+        panic!(gl.get_program_info_log(program));
+    }
+
+    for shader in shaders {
+        gl.detach_shader(program, shader);
+        gl.delete_shader(shader);
+    }
+
+    program
+}

--- a/gui/iced/src/quad.rs
+++ b/gui/iced/src/quad.rs
@@ -1,0 +1,235 @@
+use crate::program;
+use crate::Transformation;
+use glow::HasContext;
+use iced_graphics::layer;
+use iced_native::Rectangle;
+
+const MAX_INSTANCES: usize = 100_000;
+
+#[derive(Debug)]
+pub struct Pipeline {
+    program: <glow::Context as HasContext>::Program,
+    vertex_array: <glow::Context as HasContext>::VertexArray,
+    instances: <glow::Context as HasContext>::Buffer,
+    transform_location: <glow::Context as HasContext>::UniformLocation,
+    scale_location: <glow::Context as HasContext>::UniformLocation,
+    screen_height_location: <glow::Context as HasContext>::UniformLocation,
+    current_transform: Transformation,
+    current_scale: f32,
+    current_target_height: u32,
+}
+
+impl Pipeline {
+    pub fn new(gl: &glow::Context) -> Pipeline {
+        let program = unsafe {
+            program::create(
+                gl,
+                &[
+                    (glow::VERTEX_SHADER, include_str!("shader/quad.vert")),
+                    (glow::FRAGMENT_SHADER, include_str!("shader/quad.frag")),
+                ],
+            )
+        };
+
+        let transform_location =
+            unsafe { gl.get_uniform_location(program, "u_Transform") }
+                .expect("Get transform location");
+
+        let scale_location =
+            unsafe { gl.get_uniform_location(program, "u_Scale") }
+                .expect("Get scale location");
+
+        let screen_height_location =
+            unsafe { gl.get_uniform_location(program, "u_ScreenHeight") }
+                .expect("Get target height location");
+
+        unsafe {
+            gl.use_program(Some(program));
+
+            let matrix: [f32; 16] = Transformation::identity().into();
+            gl.uniform_matrix_4_f32_slice(
+                Some(transform_location),
+                false,
+                &matrix,
+            );
+
+            gl.uniform_1_f32(Some(scale_location), 1.0);
+            gl.uniform_1_f32(Some(screen_height_location), 0.0);
+
+            gl.use_program(None);
+        }
+
+        let (vertex_array, instances) =
+            unsafe { create_instance_buffer(gl, MAX_INSTANCES) };
+
+        Pipeline {
+            program,
+            vertex_array,
+            instances,
+            transform_location,
+            scale_location,
+            screen_height_location,
+            current_transform: Transformation::identity(),
+            current_scale: 1.0,
+            current_target_height: 0,
+        }
+    }
+
+    pub fn draw(
+        &mut self,
+        gl: &glow::Context,
+        target_height: u32,
+        instances: &[layer::Quad],
+        transformation: Transformation,
+        scale: f32,
+        bounds: Rectangle<u32>,
+    ) {
+        unsafe {
+            gl.enable(glow::SCISSOR_TEST);
+            gl.scissor(
+                bounds.x as i32,
+                (target_height - (bounds.y + bounds.height)) as i32,
+                bounds.width as i32,
+                bounds.height as i32,
+            );
+
+            gl.use_program(Some(self.program));
+            gl.bind_vertex_array(Some(self.vertex_array));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.instances));
+        }
+
+        if transformation != self.current_transform {
+            unsafe {
+                let matrix: [f32; 16] = transformation.into();
+                gl.uniform_matrix_4_f32_slice(
+                    Some(self.transform_location),
+                    false,
+                    &matrix,
+                );
+
+                self.current_transform = transformation;
+            }
+        }
+
+        if scale != self.current_scale {
+            unsafe {
+                gl.uniform_1_f32(Some(self.scale_location), scale);
+            }
+
+            self.current_scale = scale;
+        }
+
+        if target_height != self.current_target_height {
+            unsafe {
+                gl.uniform_1_f32(
+                    Some(self.screen_height_location),
+                    target_height as f32,
+                );
+            }
+
+            self.current_target_height = target_height;
+        }
+
+        let mut i = 0;
+        let total = instances.len();
+
+        while i < total {
+            let end = (i + MAX_INSTANCES).min(total);
+            let amount = end - i;
+
+            unsafe {
+                gl.buffer_sub_data_u8_slice(
+                    glow::ARRAY_BUFFER,
+                    0,
+                    bytemuck::cast_slice(&instances[i..end]),
+                );
+
+                gl.draw_arrays_instanced(
+                    glow::TRIANGLE_STRIP,
+                    0,
+                    4,
+                    amount as i32,
+                );
+            }
+
+            i += MAX_INSTANCES;
+        }
+
+        unsafe {
+            gl.bind_vertex_array(None);
+            gl.use_program(None);
+            gl.disable(glow::SCISSOR_TEST);
+        }
+    }
+}
+
+unsafe fn create_instance_buffer(
+    gl: &glow::Context,
+    size: usize,
+) -> (
+    <glow::Context as HasContext>::VertexArray,
+    <glow::Context as HasContext>::Buffer,
+) {
+    let vertex_array = gl.create_vertex_array().expect("Create vertex array");
+    let buffer = gl.create_buffer().expect("Create instance buffer");
+
+    gl.bind_vertex_array(Some(vertex_array));
+    gl.bind_buffer(glow::ARRAY_BUFFER, Some(buffer));
+    gl.buffer_data_size(
+        glow::ARRAY_BUFFER,
+        (size * std::mem::size_of::<layer::Quad>()) as i32,
+        glow::DYNAMIC_DRAW,
+    );
+
+    let stride = std::mem::size_of::<layer::Quad>() as i32;
+
+    gl.enable_vertex_attrib_array(0);
+    gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, stride, 0);
+    gl.vertex_attrib_divisor(0, 1);
+
+    gl.enable_vertex_attrib_array(1);
+    gl.vertex_attrib_pointer_f32(1, 2, glow::FLOAT, false, stride, 4 * 2);
+    gl.vertex_attrib_divisor(1, 1);
+
+    gl.enable_vertex_attrib_array(2);
+    gl.vertex_attrib_pointer_f32(2, 4, glow::FLOAT, false, stride, 4 * (2 + 2));
+    gl.vertex_attrib_divisor(2, 1);
+
+    gl.enable_vertex_attrib_array(3);
+    gl.vertex_attrib_pointer_f32(
+        3,
+        4,
+        glow::FLOAT,
+        false,
+        stride,
+        4 * (2 + 2 + 4),
+    );
+    gl.vertex_attrib_divisor(3, 1);
+
+    gl.enable_vertex_attrib_array(4);
+    gl.vertex_attrib_pointer_f32(
+        4,
+        1,
+        glow::FLOAT,
+        false,
+        stride,
+        4 * (2 + 2 + 4 + 4),
+    );
+    gl.vertex_attrib_divisor(4, 1);
+
+    gl.enable_vertex_attrib_array(5);
+    gl.vertex_attrib_pointer_f32(
+        5,
+        1,
+        glow::FLOAT,
+        false,
+        stride,
+        4 * (2 + 2 + 4 + 4 + 1),
+    );
+    gl.vertex_attrib_divisor(5, 1);
+
+    gl.bind_vertex_array(None);
+    gl.bind_buffer(glow::ARRAY_BUFFER, None);
+
+    (vertex_array, buffer)
+}

--- a/gui/iced/src/settings.rs
+++ b/gui/iced/src/settings.rs
@@ -1,0 +1,31 @@
+//! Configure a renderer.
+pub use iced_graphics::Antialiasing;
+
+/// The settings of a [`Renderer`].
+///
+/// [`Renderer`]: ../struct.Renderer.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Settings {
+    /// The bytes of the font that will be used by default.
+    ///
+    /// If `None` is provided, a default system font will be chosen.
+    pub default_font: Option<&'static [u8]>,
+
+    /// The default size of text.
+    ///
+    /// By default, it will be set to 20.
+    pub default_text_size: u16,
+
+    /// The antialiasing strategy that will be used for triangle primitives.
+    pub antialiasing: Option<Antialiasing>,
+}
+
+impl Default for Settings {
+    fn default() -> Settings {
+        Settings {
+            default_font: None,
+            default_text_size: 20,
+            antialiasing: None,
+        }
+    }
+}

--- a/gui/iced/src/shader/quad.frag
+++ b/gui/iced/src/shader/quad.frag
@@ -1,0 +1,70 @@
+#version 330
+
+uniform float u_ScreenHeight;
+
+in vec4 v_Color;
+in vec4 v_BorderColor;
+in vec2 v_Pos;
+in vec2 v_Scale;
+in float v_BorderRadius;
+in float v_BorderWidth;
+
+out vec4 o_Color;
+
+float distance(in vec2 frag_coord, in vec2 position, in vec2 size, float radius)
+{
+    // TODO: Try SDF approach: https://www.shadertoy.com/view/wd3XRN
+    vec2 inner_size = size - vec2(radius, radius) * 2.0;
+    vec2 top_left = position + vec2(radius, radius);
+    vec2 bottom_right = top_left + inner_size;
+
+    vec2 top_left_distance = top_left - frag_coord;
+    vec2 bottom_right_distance = frag_coord - bottom_right;
+
+    vec2 distance = vec2(
+        max(max(top_left_distance.x, bottom_right_distance.x), 0.0),
+        max(max(top_left_distance.y, bottom_right_distance.y), 0.0)
+    );
+
+    return sqrt(distance.x * distance.x + distance.y * distance.y);
+}
+
+void main() {
+    vec4 mixed_color;
+
+    vec2 fragCoord = vec2(gl_FragCoord.x, u_ScreenHeight - gl_FragCoord.y);
+
+    // TODO: Remove branching (?)
+    if(v_BorderWidth > 0) {
+        float internal_border = max(v_BorderRadius - v_BorderWidth, 0.0);
+
+        float internal_distance = distance(
+            fragCoord,
+            v_Pos + vec2(v_BorderWidth),
+            v_Scale - vec2(v_BorderWidth * 2.0),
+            internal_border
+        );
+
+        float border_mix = smoothstep(
+            max(internal_border - 0.5, 0.0),
+            internal_border + 0.5,
+            internal_distance
+        );
+
+        mixed_color = mix(v_Color, v_BorderColor, border_mix);
+    } else {
+        mixed_color = v_Color;
+    }
+
+    float d = distance(
+        fragCoord,
+        v_Pos,
+        v_Scale,
+        v_BorderRadius
+    );
+
+    float radius_alpha =
+        1.0 - smoothstep(max(v_BorderRadius - 0.5, 0.0), v_BorderRadius + 0.5, d);
+
+    o_Color = vec4(mixed_color.xyz, mixed_color.w * radius_alpha);
+}

--- a/gui/iced/src/shader/quad.vert
+++ b/gui/iced/src/shader/quad.vert
@@ -1,0 +1,47 @@
+#version 330
+
+uniform mat4 u_Transform;
+uniform float u_Scale;
+
+layout(location = 0) in vec2 i_Pos;
+layout(location = 1) in vec2 i_Scale;
+layout(location = 2) in vec4 i_Color;
+layout(location = 3) in vec4 i_BorderColor;
+layout(location = 4) in float i_BorderRadius;
+layout(location = 5) in float i_BorderWidth;
+
+out vec4 v_Color;
+out vec4 v_BorderColor;
+out vec2 v_Pos;
+out vec2 v_Scale;
+out float v_BorderRadius;
+out float v_BorderWidth;
+
+const vec2 positions[4] = vec2[](
+    vec2(0.0, 0.0),
+    vec2(0.0, 1.0),
+    vec2(1.0, 0.0),
+    vec2(1.0, 1.0)
+);
+
+void main() {
+    vec2 q_Pos = positions[gl_VertexID];
+    vec2 p_Pos = i_Pos * u_Scale;
+    vec2 p_Scale = i_Scale  * u_Scale;
+
+    mat4 i_Transform = mat4(
+        vec4(p_Scale.x + 1.0, 0.0, 0.0, 0.0),
+        vec4(0.0, p_Scale.y + 1.0, 0.0, 0.0),
+        vec4(0.0, 0.0, 1.0, 0.0),
+        vec4(p_Pos - vec2(0.5, 0.5), 0.0, 1.0)
+    );
+
+    v_Color = i_Color;
+    v_BorderColor = i_BorderColor;
+    v_Pos = p_Pos;
+    v_Scale = p_Scale;
+    v_BorderRadius = i_BorderRadius * u_Scale;
+    v_BorderWidth = i_BorderWidth * u_Scale;
+
+    gl_Position = u_Transform * i_Transform * vec4(q_Pos, 0.0, 1.0);
+}

--- a/gui/iced/src/shader/triangle.frag
+++ b/gui/iced/src/shader/triangle.frag
@@ -1,0 +1,9 @@
+#version 330
+
+in vec4 v_Color;
+
+out vec4 o_Color;
+
+void main() {
+    o_Color = v_Color;
+}

--- a/gui/iced/src/shader/triangle.vert
+++ b/gui/iced/src/shader/triangle.vert
@@ -1,0 +1,13 @@
+#version 330
+
+uniform mat4 u_Transform;
+
+layout(location = 0) in vec2 i_Position;
+layout(location = 1) in vec4 i_Color;
+
+out vec4 v_Color;
+
+void main() {
+    gl_Position = u_Transform * vec4(i_Position, 0.0, 1.0);
+    v_Color = i_Color;
+}

--- a/gui/iced/src/text.rs
+++ b/gui/iced/src/text.rs
@@ -1,0 +1,156 @@
+use crate::Transformation;
+use glow_glyph::ab_glyph;
+use iced_graphics::font;
+use std::{cell::RefCell, collections::HashMap};
+
+#[derive(Debug)]
+pub struct Pipeline {
+    draw_brush: RefCell<glow_glyph::GlyphBrush>,
+    draw_font_map: RefCell<HashMap<String, glow_glyph::FontId>>,
+    measure_brush: RefCell<glyph_brush::GlyphBrush<()>>,
+}
+
+impl Pipeline {
+    pub fn new(gl: &glow::Context, default_font: Option<&[u8]>) -> Self {
+        let default_font = default_font.map(|slice| slice.to_vec());
+
+        // TODO: Font customization
+        #[cfg(feature = "default_system_font")]
+        let default_font = {
+            default_font.or_else(|| {
+                font::Source::new()
+                    .load(&[font::Family::SansSerif, font::Family::Serif])
+                    .ok()
+            })
+        };
+
+        let default_font =
+            default_font.unwrap_or_else(|| font::FALLBACK.to_vec());
+
+        let font = ab_glyph::FontArc::try_from_vec(default_font)
+            .unwrap_or_else(|_| {
+                // log::warn!(
+                //     "System font failed to load. Falling back to \
+                //     embedded font..."
+                // );
+
+                ab_glyph::FontArc::try_from_slice(font::FALLBACK)
+                    .expect("Load fallback font")
+            });
+
+        let draw_brush =
+            glow_glyph::GlyphBrushBuilder::using_font(font.clone())
+                .initial_cache_size((2048, 2048))
+                .draw_cache_multithread(false) // TODO: Expose as a configuration flag
+                .build(&gl);
+
+        let measure_brush =
+            glyph_brush::GlyphBrushBuilder::using_font(font).build();
+
+        Pipeline {
+            draw_brush: RefCell::new(draw_brush),
+            draw_font_map: RefCell::new(HashMap::new()),
+            measure_brush: RefCell::new(measure_brush),
+        }
+    }
+
+    pub fn queue(&mut self, section: glow_glyph::Section<'_>) {
+        self.draw_brush.borrow_mut().queue(section);
+    }
+
+    pub fn draw_queued(
+        &mut self,
+        gl: &glow::Context,
+        transformation: Transformation,
+        region: glow_glyph::Region,
+    ) {
+        self.draw_brush
+            .borrow_mut()
+            .draw_queued_with_transform_and_scissoring(
+                gl,
+                transformation.into(),
+                region,
+            )
+            .expect("Draw text");
+    }
+
+    pub fn measure(
+        &self,
+        content: &str,
+        size: f32,
+        font: iced_native::Font,
+        bounds: iced_native::Size,
+    ) -> (f32, f32) {
+        use glow_glyph::GlyphCruncher;
+
+        let glow_glyph::FontId(font_id) = self.find_font(font);
+
+        let section = glow_glyph::Section {
+            bounds: (bounds.width, bounds.height),
+            text: vec![glow_glyph::Text {
+                text: content,
+                scale: size.into(),
+                font_id: glow_glyph::FontId(font_id),
+                extra: glow_glyph::Extra::default(),
+            }],
+            ..Default::default()
+        };
+
+        if let Some(bounds) =
+            self.measure_brush.borrow_mut().glyph_bounds(section)
+        {
+            (bounds.width().ceil(), bounds.height().ceil())
+        } else {
+            (0.0, 0.0)
+        }
+    }
+
+    pub fn trim_measurement_cache(&mut self) {
+        // TODO: We should probably use a `GlyphCalculator` for this. However,
+        // it uses a lifetimed `GlyphCalculatorGuard` with side-effects on drop.
+        // This makes stuff quite inconvenient. A manual method for trimming the
+        // cache would make our lives easier.
+        loop {
+            let action = self
+                .measure_brush
+                .borrow_mut()
+                .process_queued(|_, _| {}, |_| {});
+
+            match action {
+                Ok(_) => break,
+                Err(glyph_brush::BrushError::TextureTooSmall { suggested }) => {
+                    let (width, height) = suggested;
+
+                    self.measure_brush
+                        .borrow_mut()
+                        .resize_texture(width, height);
+                }
+            }
+        }
+    }
+
+    pub fn find_font(&self, font: iced_native::Font) -> glow_glyph::FontId {
+        match font {
+            iced_native::Font::Default => glow_glyph::FontId(0),
+            iced_native::Font::External { name, bytes } => {
+                if let Some(font_id) = self.draw_font_map.borrow().get(name) {
+                    return *font_id;
+                }
+
+                let font = ab_glyph::FontArc::try_from_slice(bytes)
+                    .expect("Load font");
+
+                let _ = self.measure_brush.borrow_mut().add_font(font.clone());
+
+                let font_id = self.draw_brush.borrow_mut().add_font(font);
+
+                let _ = self
+                    .draw_font_map
+                    .borrow_mut()
+                    .insert(String::from(name), font_id);
+
+                font_id
+            }
+        }
+    }
+}

--- a/gui/iced/src/triangle.rs
+++ b/gui/iced/src/triangle.rs
@@ -1,0 +1,292 @@
+//! Draw meshes of triangles.
+use crate::program;
+use crate::Transformation;
+use glow::HasContext;
+use iced_graphics::layer;
+use std::marker::PhantomData;
+
+pub use iced_graphics::triangle::{Mesh2D, Vertex2D};
+
+const VERTEX_BUFFER_SIZE: usize = 10_000;
+const INDEX_BUFFER_SIZE: usize = 10_000;
+
+#[derive(Debug)]
+pub(crate) struct Pipeline {
+    program: <glow::Context as HasContext>::Program,
+    vertex_array: <glow::Context as HasContext>::VertexArray,
+    vertices: Buffer<Vertex2D>,
+    indices: Buffer<u32>,
+    transform_location: <glow::Context as HasContext>::UniformLocation,
+    current_transform: Transformation,
+}
+
+impl Pipeline {
+    pub fn new(gl: &glow::Context) -> Pipeline {
+        let program = unsafe {
+            program::create(
+                gl,
+                &[
+                    (glow::VERTEX_SHADER, include_str!("shader/triangle.vert")),
+                    (
+                        glow::FRAGMENT_SHADER,
+                        include_str!("shader/triangle.frag"),
+                    ),
+                ],
+            )
+        };
+
+        let transform_location =
+            unsafe { gl.get_uniform_location(program, "u_Transform") }
+                .expect("Get transform location");
+
+        unsafe {
+            gl.use_program(Some(program));
+
+            let transform: [f32; 16] = Transformation::identity().into();
+            gl.uniform_matrix_4_f32_slice(
+                Some(transform_location),
+                false,
+                &transform,
+            );
+
+            gl.use_program(None);
+        }
+
+        let vertex_array =
+            unsafe { gl.create_vertex_array().expect("Create vertex array") };
+
+        unsafe {
+            gl.bind_vertex_array(Some(vertex_array));
+        }
+
+        let vertices = unsafe {
+            Buffer::new(
+                gl,
+                glow::ARRAY_BUFFER,
+                glow::DYNAMIC_DRAW,
+                VERTEX_BUFFER_SIZE,
+            )
+        };
+
+        let indices = unsafe {
+            Buffer::new(
+                gl,
+                glow::ELEMENT_ARRAY_BUFFER,
+                glow::DYNAMIC_DRAW,
+                INDEX_BUFFER_SIZE,
+            )
+        };
+
+        unsafe {
+            let stride = std::mem::size_of::<Vertex2D>() as i32;
+
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(0, 2, glow::FLOAT, false, stride, 0);
+
+            gl.enable_vertex_attrib_array(1);
+            gl.vertex_attrib_pointer_f32(
+                1,
+                4,
+                glow::FLOAT,
+                false,
+                stride,
+                4 * 2,
+            );
+
+            gl.bind_vertex_array(None);
+        }
+
+        Pipeline {
+            program,
+            vertex_array,
+            vertices,
+            indices,
+            transform_location,
+            current_transform: Transformation::identity(),
+        }
+    }
+
+    pub fn draw(
+        &mut self,
+        gl: &glow::Context,
+        target_height: u32,
+        transformation: Transformation,
+        scale_factor: f32,
+        meshes: &[layer::Mesh<'_>],
+    ) {
+        unsafe {
+            gl.enable(glow::MULTISAMPLE);
+            gl.enable(glow::SCISSOR_TEST);
+            gl.use_program(Some(self.program));
+            gl.bind_vertex_array(Some(self.vertex_array));
+        }
+
+        // This looks a bit crazy, but we are just counting how many vertices
+        // and indices we will need to handle.
+        // TODO: Improve readability
+        let (total_vertices, total_indices) = meshes
+            .iter()
+            .map(|layer::Mesh { buffers, .. }| {
+                (buffers.vertices.len(), buffers.indices.len())
+            })
+            .fold((0, 0), |(total_v, total_i), (v, i)| {
+                (total_v + v, total_i + i)
+            });
+
+        // Then we ensure the current buffers are big enough, resizing if
+        // necessary
+        unsafe {
+            self.vertices.bind(gl, total_vertices);
+            self.indices.bind(gl, total_indices);
+        }
+
+        // We upload all the vertices and indices upfront
+        let mut last_vertex = 0;
+        let mut last_index = 0;
+
+        for layer::Mesh { buffers, .. } in meshes {
+            unsafe {
+                gl.buffer_sub_data_u8_slice(
+                    glow::ARRAY_BUFFER,
+                    (last_vertex * std::mem::size_of::<Vertex2D>()) as i32,
+                    bytemuck::cast_slice(&buffers.vertices),
+                );
+
+                gl.buffer_sub_data_u8_slice(
+                    glow::ELEMENT_ARRAY_BUFFER,
+                    (last_index * std::mem::size_of::<u32>()) as i32,
+                    bytemuck::cast_slice(&buffers.indices),
+                );
+
+                last_vertex += buffers.vertices.len();
+                last_index += buffers.indices.len();
+            }
+        }
+
+        // Then we draw each mesh using offsets
+        let mut last_vertex = 0;
+        let mut last_index = 0;
+
+        for layer::Mesh {
+            buffers,
+            origin,
+            clip_bounds,
+        } in meshes
+        {
+            let transform =
+                transformation * Transformation::translate(origin.x, origin.y);
+
+            let clip_bounds = (*clip_bounds * scale_factor).snap();
+
+            unsafe {
+                if self.current_transform != transform {
+                    let matrix: [f32; 16] = transform.into();
+                    gl.uniform_matrix_4_f32_slice(
+                        Some(self.transform_location),
+                        false,
+                        &matrix,
+                    );
+
+                    self.current_transform = transform;
+                }
+
+                gl.scissor(
+                    clip_bounds.x as i32,
+                    (target_height - (clip_bounds.y + clip_bounds.height))
+                        as i32,
+                    clip_bounds.width as i32,
+                    clip_bounds.height as i32,
+                );
+
+                gl.draw_elements_base_vertex(
+                    glow::TRIANGLES,
+                    buffers.indices.len() as i32,
+                    glow::UNSIGNED_INT,
+                    (last_index * std::mem::size_of::<u32>()) as i32,
+                    last_vertex as i32,
+                );
+
+                last_vertex += buffers.vertices.len();
+                last_index += buffers.indices.len();
+            }
+        }
+
+        unsafe {
+            gl.bind_vertex_array(None);
+            gl.use_program(None);
+            gl.disable(glow::SCISSOR_TEST);
+            gl.disable(glow::MULTISAMPLE);
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct Uniforms {
+    transform: [f32; 16],
+}
+
+unsafe impl bytemuck::Zeroable for Uniforms {}
+unsafe impl bytemuck::Pod for Uniforms {}
+
+impl Default for Uniforms {
+    fn default() -> Self {
+        Self {
+            transform: *Transformation::identity().as_ref(),
+        }
+    }
+}
+
+impl From<Transformation> for Uniforms {
+    fn from(transformation: Transformation) -> Uniforms {
+        Self {
+            transform: transformation.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Buffer<T> {
+    raw: <glow::Context as HasContext>::Buffer,
+    target: u32,
+    usage: u32,
+    size: usize,
+    phantom: PhantomData<T>,
+}
+
+impl<T> Buffer<T> {
+    pub unsafe fn new(
+        gl: &glow::Context,
+        target: u32,
+        usage: u32,
+        size: usize,
+    ) -> Self {
+        let raw = gl.create_buffer().expect("Create buffer");
+
+        let mut buffer = Buffer {
+            raw,
+            target,
+            usage,
+            size: 0,
+            phantom: PhantomData,
+        };
+
+        buffer.bind(gl, size);
+
+        buffer
+    }
+
+    pub unsafe fn bind(&mut self, gl: &glow::Context, size: usize) {
+        gl.bind_buffer(self.target, Some(self.raw));
+
+        if self.size < size {
+            gl.buffer_data_size(
+                self.target,
+                (size * std::mem::size_of::<T>()) as i32,
+                self.usage,
+            );
+
+            self.size = size;
+        }
+    }
+}

--- a/gui/iced/src/widget.rs
+++ b/gui/iced/src/widget.rs
@@ -1,0 +1,61 @@
+//! Use the widgets supported out-of-the-box.
+//!
+//! # Re-exports
+//! For convenience, the contents of this module are available at the root
+//! module. Therefore, you can directly type:
+//!
+//! ```
+//! use iced_glow::{button, Button};
+//! ```
+use crate::Renderer;
+
+pub mod button;
+pub mod checkbox;
+pub mod container;
+pub mod pane_grid;
+pub mod pick_list;
+pub mod progress_bar;
+pub mod radio;
+pub mod scrollable;
+pub mod slider;
+pub mod text_input;
+
+#[doc(no_inline)]
+pub use button::Button;
+#[doc(no_inline)]
+pub use checkbox::Checkbox;
+#[doc(no_inline)]
+pub use container::Container;
+#[doc(no_inline)]
+pub use pane_grid::PaneGrid;
+#[doc(no_inline)]
+pub use pick_list::PickList;
+#[doc(no_inline)]
+pub use progress_bar::ProgressBar;
+#[doc(no_inline)]
+pub use radio::Radio;
+#[doc(no_inline)]
+pub use scrollable::Scrollable;
+#[doc(no_inline)]
+pub use slider::Slider;
+#[doc(no_inline)]
+pub use text_input::TextInput;
+
+#[cfg(feature = "canvas")]
+#[cfg_attr(docsrs, doc(cfg(feature = "canvas")))]
+pub mod canvas;
+
+#[cfg(feature = "canvas")]
+#[doc(no_inline)]
+pub use canvas::Canvas;
+
+pub use iced_native::{Image, Space};
+
+/// A container that distributes its contents vertically.
+pub type Column<'a, Message> = iced_native::Column<'a, Message, Renderer>;
+
+/// A container that distributes its contents horizontally.
+pub type Row<'a, Message> = iced_native::Row<'a, Message, Renderer>;
+
+/// A paragraph of text.
+pub type Text = iced_native::Text<Renderer>;

--- a/gui/iced/src/widget/button.rs
+++ b/gui/iced/src/widget/button.rs
@@ -1,0 +1,15 @@
+//! Allow your users to perform actions by pressing a button.
+//!
+//! A [`Button`] has some local [`State`].
+//!
+//! [`Button`]: type.Button.html
+//! [`State`]: struct.State.html
+use crate::Renderer;
+
+pub use iced_graphics::button::{Style, StyleSheet};
+pub use iced_native::button::State;
+
+/// A widget that produces a message when clicked.
+///
+/// This is an alias of an `iced_native` button with an `iced_wgpu::Renderer`.
+pub type Button<'a, Message> = iced_native::Button<'a, Message, Renderer>;

--- a/gui/iced/src/widget/canvas.rs
+++ b/gui/iced/src/widget/canvas.rs
@@ -1,0 +1,9 @@
+//! Draw 2D graphics for your users.
+//!
+//! A [`Canvas`] widget can be used to draw different kinds of 2D shapes in a
+//! [`Frame`]. It can be used for animation, data visualization, game graphics,
+//! and more!
+//!
+//! [`Canvas`]: struct.Canvas.html
+//! [`Frame`]: struct.Frame.html
+pub use iced_graphics::canvas::*;

--- a/gui/iced/src/widget/checkbox.rs
+++ b/gui/iced/src/widget/checkbox.rs
@@ -1,0 +1,9 @@
+//! Show toggle controls using checkboxes.
+use crate::Renderer;
+
+pub use iced_graphics::checkbox::{Style, StyleSheet};
+
+/// A box that can be checked.
+///
+/// This is an alias of an `iced_native` checkbox with an `iced_wgpu::Renderer`.
+pub type Checkbox<Message> = iced_native::Checkbox<Message, Renderer>;

--- a/gui/iced/src/widget/container.rs
+++ b/gui/iced/src/widget/container.rs
@@ -1,0 +1,10 @@
+//! Decorate content and apply alignment.
+use crate::Renderer;
+
+pub use iced_graphics::container::{Style, StyleSheet};
+
+/// An element decorating some content.
+///
+/// This is an alias of an `iced_native` container with a default
+/// `Renderer`.
+pub type Container<'a, Message> = iced_native::Container<'a, Message, Renderer>;

--- a/gui/iced/src/widget/pane_grid.rs
+++ b/gui/iced/src/widget/pane_grid.rs
@@ -1,0 +1,36 @@
+//! Let your users split regions of your application and organize layout dynamically.
+//!
+//! [![Pane grid - Iced](https://thumbs.gfycat.com/MixedFlatJellyfish-small.gif)](https://gfycat.com/mixedflatjellyfish)
+//!
+//! # Example
+//! The [`pane_grid` example] showcases how to use a [`PaneGrid`] with resizing,
+//! drag and drop, and hotkey support.
+//!
+//! [`pane_grid` example]: https://github.com/hecrj/iced/tree/0.1/examples/pane_grid
+//! [`PaneGrid`]: type.PaneGrid.html
+use crate::Renderer;
+
+pub use iced_native::pane_grid::{
+    Axis, Configuration, Direction, DragEvent, Focus, KeyPressEvent, Node,
+    Pane, ResizeEvent, Split, State,
+};
+
+/// A collection of panes distributed using either vertical or horizontal splits
+/// to completely fill the space available.
+///
+/// [![Pane grid - Iced](https://thumbs.gfycat.com/MixedFlatJellyfish-small.gif)](https://gfycat.com/mixedflatjellyfish)
+///
+/// This is an alias of an `iced_native` pane grid with an `iced_wgpu::Renderer`.
+pub type PaneGrid<'a, Message> = iced_native::PaneGrid<'a, Message, Renderer>;
+
+/// The content of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+pub type Content<'a, Message> =
+    iced_native::pane_grid::Content<'a, Message, Renderer>;
+
+/// The title bar of a [`Pane`].
+///
+/// [`Pane`]: struct.Pane.html
+pub type TitleBar<'a, Message> =
+    iced_native::pane_grid::TitleBar<'a, Message, Renderer>;

--- a/gui/iced/src/widget/pick_list.rs
+++ b/gui/iced/src/widget/pick_list.rs
@@ -1,0 +1,9 @@
+//! Display a dropdown list of selectable values.
+pub use iced_native::pick_list::State;
+
+pub use iced_graphics::overlay::menu::Style as Menu;
+pub use iced_graphics::pick_list::{Style, StyleSheet};
+
+/// A widget allowing the selection of a single value from a list of options.
+pub type PickList<'a, T, Message> =
+    iced_native::PickList<'a, T, Message, crate::Renderer>;

--- a/gui/iced/src/widget/progress_bar.rs
+++ b/gui/iced/src/widget/progress_bar.rs
@@ -1,0 +1,15 @@
+//! Allow your users to visually track the progress of a computation.
+//!
+//! A [`ProgressBar`] has a range of possible values and a current value,
+//! as well as a length, height and style.
+//!
+//! [`ProgressBar`]: type.ProgressBar.html
+use crate::Renderer;
+
+pub use iced_graphics::progress_bar::{Style, StyleSheet};
+
+/// A bar that displays progress.
+///
+/// This is an alias of an `iced_native` progress bar with an
+/// `iced_wgpu::Renderer`.
+pub type ProgressBar = iced_native::ProgressBar<Renderer>;

--- a/gui/iced/src/widget/radio.rs
+++ b/gui/iced/src/widget/radio.rs
@@ -1,0 +1,10 @@
+//! Create choices using radio buttons.
+use crate::Renderer;
+
+pub use iced_graphics::radio::{Style, StyleSheet};
+
+/// A circular button representing a choice.
+///
+/// This is an alias of an `iced_native` radio button with an
+/// `iced_wgpu::Renderer`.
+pub type Radio<Message> = iced_native::Radio<Message, Renderer>;

--- a/gui/iced/src/widget/scrollable.rs
+++ b/gui/iced/src/widget/scrollable.rs
@@ -1,0 +1,13 @@
+//! Navigate an endless amount of content with a scrollbar.
+use crate::Renderer;
+
+pub use iced_graphics::scrollable::{Scrollbar, Scroller, StyleSheet};
+pub use iced_native::scrollable::State;
+
+/// A widget that can vertically display an infinite amount of content
+/// with a scrollbar.
+///
+/// This is an alias of an `iced_native` scrollable with a default
+/// `Renderer`.
+pub type Scrollable<'a, Message> =
+    iced_native::Scrollable<'a, Message, Renderer>;

--- a/gui/iced/src/widget/slider.rs
+++ b/gui/iced/src/widget/slider.rs
@@ -1,0 +1,16 @@
+//! Display an interactive selector of a single value from a range of values.
+//!
+//! A [`Slider`] has some local [`State`].
+//!
+//! [`Slider`]: struct.Slider.html
+//! [`State`]: struct.State.html
+use crate::Renderer;
+
+pub use iced_graphics::slider::{Handle, HandleShape, Style, StyleSheet};
+pub use iced_native::slider::State;
+
+/// An horizontal bar and a handle that selects a single value from a range of
+/// values.
+///
+/// This is an alias of an `iced_native` slider with an `iced_wgpu::Renderer`.
+pub type Slider<'a, T, Message> = iced_native::Slider<'a, T, Message, Renderer>;

--- a/gui/iced/src/widget/text_input.rs
+++ b/gui/iced/src/widget/text_input.rs
@@ -1,0 +1,15 @@
+//! Display fields that can be filled with text.
+//!
+//! A [`TextInput`] has some local [`State`].
+//!
+//! [`TextInput`]: struct.TextInput.html
+//! [`State`]: struct.State.html
+use crate::Renderer;
+
+pub use iced_graphics::text_input::{Style, StyleSheet};
+pub use iced_native::text_input::State;
+
+/// A field that can be filled with text.
+///
+/// This is an alias of an `iced_native` text input with an `iced_wgpu::Renderer`.
+pub type TextInput<'a, Message> = iced_native::TextInput<'a, Message, Renderer>;

--- a/src/context/gl_context.rs
+++ b/src/context/gl_context.rs
@@ -15,7 +15,9 @@ mod error;
 
 /// An OpenGL context.
 #[derive(Clone)]
-pub struct GLContext;
+pub struct GLContext {
+    vao: u32,
+}
 
 fn val<T: Copy + Zero>(val: Option<&T>) -> T {
     match val {
@@ -27,7 +29,7 @@ fn val<T: Copy + Zero>(val: Option<&T>) -> T {
 impl GLContext {
     /// Creates a new OpenGL context.
     pub fn new() -> Self {
-        GLContext
+        GLContext { vao: 0 }
     }
 }
 
@@ -101,6 +103,20 @@ impl AbstractContext for GLContext {
     type Framebuffer = u32;
     type Renderbuffer = u32;
     type Texture = u32;
+
+    fn init_vao(&mut self) {
+        unsafe {
+            let mut vao = 0;
+            gl::GenVertexArrays(1, &mut vao);
+            self.vao = vao;
+            gl::BindVertexArray(vao);
+        }
+    }
+    fn bind_vao(&self) {
+        unsafe {
+            gl::BindVertexArray(self.vao);
+        }
+    }
 
     fn get_error(&self) -> GLenum {
         unsafe { gl::GetError() }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,11 +149,7 @@ extern crate stdweb;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 #[macro_use]
 extern crate stdweb_derive;
-#[cfg(feature = "conrod")]
-pub extern crate conrod_core as conrod;
 extern crate instant;
-#[cfg(feature = "conrod")]
-pub use conrod::widget_ids;
 
 pub use nalgebra;
 pub use ncollide3d;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,13 +1,9 @@
 //! Structures responsible for rendering elements other than kiss3d's meshes.
 
-#[cfg(feature = "conrod")]
-pub use self::conrod_renderer::ConrodRenderer;
 pub use self::line_renderer::LineRenderer;
 pub use self::point_renderer::PointRenderer;
 pub use self::renderer::Renderer;
 
-#[cfg(feature = "conrod")]
-mod conrod_renderer;
 pub mod line_renderer;
 pub mod point_renderer;
 mod renderer;

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -48,16 +48,16 @@ impl AbstractCanvas for GLCanvas {
             });
         let window = GlWindow::new(window, context, &events).unwrap();
         let _ = unsafe { window.make_current().unwrap() };
+        crate::context::Context::init(|| {
+            glow::Context::from_loader_function(|name| {
+                window.context().get_proc_address(name) as *const _
+            })
+        });
         verify!(gl::load_with(
             |name| window.context().get_proc_address(name) as *const _
         ));
 
-        unsafe {
-            // Setup a single VAO.
-            let mut vao = 0;
-            gl::GenVertexArrays(1, &mut vao);
-            gl::BindVertexArray(vao);
-        }
+        crate::context::Context::with_mut(|ctx| ctx.init_vao());
 
         GLCanvas {
             window,
@@ -157,6 +157,9 @@ impl AbstractCanvas for GLCanvas {
                     let modifiers = translate_modifiers(input.modifiers);
                     key_states[key as usize] = action;
                     let _ = out_events.send(WindowEvent::Key(key, action, modifiers));
+                }
+                glutin::WindowEvent::ReceivedCharacter(c) => {
+                    let _ = out_events.send(WindowEvent::Char(c));
                 }
                 _ => {}
             },

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -7,7 +7,7 @@ pub use self::gl_canvas::GLCanvas;
 pub use self::state::State;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 pub use self::webgl_canvas::WebGLCanvas;
-pub use self::window::Window;
+pub use self::window::{NullUiContext, UiContext, Window};
 
 mod canvas;
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -2,16 +2,16 @@ use crate::camera::Camera;
 use crate::planar_camera::PlanarCamera;
 use crate::post_processing::PostProcessingEffect;
 use crate::renderer::Renderer;
-use crate::window::Window;
+use crate::window::{NullUiContext, UiContext, Window};
 
 /// Trait implemented by objects describing state of an application.
 ///
 /// It is passed to the window's render loop. Its methods are called at each
 /// render loop to update the application state, and customize the cameras and
 /// post-processing effects to be used by the renderer.
-pub trait State: 'static {
+pub trait State<Ui: UiContext = NullUiContext>: 'static {
     /// Method called at each render loop before a rendering.
-    fn step(&mut self, window: &mut Window);
+    fn step(&mut self, window: &mut Window<Ui>);
 
     /// Unless `cameras_and_effect_and_renderer` is implemented, this method called at each render loop to retrieve
     /// the cameras and post-processing effects to be used for the next render.
@@ -43,6 +43,6 @@ pub trait State: 'static {
     }
 }
 
-impl State for () {
-    fn step(&mut self, _: &mut Window) {}
+impl<Ui: UiContext> State<Ui> for () {
+    fn step(&mut self, _: &mut Window<Ui>) {}
 }

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -544,6 +544,7 @@ impl<Ui: UiContext> Window<Ui> {
             ))),
             ui_context: Ui::new(width, height, ui_init),
         };
+        Context::get().bind_vao();
 
         if hide {
             usr_window.canvas.hide()
@@ -887,6 +888,7 @@ impl<Ui: UiContext> Window<Ui> {
 
         self.text_renderer.render(w as f32, h as f32);
         self.ui_context.render(w, h, self.canvas.hidpi_factor());
+        Context::get().bind_vao();
 
         // We are done: swap buffers
         self.canvas.swap_buffers();

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -16,51 +16,55 @@ use na::{Point2, Point3, Vector2, Vector3};
 use crate::camera::{ArcBall, Camera};
 use crate::context::Context;
 use crate::event::{Action, EventManager, Key, WindowEvent};
-use image::imageops;
-use image::{GenericImage, Pixel};
-use image::{ImageBuffer, Rgb};
 use crate::light::Light;
-use ncollide3d::procedural::TriMesh;
 use crate::planar_camera::{FixedView, PlanarCamera};
 use crate::planar_line_renderer::PlanarLineRenderer;
 use crate::post_processing::PostProcessingEffect;
-#[cfg(feature = "conrod")]
-use crate::renderer::ConrodRenderer;
 use crate::renderer::{LineRenderer, PointRenderer, Renderer};
-use crate::resource::{FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager};
+use crate::resource::{
+    FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager,
+};
 use crate::scene::{PlanarSceneNode, SceneNode};
 use crate::text::{Font, TextRenderer};
 use crate::window::canvas::CanvasSetup;
 use crate::window::{Canvas, State};
-
-#[cfg(feature = "conrod")]
-use std::collections::HashMap;
+use image::imageops;
+use image::{GenericImage, Pixel};
+use image::{ImageBuffer, Rgb};
+use ncollide3d::procedural::TriMesh;
 
 static DEFAULT_WIDTH: u32 = 800u32;
 static DEFAULT_HEIGHT: u32 = 600u32;
 
-#[cfg(feature = "conrod")]
-struct ConrodContext {
-    renderer: ConrodRenderer,
-    textures: conrod::image::Map<(Rc<Texture>, (u32, u32))>,
-    texture_ids: HashMap<String, conrod::image::Id>,
+pub trait UiContext: 'static {
+    type Init;
+    fn new(width: u32, height: u32, init: Self::Init) -> Self;
+    fn handle_event(&mut self, event: &WindowEvent, size: Vector2<u32>, hidpi_factor: f64) -> bool;
+    fn render(&mut self, width: u32, height: u32, hidpi_factor: f64);
 }
 
-#[cfg(feature = "conrod")]
-impl ConrodContext {
-    fn new(width: f64, height: f64) -> Self {
-        Self {
-            renderer: ConrodRenderer::new(width, height),
-            textures: conrod::image::Map::new(),
-            texture_ids: HashMap::new(),
-        }
+pub struct NullUiContext;
+
+impl UiContext for NullUiContext {
+    type Init = ();
+    fn new(_width: u32, _height: u32, _init: Self::Init) -> Self {
+        Self
     }
+    fn handle_event(
+        &mut self,
+        _event: &WindowEvent,
+        _size: Vector2<u32>,
+        _hidpi_factor: f64,
+    ) -> bool {
+        false
+    }
+    fn render(&mut self, _width: u32, _height: u32, _hidpi_factor: f64) {}
 }
 
 /// Structure representing a window and a 3D scene.
 ///
 /// This is the main interface with the 3d engine.
-pub struct Window {
+pub struct Window<Ui: UiContext = NullUiContext> {
     events: Rc<Receiver<WindowEvent>>,
     unhandled_events: Rc<RefCell<Vec<WindowEvent>>>,
     canvas: Canvas,
@@ -80,11 +84,42 @@ pub struct Window {
     planar_camera: Rc<RefCell<FixedView>>,
     camera: Rc<RefCell<ArcBall>>,
     should_close: bool,
-    #[cfg(feature = "conrod")]
-    conrod_context: ConrodContext,
+    ui_context: Ui,
 }
 
-impl Window {
+impl Window<NullUiContext> {
+    /// Opens a window, hide it then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title
+    pub fn new_hidden(title: &str) -> Self {
+        Self::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ())
+    }
+
+    /// Opens a window then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title
+    pub fn new(title: &str) -> Self {
+        Self::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ())
+    }
+
+    /// Opens a window with a custom size then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title.
+    /// * `width` - the window width.
+    /// * `height` - the window height.
+    pub fn new_with_size(title: &str, width: u32, height: u32) -> Self {
+        Self::do_new(title, false, width, height, None, ())
+    }
+
+    pub fn new_with_setup(title: &str, width: u32, height: u32, setup: CanvasSetup) -> Self {
+        Self::do_new(title, false, width, height, Some(setup), ())
+    }
+}
+
+impl<Ui: UiContext> Window<Ui> {
     /// Indicates whether this window should be closed.
     #[inline]
     pub fn should_close(&self) -> bool {
@@ -420,66 +455,30 @@ impl Window {
         self.light_mode = pos;
     }
 
-    /// Retrieve a mutable reference to the UI based on Conrod.
-    #[cfg(feature = "conrod")]
-    pub fn conrod_ui_mut(&mut self) -> &mut conrod::Ui {
-        self.conrod_context.renderer.ui_mut()
+    /// Retrieve a reference to the UI.
+    pub fn ui(&self) -> &Ui {
+        &self.ui_context
     }
 
-    /// Attributes a conrod ID to the given texture and returns it if it exists.
-    #[cfg(feature = "conrod")]
-    pub fn conrod_texture_id(&mut self, name: &str) -> Option<conrod::image::Id> {
-        let tex = TextureManager::get_global_manager(|tm| tm.get_with_size(name))?;
-        let textures = &mut self.conrod_context.textures;
-        Some(
-            *self
-                .conrod_context
-                .texture_ids
-                .entry(name.to_string())
-                .or_insert_with(|| textures.insert(tex)),
-        )
-    }
-
-    /// Retrieve a reference to the UI based on Conrod.
-    #[cfg(feature = "conrod")]
-    pub fn conrod_ui(&self) -> &conrod::Ui {
-        self.conrod_context.renderer.ui()
-    }
-
-    /// Returns `true` if the mouse is currently interacting with a Conrod widget.
-    #[cfg(feature = "conrod")]
-    pub fn is_conrod_ui_capturing_mouse(&self) -> bool {
-        let ui = self.conrod_ui();
-        let state = &ui.global_input().current;
-        let window_id = Some(ui.window);
-
-        state.widget_capturing_mouse.is_some() && state.widget_capturing_mouse != window_id
-    }
-
-    /// Returns `true` if the keyboard is currently interacting with a Conrod widget.
-    #[cfg(feature = "conrod")]
-    pub fn is_conrod_ui_capturing_keyboard(&self) -> bool {
-        let ui = self.conrod_ui();
-        let state = &ui.global_input().current;
-        let window_id = Some(ui.window);
-
-        state.widget_capturing_keyboard.is_some() && state.widget_capturing_keyboard != window_id
+    /// Retrieve a mutable reference to the UI.
+    pub fn ui_mut(&mut self) -> &mut Ui {
+        &mut self.ui_context
     }
 
     /// Opens a window, hide it then calls a user-defined procedure.
     ///
     /// # Arguments
     /// * `title` - the window title
-    pub fn new_hidden(title: &str) -> Window {
-        Window::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None)
+    pub fn new_hidden_with_ui(title: &str, ui_init: Ui::Init) -> Self {
+        Self::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ui_init)
     }
 
     /// Opens a window then calls a user-defined procedure.
     ///
     /// # Arguments
     /// * `title` - the window title
-    pub fn new(title: &str) -> Window {
-        Window::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None)
+    pub fn new_with_ui(title: &str, ui_init: Ui::Init) -> Self {
+        Self::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None, ui_init)
     }
 
     /// Opens a window with a custom size then calls a user-defined procedure.
@@ -488,12 +487,18 @@ impl Window {
     /// * `title` - the window title.
     /// * `width` - the window width.
     /// * `height` - the window height.
-    pub fn new_with_size(title: &str, width: u32, height: u32) -> Window {
-        Window::do_new(title, false, width, height, None)
+    pub fn new_with_size_and_ui(title: &str, width: u32, height: u32, ui_init: Ui::Init) -> Self {
+        Self::do_new(title, false, width, height, None, ui_init)
     }
 
-    pub fn new_with_setup(title: &str, width: u32, height: u32, setup: CanvasSetup) -> Window {
-        Window::do_new(title, false, width, height, Some(setup))
+    pub fn new_with_setup_and_ui(
+        title: &str,
+        width: u32,
+        height: u32,
+        setup: CanvasSetup,
+        ui_init: Ui::Init,
+    ) -> Self {
+        Self::do_new(title, false, width, height, Some(setup), ui_init)
     }
 
     // FIXME: make this pub?
@@ -503,13 +508,14 @@ impl Window {
         width: u32,
         height: u32,
         setup: Option<CanvasSetup>,
-    ) -> Window {
+        ui_init: Ui::Init,
+    ) -> Self {
         let (event_send, event_receive) = mpsc::channel();
         let canvas = Canvas::open(title, hide, width, height, setup, event_send);
 
         init_gl();
 
-        let mut usr_window = Window {
+        let mut usr_window = Self {
             should_close: false,
             max_dur_per_frame: None,
             canvas: canvas,
@@ -523,8 +529,6 @@ impl Window {
             planar_line_renderer: PlanarLineRenderer::new(),
             point_renderer: PointRenderer::new(),
             text_renderer: TextRenderer::new(),
-            #[cfg(feature = "conrod")]
-            conrod_context: ConrodContext::new(width as f64, height as f64),
             post_process_render_target: FramebufferManager::new_render_target(
                 width as usize,
                 height as usize,
@@ -538,6 +542,7 @@ impl Window {
                 Point3::new(0.0f32, 0.0, -1.0),
                 Point3::origin(),
             ))),
+            ui_context: Ui::new(width, height, ui_init),
         };
 
         if hide {
@@ -665,203 +670,10 @@ impl Window {
             _ => {}
         }
 
-        #[cfg(feature = "conrod")]
-        fn window_event_to_conrod_input(
-            event: WindowEvent,
-            size: Vector2<u32>,
-            hidpi: f64,
-        ) -> Option<conrod::event::Input> {
-            use conrod::event::Input;
-            use conrod::input::{Button, Key as CKey, Motion, MouseButton};
-
-            let transform_coords = |x: f64, y: f64| {
-                (
-                    (x - size.x as f64 / 2.0) / hidpi,
-                    -(y - size.y as f64 / 2.0) / hidpi,
-                )
-            };
-
-            match event {
-                WindowEvent::FramebufferSize(w, h) => {
-                    Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi))
-                }
-                WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
-                WindowEvent::CursorPos(x, y, _) => {
-                    let (x, y) = transform_coords(x, y);
-                    Some(Input::Motion(Motion::MouseCursor { x, y }))
-                }
-                WindowEvent::Scroll(x, y, _) => Some(Input::Motion(Motion::Scroll { x, y: -y })),
-                WindowEvent::MouseButton(button, action, _) => {
-                    let button = match button {
-                        crate::event::MouseButton::Button1 => MouseButton::Left,
-                        crate::event::MouseButton::Button2 => MouseButton::Right,
-                        crate::event::MouseButton::Button3 => MouseButton::Middle,
-                        crate::event::MouseButton::Button4 => MouseButton::X1,
-                        crate::event::MouseButton::Button5 => MouseButton::X2,
-                        crate::event::MouseButton::Button6 => MouseButton::Button6,
-                        crate::event::MouseButton::Button7 => MouseButton::Button7,
-                        crate::event::MouseButton::Button8 => MouseButton::Button8,
-                    };
-
-                    match action {
-                        Action::Press => Some(Input::Press(Button::Mouse(button))),
-                        Action::Release => Some(Input::Release(Button::Mouse(button))),
-                    }
-                }
-                WindowEvent::Key(key, action, _) => {
-                    let key = match key {
-                        Key::Key1 => CKey::D1,
-                        Key::Key2 => CKey::D2,
-                        Key::Key3 => CKey::D3,
-                        Key::Key4 => CKey::D4,
-                        Key::Key5 => CKey::D5,
-                        Key::Key6 => CKey::D6,
-                        Key::Key7 => CKey::D7,
-                        Key::Key8 => CKey::D8,
-                        Key::Key9 => CKey::D9,
-                        Key::Key0 => CKey::D0,
-                        Key::A => CKey::A,
-                        Key::B => CKey::B,
-                        Key::C => CKey::C,
-                        Key::D => CKey::D,
-                        Key::E => CKey::E,
-                        Key::F => CKey::F,
-                        Key::G => CKey::G,
-                        Key::H => CKey::H,
-                        Key::I => CKey::I,
-                        Key::J => CKey::J,
-                        Key::K => CKey::K,
-                        Key::L => CKey::L,
-                        Key::M => CKey::M,
-                        Key::N => CKey::N,
-                        Key::O => CKey::O,
-                        Key::P => CKey::P,
-                        Key::Q => CKey::Q,
-                        Key::R => CKey::R,
-                        Key::S => CKey::S,
-                        Key::T => CKey::T,
-                        Key::U => CKey::U,
-                        Key::V => CKey::V,
-                        Key::W => CKey::W,
-                        Key::X => CKey::X,
-                        Key::Y => CKey::Y,
-                        Key::Z => CKey::Z,
-                        Key::Escape => CKey::Escape,
-                        Key::F1 => CKey::F1,
-                        Key::F2 => CKey::F2,
-                        Key::F3 => CKey::F3,
-                        Key::F4 => CKey::F4,
-                        Key::F5 => CKey::F5,
-                        Key::F6 => CKey::F6,
-                        Key::F7 => CKey::F7,
-                        Key::F8 => CKey::F8,
-                        Key::F9 => CKey::F9,
-                        Key::F10 => CKey::F10,
-                        Key::F11 => CKey::F11,
-                        Key::F12 => CKey::F12,
-                        Key::F13 => CKey::F13,
-                        Key::F14 => CKey::F14,
-                        Key::F15 => CKey::F15,
-                        Key::F16 => CKey::F16,
-                        Key::F17 => CKey::F17,
-                        Key::F18 => CKey::F18,
-                        Key::F19 => CKey::F19,
-                        Key::F20 => CKey::F20,
-                        Key::F21 => CKey::F21,
-                        Key::F22 => CKey::F22,
-                        Key::F23 => CKey::F23,
-                        Key::F24 => CKey::F24,
-                        Key::Pause => CKey::Pause,
-                        Key::Insert => CKey::Insert,
-                        Key::Home => CKey::Home,
-                        Key::Delete => CKey::Delete,
-                        Key::End => CKey::End,
-                        Key::PageDown => CKey::PageDown,
-                        Key::PageUp => CKey::PageUp,
-                        Key::Left => CKey::Left,
-                        Key::Up => CKey::Up,
-                        Key::Right => CKey::Right,
-                        Key::Down => CKey::Down,
-                        Key::Return => CKey::Return,
-                        Key::Space => CKey::Space,
-                        Key::Caret => CKey::Caret,
-                        Key::Numpad0 => CKey::NumPad0,
-                        Key::Numpad1 => CKey::NumPad1,
-                        Key::Numpad2 => CKey::NumPad2,
-                        Key::Numpad3 => CKey::NumPad3,
-                        Key::Numpad4 => CKey::NumPad4,
-                        Key::Numpad5 => CKey::NumPad5,
-                        Key::Numpad6 => CKey::NumPad6,
-                        Key::Numpad7 => CKey::NumPad7,
-                        Key::Numpad8 => CKey::NumPad8,
-                        Key::Numpad9 => CKey::NumPad9,
-                        Key::Add => CKey::Plus,
-                        Key::At => CKey::At,
-                        Key::Backslash => CKey::Backslash,
-                        Key::Calculator => CKey::Calculator,
-                        Key::Colon => CKey::Colon,
-                        Key::Comma => CKey::Comma,
-                        Key::Equals => CKey::Equals,
-                        Key::LBracket => CKey::LeftBracket,
-                        Key::LControl => CKey::LCtrl,
-                        Key::LShift => CKey::LShift,
-                        Key::Mail => CKey::Mail,
-                        Key::MediaSelect => CKey::MediaSelect,
-                        Key::Minus => CKey::Minus,
-                        Key::Mute => CKey::Mute,
-                        Key::NumpadComma => CKey::NumPadComma,
-                        Key::NumpadEnter => CKey::NumPadEnter,
-                        Key::NumpadEquals => CKey::NumPadEquals,
-                        Key::Period => CKey::Period,
-                        Key::Power => CKey::Power,
-                        Key::RAlt => CKey::RAlt,
-                        Key::RBracket => CKey::RightBracket,
-                        Key::RControl => CKey::RCtrl,
-                        Key::RShift => CKey::RShift,
-                        Key::Semicolon => CKey::Semicolon,
-                        Key::Slash => CKey::Slash,
-                        Key::Sleep => CKey::Sleep,
-                        Key::Stop => CKey::Stop,
-                        Key::Tab => CKey::Tab,
-                        Key::VolumeDown => CKey::VolumeDown,
-                        Key::VolumeUp => CKey::VolumeUp,
-                        Key::Copy => CKey::Copy,
-                        Key::Paste => CKey::Paste,
-                        Key::Cut => CKey::Cut,
-                        _ => CKey::Unknown,
-                    };
-
-                    match action {
-                        Action::Press => Some(Input::Press(Button::Keyboard(key))),
-                        Action::Release => Some(Input::Release(Button::Keyboard(key))),
-                    }
-                }
-                _ => None,
-            }
-        }
-
-        #[cfg(feature = "conrod")]
         {
             let (size, hidpi) = (self.size(), self.hidpi_factor());
-            let conrod_ui = self.conrod_ui_mut();
-            if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
-                conrod_ui.handle_event(input);
-            }
-
-            let state = &conrod_ui.global_input().current;
-            let window_id = Some(conrod_ui.window);
-
-            if event.is_keyboard_event()
-                && state.widget_capturing_keyboard.is_some()
-                && state.widget_capturing_keyboard != window_id
-            {
-                return;
-            }
-
-            if event.is_mouse_event()
-                && state.widget_capturing_mouse.is_some()
-                && state.widget_capturing_mouse != window_id
-            {
+            let is_handled = self.ui_context.handle_event(event, size, hidpi);
+            if is_handled {
                 return;
             }
         }
@@ -878,17 +690,17 @@ impl Window {
     }
 
     /// Runs the render and event loop until the window is closed.
-    pub fn render_loop<S: State>(mut self, mut state: S) {
+    pub fn render_loop<S: State<Ui>>(mut self, mut state: S) {
         Canvas::render_loop(move |_| self.do_render_with_state(&mut state))
     }
 
     /// Render one frame using the specified state.
     #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
-    pub fn render_with_state<S: State>(&mut self, state: &mut S) -> bool {
+    pub fn render_with_state<S: State<Ui>>(&mut self, state: &mut S) -> bool {
         self.do_render_with_state(state)
     }
 
-    fn do_render_with_state<S: State>(&mut self, state: &mut S) -> bool {
+    fn do_render_with_state<S: State<Ui>>(&mut self, state: &mut S) -> bool {
         {
             let (camera, planar_camera, renderer, effect) = state.cameras_and_effect_and_renderer();
             self.should_close = !self.do_render_with(camera, planar_camera, renderer, effect);
@@ -1074,13 +886,7 @@ impl Window {
         }
 
         self.text_renderer.render(w as f32, h as f32);
-        #[cfg(feature = "conrod")]
-        self.conrod_context.renderer.render(
-            w as f32,
-            h as f32,
-            self.canvas.hidpi_factor() as f32,
-            &self.conrod_context.textures,
-        );
+        self.ui_context.render(w, h, self.canvas.hidpi_factor());
 
         // We are done: swap buffers
         self.canvas.swap_buffers();


### PR DESCRIPTION
This implements a hacky and incomplete `iced_native` UI support built on top the generic version of PR #233.

A short write-up on this PR:

- A lot of code was adapted from the [`iced_glow` implementation](https://github.com/hecrj/iced/tree/4030326a352c365a282980aa2a37d549f4b659ae/glow/src), some unmodified
- The `glow::Context` is obtained in a hackish way from Kiss3d (this would be a non-issue if Kiss3d switches to `glow` in the future as in the `web-sys` branch)
- Kiss3d assumes a single VAO but the `iced_glow` `rect.rs` implementation uses its own VAO, so extra code had to be added to have Kiss3d rebind its VAO
- The code flow and demo example mostly follows `iced`'s [`integration` example](https://github.com/hecrj/iced/tree/4030326a352c365a282980aa2a37d549f4b659ae/examples/integration)
- `iced_native` does not handle input events in a way that can support integration well (hecrj/iced#408), which means there is currently no way to tell whether an `iced` widget are capturing the mouse or keyboard and there is no way to determine whether the input events are unhandled by `iced`.