### PR TITLE
Migrate to glutin 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ conrod_core  = { version = "0.71", features = [ "wasm-bindgen" ], optional = tru
 glow = "0.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = "0.21"
+glutin = "0.25"
 
 # We repeat all three targets instead of any(target_arch = "wasm32", target_arch = "asmjs")
 # to avoid https://github.com/koute/stdweb/issues/135

--- a/src/planar_camera/fixed_view.rs
+++ b/src/planar_camera/fixed_view.rs
@@ -24,13 +24,13 @@ impl FixedView {
 
 impl PlanarCamera for FixedView {
     fn handle_event(&mut self, canvas: &Canvas, event: &WindowEvent) {
-        let hidpi = canvas.hidpi_factor();
+        let scale = canvas.scale_factor();
 
         match *event {
             WindowEvent::FramebufferSize(w, h) => {
                 let diag = Vector3::new(
-                    2.0 * (hidpi as f32) / (w as f32),
-                    2.0 * (hidpi as f32) / (h as f32),
+                    2.0 * (scale as f32) / (w as f32),
+                    2.0 * (scale as f32) / (h as f32),
                     1.0,
                 );
                 let inv_diag = Vector3::new(1.0 / diag.x, 1.0 / diag.y, 1.0);

--- a/src/planar_camera/sidescroll.rs
+++ b/src/planar_camera/sidescroll.rs
@@ -120,7 +120,7 @@ impl Sidescroll {
 
 impl PlanarCamera for Sidescroll {
     fn handle_event(&mut self, canvas: &Canvas, event: &WindowEvent) {
-        let hidpi = 1.0; // canvas.hidpi_factor();
+        let scale = 1.0; // canvas.scale_factor();
 
         match *event {
             WindowEvent::CursorPos(x, y, _) => {
@@ -138,11 +138,11 @@ impl PlanarCamera for Sidescroll {
             WindowEvent::Scroll(_, off, _) => self.handle_scroll(off as f32),
             WindowEvent::FramebufferSize(w, h) => {
                 self.proj = Matrix3::new(
-                    2.0 * (hidpi as f32) / (w as f32),
+                    2.0 * (scale as f32) / (w as f32),
                     0.0,
                     0.0,
                     0.0,
-                    2.0 * (hidpi as f32) / (h as f32),
+                    2.0 * (scale as f32) / (h as f32),
                     0.0,
                     0.0,
                     0.0,

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -174,14 +174,14 @@ impl ConrodRenderer {
         &mut self,
         width: f32,
         height: f32,
-        hidpi_factor: f32,
+        scale_factor: f32,
         texture_map: &conrod::image::Map<(Rc<Texture>, (u32, u32))>,
     ) {
         // NOTE: this seems necessary for WASM.
         if !self.resized_once {
             self.ui.handle_event(conrod::event::Input::Resize(
-                width as f64 / hidpi_factor as f64,
-                height as f64 / hidpi_factor as f64,
+                width as f64 / scale_factor as f64,
+                height as f64 / scale_factor as f64,
             ));
             self.resized_once = true;
         }
@@ -207,10 +207,10 @@ impl ConrodRenderer {
 
         let rect_to_gl_rect = |rect: Rect| {
             let (w, h) = rect.w_h();
-            let l = rect.left() as f32 * hidpi_factor + width / 2.0;
-            let b = rect.bottom() as f32 * hidpi_factor + height / 2.0;
-            let w = w as f32 * hidpi_factor;
-            let h = h as f32 * hidpi_factor;
+            let l = rect.left() as f32 * scale_factor + width / 2.0;
+            let b = rect.bottom() as f32 * scale_factor + height / 2.0;
+            let w = w as f32 * scale_factor;
+            let h = h as f32 * scale_factor;
 
             (l.max(0.0), b.max(0.0), w.min(width), h.min(height))
         };
@@ -360,26 +360,26 @@ impl ConrodRenderer {
                     let tr = (primitive.rect.x.end, primitive.rect.y.end);
 
                     vertices.extend_from_slice(&[
-                        tl.0 as f32 * hidpi_factor,
-                        tl.1 as f32 * hidpi_factor,
+                        tl.0 as f32 * scale_factor,
+                        tl.1 as f32 * scale_factor,
                         color.0,
                         color.1,
                         color.2,
                         color.3,
-                        bl.0 as f32 * hidpi_factor,
-                        bl.1 as f32 * hidpi_factor,
+                        bl.0 as f32 * scale_factor,
+                        bl.1 as f32 * scale_factor,
                         color.0,
                         color.1,
                         color.2,
                         color.3,
-                        br.0 as f32 * hidpi_factor,
-                        br.1 as f32 * hidpi_factor,
+                        br.0 as f32 * scale_factor,
+                        br.1 as f32 * scale_factor,
                         color.0,
                         color.1,
                         color.2,
                         color.3,
-                        tr.0 as f32 * hidpi_factor,
-                        tr.1 as f32 * hidpi_factor,
+                        tr.0 as f32 * scale_factor,
+                        tr.1 as f32 * scale_factor,
                         color.0,
                         color.1,
                         color.2,
@@ -398,20 +398,20 @@ impl ConrodRenderer {
                         let pts = triangle.points();
 
                         vertices.extend_from_slice(&[
-                            pts[0][0] as f32 * hidpi_factor,
-                            pts[0][1] as f32 * hidpi_factor,
+                            pts[0][0] as f32 * scale_factor,
+                            pts[0][1] as f32 * scale_factor,
                             color.0,
                             color.1,
                             color.2,
                             color.3,
-                            pts[1][0] as f32 * hidpi_factor,
-                            pts[1][1] as f32 * hidpi_factor,
+                            pts[1][0] as f32 * scale_factor,
+                            pts[1][1] as f32 * scale_factor,
                             color.0,
                             color.1,
                             color.2,
                             color.3,
-                            pts[2][0] as f32 * hidpi_factor,
-                            pts[2][1] as f32 * hidpi_factor,
+                            pts[2][0] as f32 * scale_factor,
+                            pts[2][1] as f32 * scale_factor,
                             color.0,
                             color.1,
                             color.2,
@@ -429,20 +429,20 @@ impl ConrodRenderer {
                         let ((a, ca), (b, cb), (c, cc)) =
                             (triangle.0[0], triangle.0[1], triangle.0[2]);
                         vertices.extend_from_slice(&[
-                            a[0] as f32 * hidpi_factor,
-                            a[1] as f32 * hidpi_factor,
+                            a[0] as f32 * scale_factor,
+                            a[1] as f32 * scale_factor,
                             ca.0,
                             ca.1,
                             ca.2,
                             ca.3,
-                            b[0] as f32 * hidpi_factor,
-                            b[1] as f32 * hidpi_factor,
+                            b[0] as f32 * scale_factor,
+                            b[1] as f32 * scale_factor,
                             cb.0,
                             cb.1,
                             cb.2,
                             cb.3,
-                            c[0] as f32 * hidpi_factor,
-                            c[1] as f32 * hidpi_factor,
+                            c[0] as f32 * scale_factor,
+                            c[1] as f32 * scale_factor,
                             cc.0,
                             cc.1,
                             cc.2,
@@ -465,10 +465,10 @@ impl ConrodRenderer {
                             texture: image_id,
                         };
 
-                        let min_px = primitive.rect.x.start as f32 * hidpi_factor;
-                        let min_py = primitive.rect.y.start as f32 * hidpi_factor;
-                        let max_px = primitive.rect.x.end as f32 * hidpi_factor;
-                        let max_py = primitive.rect.y.end as f32 * hidpi_factor;
+                        let min_px = primitive.rect.x.start as f32 * scale_factor;
+                        let min_py = primitive.rect.y.start as f32 * scale_factor;
+                        let max_px = primitive.rect.x.end as f32 * scale_factor;
+                        let max_py = primitive.rect.y.end as f32 * scale_factor;
 
                         let w = (texture.1).0 as f64;
                         let h = (texture.1).1 as f64;
@@ -534,7 +534,7 @@ impl ConrodRenderer {
                     /*
                      * Update the text image.
                      */
-                    let positioned_glyphs = text.positioned_glyphs(hidpi_factor);
+                    let positioned_glyphs = text.positioned_glyphs(scale_factor);
                     for glyph in positioned_glyphs.iter() {
                         self.cache.queue_glyph(font_id.index(), glyph.clone());
                     }

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -97,9 +97,9 @@ impl Canvas {
         self.canvas.cursor_pos()
     }
 
-    /// The high-dpi factor.
-    pub fn hidpi_factor(&self) -> f64 {
-        self.canvas.hidpi_factor()
+    /// The scale factor.
+    pub fn scale_factor(&self) -> f64 {
+        self.canvas.scale_factor()
     }
 
     /// Set the window title.
@@ -160,7 +160,7 @@ pub(crate) trait AbstractCanvas {
     fn swap_buffers(&mut self);
     fn size(&self) -> (u32, u32);
     fn cursor_pos(&self) -> Option<(f64, f64)>;
-    fn hidpi_factor(&self) -> f64;
+    fn scale_factor(&self) -> f64;
 
     fn set_title(&mut self, title: &str);
     fn set_icon(&mut self, icon: impl GenericImage<Pixel = impl Pixel<Subpixel = u8>>);

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -5,15 +5,20 @@ use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent
 use crate::window::canvas::{CanvasSetup, NumSamples};
 use crate::window::AbstractCanvas;
 use glutin::{
-    self, dpi::LogicalSize, ContextBuilder, EventsLoop, GlRequest, PossiblyCurrent, TouchPhase,
-    WindowBuilder, WindowedContext,
+    self,
+    dpi::LogicalSize,
+    event::TouchPhase,
+    event_loop::{ControlFlow, EventLoop},
+    platform::desktop::EventLoopExtDesktop,
+    window::WindowBuilder,
+    ContextBuilder, GlRequest, PossiblyCurrent, WindowedContext,
 };
 use image::{GenericImage, Pixel};
 
 /// A canvas based on glutin and OpenGL.
 pub struct GLCanvas {
     window: WindowedContext<PossiblyCurrent>,
-    events: EventsLoop,
+    events: EventLoop<()>,
     cursor_pos: Option<(f64, f64)>,
     key_states: [Action; Key::Unknown as usize + 1],
     button_states: [Action; MouseButton::Button8 as usize + 1],
@@ -30,11 +35,11 @@ impl AbstractCanvas for GLCanvas {
         canvas_setup: Option<CanvasSetup>,
         out_events: Sender<WindowEvent>,
     ) -> Self {
-        let events = EventsLoop::new();
+        let events = EventLoop::new();
         let window = WindowBuilder::new()
             .with_title(title)
-            .with_dimensions(LogicalSize::new(width as f64, height as f64))
-            .with_visibility(!hide);
+            .with_inner_size(LogicalSize::new(width as f64, height as f64))
+            .with_visible(!hide);
         let canvas_setup = canvas_setup.unwrap_or(CanvasSetup {
             vsync: true,
             samples: NumSamples::Zero,
@@ -82,86 +87,87 @@ impl AbstractCanvas for GLCanvas {
         let key_states = &mut self.key_states;
         let cursor_pos = &mut self.cursor_pos;
 
-        self.events.poll_events(|event| match event {
-            glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::CloseRequested => {
-                    let _ = out_events.send(WindowEvent::Close);
-                }
-                glutin::WindowEvent::Resized(logical_size) => {
-                    let dpi_factor = window.window().get_hidpi_factor();
-                    let physical_size = logical_size.to_physical(dpi_factor);
-                    window.resize(physical_size);
-                    let fb_size: (u32, u32) = physical_size.into();
-                    let _ = out_events.send(WindowEvent::FramebufferSize(fb_size.0, fb_size.1));
-                }
-                glutin::WindowEvent::CursorMoved {
-                    position,
-                    modifiers,
-                    ..
-                } => {
-                    let modifiers = translate_modifiers(modifiers);
-                    let dpi_factor = window.window().get_hidpi_factor();
-                    let physical_pos = position.to_physical(dpi_factor);
-                    *cursor_pos = Some(physical_pos.into());
-                    let _ = out_events.send(WindowEvent::CursorPos(
-                        physical_pos.x,
-                        physical_pos.y,
-                        modifiers,
-                    ));
-                }
-                glutin::WindowEvent::MouseInput {
-                    state,
-                    button,
-                    modifiers,
-                    ..
-                } => {
-                    let action = translate_action(state);
-                    let button = translate_mouse_button(button);
-                    let modifiers = translate_modifiers(modifiers);
-                    button_states[button as usize] = action;
-                    let _ = out_events.send(WindowEvent::MouseButton(button, action, modifiers));
-                }
-                glutin::WindowEvent::Touch(touch) => {
-                    let action = match touch.phase {
-                        TouchPhase::Started => TouchAction::Start,
-                        TouchPhase::Ended => TouchAction::End,
-                        TouchPhase::Moved => TouchAction::Move,
-                        TouchPhase::Cancelled => TouchAction::Cancel,
-                    };
+        self.events.run_return(|event, _, control_flow| {
+            use glutin::event::Event;
 
-                    let _ = out_events.send(WindowEvent::Touch(
-                        touch.id,
-                        touch.location.x,
-                        touch.location.y,
-                        action,
-                        Modifiers::empty(),
-                    ));
-                }
-                glutin::WindowEvent::MouseWheel {
-                    delta, modifiers, ..
-                } => {
-                    let (x, y) = match delta {
-                        glutin::MouseScrollDelta::LineDelta(dx, dy) => {
-                            (dx as f64 * 10.0, dy as f64 * 10.0)
-                        }
-                        glutin::MouseScrollDelta::PixelDelta(delta) => delta.into(),
-                    };
-                    let modifiers = translate_modifiers(modifiers);
-                    let _ = out_events.send(WindowEvent::Scroll(x, y, modifiers));
-                }
-                glutin::WindowEvent::KeyboardInput { input, .. } => {
-                    let action = translate_action(input.state);
-                    let key = translate_key(input.virtual_keycode);
-                    let modifiers = translate_modifiers(input.modifiers);
-                    key_states[key as usize] = action;
-                    let _ = out_events.send(WindowEvent::Key(key, action, modifiers));
-                }
-                glutin::WindowEvent::ReceivedCharacter(c) => {
-                    let _ = out_events.send(WindowEvent::Char(c));
+            match event {
+                Event::WindowEvent { event, .. } => match event {
+                    glutin::event::WindowEvent::CloseRequested => {
+                        let _ = out_events.send(WindowEvent::Close);
+                    }
+                    glutin::event::WindowEvent::Resized(physical_size) => {
+                        window.resize(physical_size);
+                        let fb_size: (u32, u32) = physical_size.into();
+                        let _ = out_events.send(WindowEvent::FramebufferSize(fb_size.0, fb_size.1));
+                    }
+                    glutin::event::WindowEvent::CursorMoved {
+                        position,
+                        modifiers,
+                        ..
+                    } => {
+                        let modifiers = translate_modifiers(modifiers);
+                        *cursor_pos = Some(position.into());
+                        let _ = out_events
+                            .send(WindowEvent::CursorPos(position.x, position.y, modifiers));
+                    }
+                    glutin::event::WindowEvent::MouseInput {
+                        state,
+                        button,
+                        modifiers,
+                        ..
+                    } => {
+                        let action = translate_action(state);
+                        let button = translate_mouse_button(button);
+                        let modifiers = translate_modifiers(modifiers);
+                        button_states[button as usize] = action;
+                        let _ =
+                            out_events.send(WindowEvent::MouseButton(button, action, modifiers));
+                    }
+                    glutin::event::WindowEvent::Touch(touch) => {
+                        let action = match touch.phase {
+                            TouchPhase::Started => TouchAction::Start,
+                            TouchPhase::Ended => TouchAction::End,
+                            TouchPhase::Moved => TouchAction::Move,
+                            TouchPhase::Cancelled => TouchAction::Cancel,
+                        };
+
+                        let _ = out_events.send(WindowEvent::Touch(
+                            touch.id,
+                            touch.location.x,
+                            touch.location.y,
+                            action,
+                            Modifiers::empty(),
+                        ));
+                    }
+                    glutin::event::WindowEvent::MouseWheel {
+                        delta, modifiers, ..
+                    } => {
+                        let (x, y) = match delta {
+                            glutin::event::MouseScrollDelta::LineDelta(dx, dy) => {
+                                (dx as f64 * 10.0, dy as f64 * 10.0)
+                            }
+                            glutin::event::MouseScrollDelta::PixelDelta(delta) => delta.into(),
+                        };
+                        let modifiers = translate_modifiers(modifiers);
+                        let _ = out_events.send(WindowEvent::Scroll(x, y, modifiers));
+                    }
+                    glutin::event::WindowEvent::KeyboardInput { input, .. } => {
+                        let action = translate_action(input.state);
+                        let key = translate_key(input.virtual_keycode);
+                        let modifiers = translate_modifiers(input.modifiers);
+                        key_states[key as usize] = action;
+                        let _ = out_events.send(WindowEvent::Key(key, action, modifiers));
+                    }
+                    glutin::event::WindowEvent::ReceivedCharacter(c) => {
+                        let _ = out_events.send(WindowEvent::Char(c));
+                    }
+                    _ => {}
+                },
+                Event::RedrawEventsCleared => {
+                    *control_flow = ControlFlow::Exit;
                 }
                 _ => {}
-            },
-            _ => {}
+            };
         })
     }
 
@@ -170,21 +176,15 @@ impl AbstractCanvas for GLCanvas {
     }
 
     fn size(&self) -> (u32, u32) {
-        let hidpi = self.window.window().get_hidpi_factor();
-        let logical_size = self
-            .window
-            .window()
-            .get_inner_size()
-            .expect("The window was closed.");
-        logical_size.to_physical(hidpi).into()
+        self.window.window().inner_size().into()
     }
 
     fn cursor_pos(&self) -> Option<(f64, f64)> {
         self.cursor_pos
     }
 
-    fn hidpi_factor(&self) -> f64 {
-        self.window.window().get_hidpi_factor() as f64
+    fn scale_factor(&self) -> f64 {
+        self.window.window().scale_factor() as f64
     }
 
     fn set_title(&mut self, title: &str) {
@@ -197,32 +197,31 @@ impl AbstractCanvas for GLCanvas {
         for (_, _, pixel) in icon.pixels() {
             rgba.extend_from_slice(&pixel.to_rgba().0);
         }
-        let icon = glutin::Icon::from_rgba(rgba, width, height).unwrap();
+        let icon = glutin::window::Icon::from_rgba(rgba, width, height).unwrap();
         self.window.window().set_window_icon(Some(icon))
     }
 
     fn set_cursor_grab(&self, grab: bool) {
-        let _ = self.window.window().grab_cursor(grab);
+        let _ = self.window.window().set_cursor_grab(grab);
     }
 
     fn set_cursor_position(&self, x: f64, y: f64) {
-        let dpi = self.window.window().get_hidpi_factor();
         self.window
             .window()
-            .set_cursor_position(glutin::dpi::LogicalPosition::new(x / dpi, y / dpi))
+            .set_cursor_position(glutin::dpi::PhysicalPosition::new(x, y))
             .unwrap();
     }
 
     fn hide_cursor(&self, hide: bool) {
-        self.window.window().hide_cursor(hide);
+        self.window.window().set_cursor_visible(!hide)
     }
 
     fn hide(&mut self) {
-        self.window.window().hide()
+        self.window.window().set_visible(false)
     }
 
     fn show(&mut self) {
-        self.window.window().show()
+        self.window.window().set_visible(true)
     }
 
     fn get_mouse_button(&self, button: MouseButton) -> Action {
@@ -233,204 +232,206 @@ impl AbstractCanvas for GLCanvas {
     }
 }
 
-fn translate_action(action: glutin::ElementState) -> Action {
+fn translate_action(action: glutin::event::ElementState) -> Action {
     match action {
-        glutin::ElementState::Pressed => Action::Press,
-        glutin::ElementState::Released => Action::Release,
+        glutin::event::ElementState::Pressed => Action::Press,
+        glutin::event::ElementState::Released => Action::Release,
     }
 }
 
-fn translate_modifiers(modifiers: glutin::ModifiersState) -> Modifiers {
+fn translate_modifiers(modifiers: glutin::event::ModifiersState) -> Modifiers {
     let mut res = Modifiers::empty();
-    if modifiers.shift {
+    if modifiers.shift() {
         res.insert(Modifiers::Shift)
     }
-    if modifiers.ctrl {
+    if modifiers.ctrl() {
         res.insert(Modifiers::Control)
     }
-    if modifiers.alt {
+    if modifiers.alt() {
         res.insert(Modifiers::Alt)
     }
-    if modifiers.logo {
+    if modifiers.logo() {
         res.insert(Modifiers::Super)
     }
 
     res
 }
 
-fn translate_mouse_button(button: glutin::MouseButton) -> MouseButton {
+fn translate_mouse_button(button: glutin::event::MouseButton) -> MouseButton {
     match button {
-        glutin::MouseButton::Left => MouseButton::Button1,
-        glutin::MouseButton::Right => MouseButton::Button2,
-        glutin::MouseButton::Middle => MouseButton::Button3,
-        glutin::MouseButton::Other(_) => MouseButton::Button4, // XXX: the default is not good.
+        glutin::event::MouseButton::Left => MouseButton::Button1,
+        glutin::event::MouseButton::Right => MouseButton::Button2,
+        glutin::event::MouseButton::Middle => MouseButton::Button3,
+        glutin::event::MouseButton::Other(_) => MouseButton::Button4, // XXX: the default is not good.
     }
 }
 
-fn translate_key(button: Option<glutin::VirtualKeyCode>) -> Key {
+fn translate_key(button: Option<glutin::event::VirtualKeyCode>) -> Key {
     if let Some(button) = button {
         match button {
-            glutin::VirtualKeyCode::Key1 => Key::Key1,
-            glutin::VirtualKeyCode::Key2 => Key::Key2,
-            glutin::VirtualKeyCode::Key3 => Key::Key3,
-            glutin::VirtualKeyCode::Key4 => Key::Key4,
-            glutin::VirtualKeyCode::Key5 => Key::Key5,
-            glutin::VirtualKeyCode::Key6 => Key::Key6,
-            glutin::VirtualKeyCode::Key7 => Key::Key7,
-            glutin::VirtualKeyCode::Key8 => Key::Key8,
-            glutin::VirtualKeyCode::Key9 => Key::Key9,
-            glutin::VirtualKeyCode::Key0 => Key::Key0,
-            glutin::VirtualKeyCode::A => Key::A,
-            glutin::VirtualKeyCode::B => Key::B,
-            glutin::VirtualKeyCode::C => Key::C,
-            glutin::VirtualKeyCode::D => Key::D,
-            glutin::VirtualKeyCode::E => Key::E,
-            glutin::VirtualKeyCode::F => Key::F,
-            glutin::VirtualKeyCode::G => Key::G,
-            glutin::VirtualKeyCode::H => Key::H,
-            glutin::VirtualKeyCode::I => Key::I,
-            glutin::VirtualKeyCode::J => Key::J,
-            glutin::VirtualKeyCode::K => Key::K,
-            glutin::VirtualKeyCode::L => Key::L,
-            glutin::VirtualKeyCode::M => Key::M,
-            glutin::VirtualKeyCode::N => Key::N,
-            glutin::VirtualKeyCode::O => Key::O,
-            glutin::VirtualKeyCode::P => Key::P,
-            glutin::VirtualKeyCode::Q => Key::Q,
-            glutin::VirtualKeyCode::R => Key::R,
-            glutin::VirtualKeyCode::S => Key::S,
-            glutin::VirtualKeyCode::T => Key::T,
-            glutin::VirtualKeyCode::U => Key::U,
-            glutin::VirtualKeyCode::V => Key::V,
-            glutin::VirtualKeyCode::W => Key::W,
-            glutin::VirtualKeyCode::X => Key::X,
-            glutin::VirtualKeyCode::Y => Key::Y,
-            glutin::VirtualKeyCode::Z => Key::Z,
-            glutin::VirtualKeyCode::Escape => Key::Escape,
-            glutin::VirtualKeyCode::F1 => Key::F1,
-            glutin::VirtualKeyCode::F2 => Key::F2,
-            glutin::VirtualKeyCode::F3 => Key::F3,
-            glutin::VirtualKeyCode::F4 => Key::F4,
-            glutin::VirtualKeyCode::F5 => Key::F5,
-            glutin::VirtualKeyCode::F6 => Key::F6,
-            glutin::VirtualKeyCode::F7 => Key::F7,
-            glutin::VirtualKeyCode::F8 => Key::F8,
-            glutin::VirtualKeyCode::F9 => Key::F9,
-            glutin::VirtualKeyCode::F10 => Key::F10,
-            glutin::VirtualKeyCode::F11 => Key::F11,
-            glutin::VirtualKeyCode::F12 => Key::F12,
-            glutin::VirtualKeyCode::F13 => Key::F13,
-            glutin::VirtualKeyCode::F14 => Key::F14,
-            glutin::VirtualKeyCode::F15 => Key::F15,
-            glutin::VirtualKeyCode::F16 => Key::F16,
-            glutin::VirtualKeyCode::F17 => Key::F17,
-            glutin::VirtualKeyCode::F18 => Key::F18,
-            glutin::VirtualKeyCode::F19 => Key::F19,
-            glutin::VirtualKeyCode::F20 => Key::F20,
-            glutin::VirtualKeyCode::F21 => Key::F21,
-            glutin::VirtualKeyCode::F22 => Key::F22,
-            glutin::VirtualKeyCode::F23 => Key::F23,
-            glutin::VirtualKeyCode::F24 => Key::F24,
-            glutin::VirtualKeyCode::Snapshot => Key::Snapshot,
-            glutin::VirtualKeyCode::Scroll => Key::Scroll,
-            glutin::VirtualKeyCode::Pause => Key::Pause,
-            glutin::VirtualKeyCode::Insert => Key::Insert,
-            glutin::VirtualKeyCode::Home => Key::Home,
-            glutin::VirtualKeyCode::Delete => Key::Delete,
-            glutin::VirtualKeyCode::End => Key::End,
-            glutin::VirtualKeyCode::PageDown => Key::PageDown,
-            glutin::VirtualKeyCode::PageUp => Key::PageUp,
-            glutin::VirtualKeyCode::Left => Key::Left,
-            glutin::VirtualKeyCode::Up => Key::Up,
-            glutin::VirtualKeyCode::Right => Key::Right,
-            glutin::VirtualKeyCode::Down => Key::Down,
-            glutin::VirtualKeyCode::Back => Key::Back,
-            glutin::VirtualKeyCode::Return => Key::Return,
-            glutin::VirtualKeyCode::Space => Key::Space,
-            glutin::VirtualKeyCode::Compose => Key::Compose,
-            glutin::VirtualKeyCode::Caret => Key::Caret,
-            glutin::VirtualKeyCode::Numlock => Key::Numlock,
-            glutin::VirtualKeyCode::Numpad0 => Key::Numpad0,
-            glutin::VirtualKeyCode::Numpad1 => Key::Numpad1,
-            glutin::VirtualKeyCode::Numpad2 => Key::Numpad2,
-            glutin::VirtualKeyCode::Numpad3 => Key::Numpad3,
-            glutin::VirtualKeyCode::Numpad4 => Key::Numpad4,
-            glutin::VirtualKeyCode::Numpad5 => Key::Numpad5,
-            glutin::VirtualKeyCode::Numpad6 => Key::Numpad6,
-            glutin::VirtualKeyCode::Numpad7 => Key::Numpad7,
-            glutin::VirtualKeyCode::Numpad8 => Key::Numpad8,
-            glutin::VirtualKeyCode::Numpad9 => Key::Numpad9,
-            glutin::VirtualKeyCode::AbntC1 => Key::AbntC1,
-            glutin::VirtualKeyCode::AbntC2 => Key::AbntC2,
-            glutin::VirtualKeyCode::Add => Key::Add,
-            glutin::VirtualKeyCode::Apostrophe => Key::Apostrophe,
-            glutin::VirtualKeyCode::Apps => Key::Apps,
-            glutin::VirtualKeyCode::At => Key::At,
-            glutin::VirtualKeyCode::Ax => Key::Ax,
-            glutin::VirtualKeyCode::Backslash => Key::Backslash,
-            glutin::VirtualKeyCode::Calculator => Key::Calculator,
-            glutin::VirtualKeyCode::Capital => Key::Capital,
-            glutin::VirtualKeyCode::Colon => Key::Colon,
-            glutin::VirtualKeyCode::Comma => Key::Comma,
-            glutin::VirtualKeyCode::Convert => Key::Convert,
-            glutin::VirtualKeyCode::Decimal => Key::Decimal,
-            glutin::VirtualKeyCode::Divide => Key::Divide,
-            glutin::VirtualKeyCode::Equals => Key::Equals,
-            glutin::VirtualKeyCode::Grave => Key::Grave,
-            glutin::VirtualKeyCode::Kana => Key::Kana,
-            glutin::VirtualKeyCode::Kanji => Key::Kanji,
-            glutin::VirtualKeyCode::LAlt => Key::LAlt,
-            glutin::VirtualKeyCode::LBracket => Key::LBracket,
-            glutin::VirtualKeyCode::LControl => Key::LControl,
-            glutin::VirtualKeyCode::LShift => Key::LShift,
-            glutin::VirtualKeyCode::LWin => Key::LWin,
-            glutin::VirtualKeyCode::Mail => Key::Mail,
-            glutin::VirtualKeyCode::MediaSelect => Key::MediaSelect,
-            glutin::VirtualKeyCode::MediaStop => Key::MediaStop,
-            glutin::VirtualKeyCode::Minus => Key::Minus,
-            glutin::VirtualKeyCode::Multiply => Key::Multiply,
-            glutin::VirtualKeyCode::Mute => Key::Mute,
-            glutin::VirtualKeyCode::MyComputer => Key::MyComputer,
-            glutin::VirtualKeyCode::NavigateForward => Key::NavigateForward,
-            glutin::VirtualKeyCode::NavigateBackward => Key::NavigateBackward,
-            glutin::VirtualKeyCode::NextTrack => Key::NextTrack,
-            glutin::VirtualKeyCode::NoConvert => Key::NoConvert,
-            glutin::VirtualKeyCode::NumpadComma => Key::NumpadComma,
-            glutin::VirtualKeyCode::NumpadEnter => Key::NumpadEnter,
-            glutin::VirtualKeyCode::NumpadEquals => Key::NumpadEquals,
-            glutin::VirtualKeyCode::OEM102 => Key::OEM102,
-            glutin::VirtualKeyCode::Period => Key::Period,
-            glutin::VirtualKeyCode::PlayPause => Key::PlayPause,
-            glutin::VirtualKeyCode::Power => Key::Power,
-            glutin::VirtualKeyCode::PrevTrack => Key::PrevTrack,
-            glutin::VirtualKeyCode::RAlt => Key::RAlt,
-            glutin::VirtualKeyCode::RBracket => Key::RBracket,
-            glutin::VirtualKeyCode::RControl => Key::RControl,
-            glutin::VirtualKeyCode::RShift => Key::RShift,
-            glutin::VirtualKeyCode::RWin => Key::RWin,
-            glutin::VirtualKeyCode::Semicolon => Key::Semicolon,
-            glutin::VirtualKeyCode::Slash => Key::Slash,
-            glutin::VirtualKeyCode::Sleep => Key::Sleep,
-            glutin::VirtualKeyCode::Stop => Key::Stop,
-            glutin::VirtualKeyCode::Subtract => Key::Subtract,
-            glutin::VirtualKeyCode::Sysrq => Key::Sysrq,
-            glutin::VirtualKeyCode::Tab => Key::Tab,
-            glutin::VirtualKeyCode::Underline => Key::Underline,
-            glutin::VirtualKeyCode::Unlabeled => Key::Unlabeled,
-            glutin::VirtualKeyCode::VolumeDown => Key::VolumeDown,
-            glutin::VirtualKeyCode::VolumeUp => Key::VolumeUp,
-            glutin::VirtualKeyCode::Wake => Key::Wake,
-            glutin::VirtualKeyCode::WebBack => Key::WebBack,
-            glutin::VirtualKeyCode::WebFavorites => Key::WebFavorites,
-            glutin::VirtualKeyCode::WebForward => Key::WebForward,
-            glutin::VirtualKeyCode::WebHome => Key::WebHome,
-            glutin::VirtualKeyCode::WebRefresh => Key::WebRefresh,
-            glutin::VirtualKeyCode::WebSearch => Key::WebSearch,
-            glutin::VirtualKeyCode::WebStop => Key::WebStop,
-            glutin::VirtualKeyCode::Yen => Key::Yen,
-            glutin::VirtualKeyCode::Copy => Key::Copy,
-            glutin::VirtualKeyCode::Paste => Key::Paste,
-            glutin::VirtualKeyCode::Cut => Key::Cut,
+            glutin::event::VirtualKeyCode::Key1 => Key::Key1,
+            glutin::event::VirtualKeyCode::Key2 => Key::Key2,
+            glutin::event::VirtualKeyCode::Key3 => Key::Key3,
+            glutin::event::VirtualKeyCode::Key4 => Key::Key4,
+            glutin::event::VirtualKeyCode::Key5 => Key::Key5,
+            glutin::event::VirtualKeyCode::Key6 => Key::Key6,
+            glutin::event::VirtualKeyCode::Key7 => Key::Key7,
+            glutin::event::VirtualKeyCode::Key8 => Key::Key8,
+            glutin::event::VirtualKeyCode::Key9 => Key::Key9,
+            glutin::event::VirtualKeyCode::Key0 => Key::Key0,
+            glutin::event::VirtualKeyCode::A => Key::A,
+            glutin::event::VirtualKeyCode::B => Key::B,
+            glutin::event::VirtualKeyCode::C => Key::C,
+            glutin::event::VirtualKeyCode::D => Key::D,
+            glutin::event::VirtualKeyCode::E => Key::E,
+            glutin::event::VirtualKeyCode::F => Key::F,
+            glutin::event::VirtualKeyCode::G => Key::G,
+            glutin::event::VirtualKeyCode::H => Key::H,
+            glutin::event::VirtualKeyCode::I => Key::I,
+            glutin::event::VirtualKeyCode::J => Key::J,
+            glutin::event::VirtualKeyCode::K => Key::K,
+            glutin::event::VirtualKeyCode::L => Key::L,
+            glutin::event::VirtualKeyCode::M => Key::M,
+            glutin::event::VirtualKeyCode::N => Key::N,
+            glutin::event::VirtualKeyCode::O => Key::O,
+            glutin::event::VirtualKeyCode::P => Key::P,
+            glutin::event::VirtualKeyCode::Q => Key::Q,
+            glutin::event::VirtualKeyCode::R => Key::R,
+            glutin::event::VirtualKeyCode::S => Key::S,
+            glutin::event::VirtualKeyCode::T => Key::T,
+            glutin::event::VirtualKeyCode::U => Key::U,
+            glutin::event::VirtualKeyCode::V => Key::V,
+            glutin::event::VirtualKeyCode::W => Key::W,
+            glutin::event::VirtualKeyCode::X => Key::X,
+            glutin::event::VirtualKeyCode::Y => Key::Y,
+            glutin::event::VirtualKeyCode::Z => Key::Z,
+            glutin::event::VirtualKeyCode::Escape => Key::Escape,
+            glutin::event::VirtualKeyCode::F1 => Key::F1,
+            glutin::event::VirtualKeyCode::F2 => Key::F2,
+            glutin::event::VirtualKeyCode::F3 => Key::F3,
+            glutin::event::VirtualKeyCode::F4 => Key::F4,
+            glutin::event::VirtualKeyCode::F5 => Key::F5,
+            glutin::event::VirtualKeyCode::F6 => Key::F6,
+            glutin::event::VirtualKeyCode::F7 => Key::F7,
+            glutin::event::VirtualKeyCode::F8 => Key::F8,
+            glutin::event::VirtualKeyCode::F9 => Key::F9,
+            glutin::event::VirtualKeyCode::F10 => Key::F10,
+            glutin::event::VirtualKeyCode::F11 => Key::F11,
+            glutin::event::VirtualKeyCode::F12 => Key::F12,
+            glutin::event::VirtualKeyCode::F13 => Key::F13,
+            glutin::event::VirtualKeyCode::F14 => Key::F14,
+            glutin::event::VirtualKeyCode::F15 => Key::F15,
+            glutin::event::VirtualKeyCode::F16 => Key::F16,
+            glutin::event::VirtualKeyCode::F17 => Key::F17,
+            glutin::event::VirtualKeyCode::F18 => Key::F18,
+            glutin::event::VirtualKeyCode::F19 => Key::F19,
+            glutin::event::VirtualKeyCode::F20 => Key::F20,
+            glutin::event::VirtualKeyCode::F21 => Key::F21,
+            glutin::event::VirtualKeyCode::F22 => Key::F22,
+            glutin::event::VirtualKeyCode::F23 => Key::F23,
+            glutin::event::VirtualKeyCode::F24 => Key::F24,
+            glutin::event::VirtualKeyCode::Snapshot => Key::Snapshot,
+            glutin::event::VirtualKeyCode::Scroll => Key::Scroll,
+            glutin::event::VirtualKeyCode::Pause => Key::Pause,
+            glutin::event::VirtualKeyCode::Insert => Key::Insert,
+            glutin::event::VirtualKeyCode::Home => Key::Home,
+            glutin::event::VirtualKeyCode::Delete => Key::Delete,
+            glutin::event::VirtualKeyCode::End => Key::End,
+            glutin::event::VirtualKeyCode::PageDown => Key::PageDown,
+            glutin::event::VirtualKeyCode::PageUp => Key::PageUp,
+            glutin::event::VirtualKeyCode::Left => Key::Left,
+            glutin::event::VirtualKeyCode::Up => Key::Up,
+            glutin::event::VirtualKeyCode::Right => Key::Right,
+            glutin::event::VirtualKeyCode::Down => Key::Down,
+            glutin::event::VirtualKeyCode::Back => Key::Back,
+            glutin::event::VirtualKeyCode::Return => Key::Return,
+            glutin::event::VirtualKeyCode::Space => Key::Space,
+            glutin::event::VirtualKeyCode::Compose => Key::Compose,
+            glutin::event::VirtualKeyCode::Caret => Key::Caret,
+            glutin::event::VirtualKeyCode::Numlock => Key::Numlock,
+            glutin::event::VirtualKeyCode::Numpad0 => Key::Numpad0,
+            glutin::event::VirtualKeyCode::Numpad1 => Key::Numpad1,
+            glutin::event::VirtualKeyCode::Numpad2 => Key::Numpad2,
+            glutin::event::VirtualKeyCode::Numpad3 => Key::Numpad3,
+            glutin::event::VirtualKeyCode::Numpad4 => Key::Numpad4,
+            glutin::event::VirtualKeyCode::Numpad5 => Key::Numpad5,
+            glutin::event::VirtualKeyCode::Numpad6 => Key::Numpad6,
+            glutin::event::VirtualKeyCode::Numpad7 => Key::Numpad7,
+            glutin::event::VirtualKeyCode::Numpad8 => Key::Numpad8,
+            glutin::event::VirtualKeyCode::Numpad9 => Key::Numpad9,
+            glutin::event::VirtualKeyCode::AbntC1 => Key::AbntC1,
+            glutin::event::VirtualKeyCode::AbntC2 => Key::AbntC2,
+            glutin::event::VirtualKeyCode::NumpadAdd => Key::Add,
+            glutin::event::VirtualKeyCode::Apostrophe => Key::Apostrophe,
+            glutin::event::VirtualKeyCode::Apps => Key::Apps,
+            glutin::event::VirtualKeyCode::At => Key::At,
+            glutin::event::VirtualKeyCode::Ax => Key::Ax,
+            glutin::event::VirtualKeyCode::Backslash => Key::Backslash,
+            glutin::event::VirtualKeyCode::Calculator => Key::Calculator,
+            glutin::event::VirtualKeyCode::Capital => Key::Capital,
+            glutin::event::VirtualKeyCode::Colon => Key::Colon,
+            glutin::event::VirtualKeyCode::Comma => Key::Comma,
+            glutin::event::VirtualKeyCode::Convert => Key::Convert,
+            glutin::event::VirtualKeyCode::NumpadDecimal => Key::Decimal,
+            glutin::event::VirtualKeyCode::NumpadDivide => Key::Divide,
+            glutin::event::VirtualKeyCode::Asterisk => Key::Multiply,
+            glutin::event::VirtualKeyCode::Plus => Key::Add,
+            glutin::event::VirtualKeyCode::Equals => Key::Equals,
+            glutin::event::VirtualKeyCode::Grave => Key::Grave,
+            glutin::event::VirtualKeyCode::Kana => Key::Kana,
+            glutin::event::VirtualKeyCode::Kanji => Key::Kanji,
+            glutin::event::VirtualKeyCode::LAlt => Key::LAlt,
+            glutin::event::VirtualKeyCode::LBracket => Key::LBracket,
+            glutin::event::VirtualKeyCode::LControl => Key::LControl,
+            glutin::event::VirtualKeyCode::LShift => Key::LShift,
+            glutin::event::VirtualKeyCode::LWin => Key::LWin,
+            glutin::event::VirtualKeyCode::Mail => Key::Mail,
+            glutin::event::VirtualKeyCode::MediaSelect => Key::MediaSelect,
+            glutin::event::VirtualKeyCode::MediaStop => Key::MediaStop,
+            glutin::event::VirtualKeyCode::Minus => Key::Minus,
+            glutin::event::VirtualKeyCode::NumpadMultiply => Key::Multiply,
+            glutin::event::VirtualKeyCode::Mute => Key::Mute,
+            glutin::event::VirtualKeyCode::MyComputer => Key::MyComputer,
+            glutin::event::VirtualKeyCode::NavigateForward => Key::NavigateForward,
+            glutin::event::VirtualKeyCode::NavigateBackward => Key::NavigateBackward,
+            glutin::event::VirtualKeyCode::NextTrack => Key::NextTrack,
+            glutin::event::VirtualKeyCode::NoConvert => Key::NoConvert,
+            glutin::event::VirtualKeyCode::NumpadComma => Key::NumpadComma,
+            glutin::event::VirtualKeyCode::NumpadEnter => Key::NumpadEnter,
+            glutin::event::VirtualKeyCode::NumpadEquals => Key::NumpadEquals,
+            glutin::event::VirtualKeyCode::OEM102 => Key::OEM102,
+            glutin::event::VirtualKeyCode::Period => Key::Period,
+            glutin::event::VirtualKeyCode::PlayPause => Key::PlayPause,
+            glutin::event::VirtualKeyCode::Power => Key::Power,
+            glutin::event::VirtualKeyCode::PrevTrack => Key::PrevTrack,
+            glutin::event::VirtualKeyCode::RAlt => Key::RAlt,
+            glutin::event::VirtualKeyCode::RBracket => Key::RBracket,
+            glutin::event::VirtualKeyCode::RControl => Key::RControl,
+            glutin::event::VirtualKeyCode::RShift => Key::RShift,
+            glutin::event::VirtualKeyCode::RWin => Key::RWin,
+            glutin::event::VirtualKeyCode::Semicolon => Key::Semicolon,
+            glutin::event::VirtualKeyCode::Slash => Key::Slash,
+            glutin::event::VirtualKeyCode::Sleep => Key::Sleep,
+            glutin::event::VirtualKeyCode::Stop => Key::Stop,
+            glutin::event::VirtualKeyCode::NumpadSubtract => Key::Subtract,
+            glutin::event::VirtualKeyCode::Sysrq => Key::Sysrq,
+            glutin::event::VirtualKeyCode::Tab => Key::Tab,
+            glutin::event::VirtualKeyCode::Underline => Key::Underline,
+            glutin::event::VirtualKeyCode::Unlabeled => Key::Unlabeled,
+            glutin::event::VirtualKeyCode::VolumeDown => Key::VolumeDown,
+            glutin::event::VirtualKeyCode::VolumeUp => Key::VolumeUp,
+            glutin::event::VirtualKeyCode::Wake => Key::Wake,
+            glutin::event::VirtualKeyCode::WebBack => Key::WebBack,
+            glutin::event::VirtualKeyCode::WebFavorites => Key::WebFavorites,
+            glutin::event::VirtualKeyCode::WebForward => Key::WebForward,
+            glutin::event::VirtualKeyCode::WebHome => Key::WebHome,
+            glutin::event::VirtualKeyCode::WebRefresh => Key::WebRefresh,
+            glutin::event::VirtualKeyCode::WebSearch => Key::WebSearch,
+            glutin::event::VirtualKeyCode::WebStop => Key::WebStop,
+            glutin::event::VirtualKeyCode::Yen => Key::Yen,
+            glutin::event::VirtualKeyCode::Copy => Key::Copy,
+            glutin::event::VirtualKeyCode::Paste => Key::Paste,
+            glutin::event::VirtualKeyCode::Cut => Key::Cut,
         }
     } else {
         Key::Unknown

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -422,9 +422,9 @@ impl Window {
         false // FIXME
     }
 
-    /// The hidpi factor of this screen.
-    pub fn hidpi_factor(&self) -> f64 {
-        self.canvas.hidpi_factor()
+    /// The scale factor of this screen.
+    pub fn scale_factor(&self) -> f64 {
+        self.canvas.scale_factor()
     }
 
     /// Sets the light mode. Only one light is supported.
@@ -682,21 +682,21 @@ impl Window {
         fn window_event_to_conrod_input(
             event: WindowEvent,
             size: Vector2<u32>,
-            hidpi: f64,
+            scale: f64,
         ) -> Option<conrod::event::Input> {
             use conrod::event::Input;
             use conrod::input::{Button, Key as CKey, Motion, MouseButton};
 
             let transform_coords = |x: f64, y: f64| {
                 (
-                    (x - size.x as f64 / 2.0) / hidpi,
-                    -(y - size.y as f64 / 2.0) / hidpi,
+                    (x - size.x as f64 / 2.0) / scale,
+                    -(y - size.y as f64 / 2.0) / scale,
                 )
             };
 
             match event {
                 WindowEvent::FramebufferSize(w, h) => {
-                    Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi))
+                    Some(Input::Resize(w as f64 / scale, h as f64 / scale))
                 }
                 WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
                 WindowEvent::CursorPos(x, y, _) => {
@@ -868,9 +868,9 @@ impl Window {
 
         #[cfg(feature = "conrod")]
         {
-            let (size, hidpi) = (self.size(), self.hidpi_factor());
+            let (size, scale) = (self.size(), self.scale_factor());
             let conrod_ui = self.conrod_ui_mut();
-            if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
+            if let Some(input) = window_event_to_conrod_input(*event, size, scale) {
                 conrod_ui.handle_event(input);
             }
 
@@ -1104,7 +1104,7 @@ impl Window {
         self.conrod_context.renderer.render(
             w as f32,
             h as f32,
-            self.canvas.hidpi_factor() as f32,
+            self.canvas.scale_factor() as f32,
             &self.conrod_context.textures,
         );
 


### PR DESCRIPTION
Some variables/methods are renamed to reflect the change in glutin. It also fixes #249 to build with nightly compiler.