### PR TITLE
:bug: #257 using same cfg attributes as glutin

### DIFF
--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -35,7 +35,13 @@ impl AbstractCanvas for GLCanvas {
         canvas_setup: Option<CanvasSetup>,
         out_events: Sender<WindowEvent>,
     ) -> Self {
-        #[cfg(unix)]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ))]
         let events = {
             use glutin::platform::unix::EventLoopExtUnix;
             EventLoop::new_any_thread()
@@ -45,7 +51,14 @@ impl AbstractCanvas for GLCanvas {
             use glutin::platform::windows::EventLoopExtWindows;
             EventLoop::new_any_thread()
         };
-        #[cfg(not(any(unix, windows)))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            windows
+        )))]
         let events = EventLoop::new();
 
         let window = WindowBuilder::new()


### PR DESCRIPTION
glutin is not using cfg(unix) so it's true for kiss3D but not for glutin and can lead to some issue. It's only in the gl_canvas.rs

I made very small changes but my project now build with this version :) Thanks to your comment I was able to fix this. However if there is other place you think i should make some changes i will be happy to :) 