### PR TITLE
Add feature to toggle thread support in image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "kiss3d"
-version = "0.29.0"
+version = "0.30.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 description = "3D graphics engine for Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ name = "kiss3d"
 path = "src/lib.rs"
 
 [features]
+default = [ "image-threads" ]
 conrod = [ "conrod_core" ]
+image-threads = [ "image/jpeg_rayon" ]
 
 
 [dependencies]
@@ -40,13 +42,17 @@ bitflags     = "1.2"
 num-traits   = "0.2"
 nalgebra     = "0.25"
 ncollide3d   = "0.28"
-image        = "0.23"
 serde        = "1"
 serde_derive = "1"
 rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
 instant      = { version = "0.1", features = [ "wasm-bindgen" ]}
 conrod_core  = { version = "0.71", features = [ "wasm-bindgen" ], optional = true }
 glow = "0.7"
+
+[dependencies.image]
+version = "0.23"
+default-features = false
+features = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = "0.26"


### PR DESCRIPTION
Loading JPEG images from memory doesn't seem to work in WASM because threads aren't supported yet. This PR exposes a feature to enable threads in the `image` crate. This feature is enabled by default.