### PR TITLE
Bump the dependencies we can.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,18 @@ either       = "1"
 libc         = "0.2"
 bitflags     = "1.2"
 num-traits   = "0.2"
-nalgebra     = "0.22"
-ncollide3d   = "0.25"
-image        = "0.22"
+nalgebra     = "0.23"
+ncollide3d   = "0.26"
+image        = "0.23"
 serde        = "1"
 serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "wasm-bindgen" ]}
-conrod_core  = { version = "0.70", features = [ "wasm-bindgen" ], optional = true }
+conrod_core  = { version = "0.71", features = [ "wasm-bindgen" ], optional = true }
 glow = "0.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = "0.19"
+glutin = "0.21"
 
 # We repeat all three targets instead of any(target_arch = "wasm32", target_arch = "asmjs")
 # to avoid https://github.com/koute/stdweb/issues/135
@@ -60,4 +60,4 @@ web-sys = { version = "0.3", features = [ "console", "KeyEvent", "KeyboardEvent"
 
 [dev-dependencies]
 rand = "0.7"
-ncollide2d = "0.25"
+ncollide2d = "0.26"

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -5,8 +5,8 @@ use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent
 use crate::window::canvas::{CanvasSetup, NumSamples};
 use crate::window::AbstractCanvas;
 use glutin::{
-    self, dpi::LogicalSize, ContextBuilder, EventsLoop, GlRequest, TouchPhase,
-    WindowBuilder, WindowedContext, PossiblyCurrent
+    self, dpi::LogicalSize, ContextBuilder, EventsLoop, GlRequest, PossiblyCurrent, TouchPhase,
+    WindowBuilder, WindowedContext,
 };
 use image::{GenericImage, Pixel};
 
@@ -46,12 +46,11 @@ impl AbstractCanvas for GLCanvas {
                 opengl_version: (3, 2),
                 opengles_version: (2, 0),
             })
-            .build_windowed(window, &events).unwrap();
+            .build_windowed(window, &events)
+            .unwrap();
         let window = unsafe { window.make_current().unwrap() };
         Context::init(|| unsafe {
-            glow::Context::from_loader_function(|name| {
-                window.get_proc_address(name) as *const _
-            })
+            glow::Context::from_loader_function(|name| window.get_proc_address(name) as *const _)
         });
 
         let ctxt = Context::get();
@@ -208,9 +207,11 @@ impl AbstractCanvas for GLCanvas {
 
     fn set_cursor_position(&self, x: f64, y: f64) {
         let dpi = self.window.window().get_hidpi_factor();
-        self.window.window().set_cursor_position(glutin::dpi::LogicalPosition::new(x / dpi, y / dpi)).unwrap();
+        self.window
+            .window()
+            .set_cursor_position(glutin::dpi::LogicalPosition::new(x / dpi, y / dpi))
+            .unwrap();
     }
-
 
     fn hide_cursor(&self, hide: bool) {
         self.window.window().hide_cursor(hide);

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -487,6 +487,14 @@ impl AbstractCanvas for WebGLCanvas {
         // Not supported.
     }
 
+    fn set_cursor_position(&self, _: f64, _: f64) {
+        // Not supported.
+    }
+
+    fn hide_cursor(&self, _: bool) {
+        // Not supported.
+    }
+
     fn hide(&mut self) {
         // Not supported.
     }

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -112,7 +112,6 @@ impl Window {
         Vector2::new(w, h)
     }
 
-
     /// Sets the maximum number of frames per second. Cannot be 0. `None` means there is no limit.
     #[inline]
     pub fn set_framerate_limit(&mut self, fps: Option<u64>) {


### PR DESCRIPTION
This updates some of our dependencies. However:
- We don't use the latest version of `winit` because it no longer have the `poll_events` method. This would require significant changes in our event loop system. So updating winit should be done on its own PR.
- We don't use the latest version of `rusttype` because `conrod` still depends on the older one.