### PR TITLE
Rotation simplified

### DIFF
--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -537,6 +537,18 @@ impl SceneNodeData {
         self.local_transform.append_rotation_wrt_center_mut(r)
     }
 
+    /// Appends a rotation in given angle and axis, hiding complicated UnitQuaternion implementation.
+    pub fn add_rotation_in_axis(&mut self, angle: f32, axis: char) {
+        let rot;
+        match axis {
+            'x' | 'X' => rot = UnitQuaternion::from_axis_angle(&Vector3::x_axis(), angle),
+            'y' | 'Y' => rot = UnitQuaternion::from_axis_angle(&Vector3::y_axis(), angle),
+            'z' | 'Z' => rot = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), angle),
+            _ => return,
+        }
+        self.prepend_to_local_rotation(&rot);
+    }
+
     /// Prepends a rotation to this node local transformation.
     #[inline]
     pub fn prepend_to_local_rotation(&mut self, r: &UnitQuaternion<f32>) {

--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -537,18 +537,6 @@ impl SceneNodeData {
         self.local_transform.append_rotation_wrt_center_mut(r)
     }
 
-    /// Appends a rotation in given angle and axis, hiding complicated UnitQuaternion implementation.
-    pub fn add_rotation_in_axis(&mut self, angle: f32, axis: char) {
-        let rot;
-        match axis {
-            'x' | 'X' => rot = UnitQuaternion::from_axis_angle(&Vector3::x_axis(), angle),
-            'y' | 'Y' => rot = UnitQuaternion::from_axis_angle(&Vector3::y_axis(), angle),
-            'z' | 'Z' => rot = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), angle),
-            _ => return,
-        }
-        self.prepend_to_local_rotation(&rot);
-    }
-
     /// Prepends a rotation to this node local transformation.
     #[inline]
     pub fn prepend_to_local_rotation(&mut self, r: &UnitQuaternion<f32>) {
@@ -1135,6 +1123,18 @@ impl SceneNode {
     #[inline]
     pub fn append_rotation(&mut self, r: &UnitQuaternion<f32>) {
         self.data_mut().append_rotation(r)
+    }
+
+    /// Appends a rotation in given angle and axis, hiding complicated UnitQuaternion implementation.
+    pub fn add_rotation_in_axis(&mut self, angle: f32, axis: char) {
+        let rot;
+        match axis {
+            'x' | 'X' => rot = UnitQuaternion::from_axis_angle(&Vector3::x_axis(), angle),
+            'y' | 'Y' => rot = UnitQuaternion::from_axis_angle(&Vector3::y_axis(), angle),
+            'z' | 'Z' => rot = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), angle),
+            _ => return,
+        }
+        self.prepend_to_local_rotation(&rot);
     }
 
     /// Appends a rotation to this node local transformation.


### PR DESCRIPTION
Appends a rotation in given angle and axis for SceneNode, hiding complicated UnitQuaternion implementation. Making it more kiss :).