### PR TITLE
Rename max_dur_per_frame to min_dur_per_frame

### DIFF
--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -65,7 +65,7 @@ impl ConrodContext {
 pub struct Window {
     events: Rc<Receiver<WindowEvent>>,
     unhandled_events: Rc<RefCell<Vec<WindowEvent>>>,
-    max_dur_per_frame: Option<Duration>,
+    min_dur_per_frame: Option<Duration>,
     scene: SceneNode,
     scene2: PlanarSceneNode,
     light_mode: Light, // FIXME: move that to the scene graph
@@ -115,7 +115,7 @@ impl Window {
     /// Sets the maximum number of frames per second. Cannot be 0. `None` means there is no limit.
     #[inline]
     pub fn set_framerate_limit(&mut self, fps: Option<u64>) {
-        self.max_dur_per_frame = fps.map(|f| {
+        self.min_dur_per_frame = fps.map(|f| {
             assert!(f != 0);
             Duration::from_millis(1000 / f)
         })
@@ -530,7 +530,7 @@ impl Window {
 
         let mut usr_window = Window {
             should_close: false,
-            max_dur_per_frame: None,
+            min_dur_per_frame: None,
             canvas: canvas,
             events: Rc::new(event_receive),
             unhandled_events: Rc::new(RefCell::new(Vec::new())),
@@ -1120,7 +1120,7 @@ impl Window {
         #[cfg(not(target_arch = "wasm32"))]
         {
             // Limit the fps if needed.
-            if let Some(dur) = self.max_dur_per_frame {
+            if let Some(dur) = self.min_dur_per_frame {
                 let elapsed = self.curr_time.elapsed();
                 if elapsed < dur {
                     thread::sleep(dur - elapsed);


### PR DESCRIPTION
I was evaluating `kiss3d` for a potential project and came across this issue, so I thought I'd submit a quick PR.

This field is the *minimum* duration per frame, so the name `min_dur_per_frame` is correct, even though it is the duration which corresponds to the *maximum* frame rate.