### PR TITLE
(web-sys) Update to glow 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "wasm-bindgen" ]}
 conrod_core  = { version = "0.70", features = [ "wasm-bindgen" ], optional = true }
-glow         = "0.4"
+glow = "0.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = "0.19"

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -247,7 +247,7 @@ impl ConrodRenderer {
 
             if render {
                 let (x, y, w, h) = rect_to_gl_rect(curr_scizzor);
-                ctxt.scissor(x as i32, y as i32, w as i32, h as i32);
+                verify!(ctxt.scissor(x as i32, y as i32, w as i32, h as i32));
                 match mode {
                     RenderMode::Shape => {
                         self.triangle_shader.use_program();
@@ -578,7 +578,7 @@ impl ConrodRenderer {
 
         verify!(ctxt.enable(Context::DEPTH_TEST));
         verify!(ctxt.disable(Context::BLEND));
-        ctxt.scissor(0, 0, width as i32, height as i32);
+        verify!(ctxt.scissor(0, 0, width as i32, height as i32));
     }
 }
 

--- a/src/resource/effect.rs
+++ b/src/resource/effect.rs
@@ -90,13 +90,13 @@ impl Effect {
 impl Drop for Effect {
     fn drop(&mut self) {
         let ctxt = Context::get();
-        if ctxt.is_program(Some(&self.program)) {
+        if verify!(ctxt.is_program(Some(&self.program))) {
             verify!(ctxt.delete_program(Some(&self.program)));
         }
-        if ctxt.is_shader(Some(&self.fshader)) {
+        if verify!(ctxt.is_shader(Some(&self.fshader))) {
             verify!(ctxt.delete_shader(Some(&self.fshader)));
         }
-        if ctxt.is_shader(Some(&self.vshader)) {
+        if verify!(ctxt.is_shader(Some(&self.vshader))) {
             verify!(ctxt.delete_shader(Some(&self.vshader)));
         }
     }

--- a/src/resource/framebuffer_manager.rs
+++ b/src/resource/framebuffer_manager.rs
@@ -288,7 +288,7 @@ impl FramebufferManager {
 impl Drop for FramebufferManager {
     fn drop(&mut self) {
         let ctxt = Context::get();
-        if ctxt.is_framebuffer(Some(&self.fbo)) {
+        if verify!(ctxt.is_framebuffer(Some(&self.fbo))) {
             verify!(ctxt.bind_framebuffer(Context::FRAMEBUFFER, None));
             verify!(ctxt.delete_framebuffer(Some(&self.fbo)));
         }
@@ -298,18 +298,18 @@ impl Drop for FramebufferManager {
 impl Drop for OffscreenBuffers {
     fn drop(&mut self) {
         let ctxt = Context::get();
-        if ctxt.is_texture(Some(&self.texture)) {
+        if verify!(ctxt.is_texture(Some(&self.texture))) {
             verify!(ctxt.delete_texture(Some(&self.texture)));
         }
 
         match &self.depth {
             Either::Left(texture) => {
-                if ctxt.is_texture(Some(texture)) {
+                if verify!(ctxt.is_texture(Some(texture))) {
                     verify!(ctxt.delete_texture(Some(texture)));
                 }
             }
             Either::Right(renderbuffer) => {
-                if ctxt.is_renderbuffer(Some(renderbuffer)) {
+                if verify!(ctxt.is_renderbuffer(Some(renderbuffer))) {
                     verify!(ctxt.delete_renderbuffer(Some(renderbuffer)));
                 }
             }

--- a/src/resource/texture_manager.rs
+++ b/src/resource/texture_manager.rs
@@ -64,7 +64,7 @@ impl Drop for Texture {
     fn drop(&mut self) {
         unsafe {
             let ctxt = Context::get();
-            if ctxt.is_texture(Some(self)) {
+            if verify!(ctxt.is_texture(Some(self))) {
                 verify!(Context::get().delete_texture(Some(self)));
             }
         }

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -48,7 +48,7 @@ impl AbstractCanvas for GLCanvas {
             });
         let window = GlWindow::new(window, context, &events).unwrap();
         let _ = unsafe { window.make_current().unwrap() };
-        Context::init(|| {
+        Context::init(|| unsafe {
             glow::Context::from_loader_function(|name| {
                 window.context().get_proc_address(name) as *const _
             })

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -65,7 +65,6 @@ impl ConrodContext {
 pub struct Window {
     events: Rc<Receiver<WindowEvent>>,
     unhandled_events: Rc<RefCell<Vec<WindowEvent>>>,
-    canvas: Canvas,
     max_dur_per_frame: Option<Duration>,
     scene: SceneNode,
     scene2: PlanarSceneNode,
@@ -84,6 +83,7 @@ pub struct Window {
     should_close: bool,
     #[cfg(feature = "conrod")]
     conrod_context: ConrodContext,
+    canvas: Canvas,
 }
 
 impl Window {


### PR DESCRIPTION
- Fix glow API changes
- Added a few `verify!` calls
- Move `Window::canvas` field to the end so that the GlWindow will not
  be dropped before other structs that requires the OpenGL Context in
  their `Drop` impl.

Note that the last point is necessary because Kiss3d currently uses a "global" OpenGL context, as otherwise one may get a `GL_INVALID_OPERATION` or even a segfault when closing the Kiss3d window.

Depends on grovesNL/glow#118.

(For #241)