### PR TITLE
exponential arc ball zoom

### DIFF
--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -80,7 +80,7 @@ impl ArcBall {
             pitch_step: 0.005,
             min_pitch: 0.01,
             max_pitch: std::f32::consts::PI - 0.01,
-            dist_step: 1.02,
+            dist_step: 1.01,
             rotate_button: Some(MouseButton::Button1),
             rotate_modifiers: None,
             drag_button: Some(MouseButton::Button2),

--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -58,7 +58,7 @@ pub struct ArcBall {
 impl ArcBall {
     /// Create a new arc-ball camera.
     pub fn new(eye: Point3<f32>, at: Point3<f32>) -> ArcBall {
-        ArcBall::new_with_frustrum(f32::consts::PI / 4.0, 0.1, 1024.0, eye, at)
+        ArcBall::new_with_frustrum(f32::consts::PI / 4.0, 0.001, 1024.0, eye, at)
     }
 
     /// Creates a new arc ball camera with default sensitivity values.
@@ -75,12 +75,12 @@ impl ArcBall {
             pitch: 0.0,
             dist: 0.0,
             min_dist: 0.00001,
-            max_dist: std::f32::MAX,
+            max_dist: 1.0e4,
             yaw_step: 0.005,
             pitch_step: 0.005,
             min_pitch: 0.01,
             max_pitch: std::f32::consts::PI - 0.01,
-            dist_step: 40.0,
+            dist_step: 1.02,
             rotate_button: Some(MouseButton::Button1),
             rotate_modifiers: None,
             drag_button: Some(MouseButton::Button2),
@@ -313,7 +313,7 @@ impl ArcBall {
     }
 
     fn handle_scroll(&mut self, off: f32) {
-        self.dist = self.dist + self.dist_step * (off) / 120.0;
+        self.dist = self.dist * self.dist_step.powf(off);
         self.update_restrictions();
         self.update_projviews();
     }


### PR DESCRIPTION
Currently the arc ball zoom (on scroll) changes the dist by a fixed amount, causing the camera to move a great deal relative to the subject when it is very close to the subject, and not affecting the view much at all when the camera is already far away. In particular, previously, zooming in by a single tick causes everything to disappear in some applications, which is very annoying.

In most other 3D applications an arc ball zoom is implemented as an exponential thing instead, so I have done that here.

Also, I fixed the default `max_dist` which was previously (nearly) unbounded at `f32::MAX`. When `dist` gets large, the code will crash because the projection matrix becomes nearly singular (determinant less than `f32::epsilon`) so inverting the matrix in function `update_projviews()` with `.unwrap()` will crash. Probably nobody found this bug because it would have taken a lot of scrolling with a fixed increment to find it. 