### PR TITLE
Bump nalgebra to a safe version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ either       = "1"
 libc         = "0.2"
 bitflags     = "1.2"
 num-traits   = "0.2"
-nalgebra     = "0.27.1"
-ncollide3d   = "0.30"
+nalgebra     = "0.29"
+ncollide3d   = "0.32"
 image        = "0.23"
 serde        = "1"
 serde_derive = "1"
@@ -60,5 +60,5 @@ web-sys = { version = "0.3", features = [ "console", "KeyEvent", "KeyboardEvent"
 
 [dev-dependencies]
 rand = "0.8"
-ncollide2d = "0.30"
-nalgebra   = { version = "0.27.1", features = [ "rand" ] }
+ncollide2d = "0.32"
+nalgebra   = { version = "0.29", features = [ "rand" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ either       = "1"
 libc         = "0.2"
 bitflags     = "1.2"
 num-traits   = "0.2"
-nalgebra     = "0.26"
-ncollide3d   = "0.29"
+nalgebra     = "0.27.1"
+ncollide3d   = "0.30"
 image        = "0.23"
 serde        = "1"
 serde_derive = "1"
@@ -60,5 +60,5 @@ web-sys = { version = "0.3", features = [ "console", "KeyEvent", "KeyboardEvent"
 
 [dev-dependencies]
 rand = "0.8"
-ncollide2d = "0.29"
-nalgebra   = { version = "0.26", features = [ "rand" ] }
+ncollide2d = "0.30"
+nalgebra   = { version = "0.27.1", features = [ "rand" ] }


### PR DESCRIPTION
Hey,

This bumps version of nalgebra to new version which should be safe from https://github.com/dimforge/nalgebra/issues/883

I noticed issue mentioning that you don't have time to actively maintain this crate anymore so I figured I might save you some by just creating this PR myself even when it's a simple one.

I also saw that https://github.com/sebcrozet/kiss3d/pull/280 exists but it seems that it missed updating the `dev-dependencies`

## Testing

Since this crate doesn't have many tests I tested it by running the examples to make sure they work. I did this on a linux machine  but I think it's pretty safe to assume that it doesn't break anything on other platforms.