### PR TITLE
canvas: Force correct drop order when render_loop ends

### DIFF
--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -70,7 +70,7 @@ impl Canvas {
     }
 
     /// Run the platform-specific render loop.
-    pub fn render_loop(data: impl FnMut(f64) -> bool + 'static) {
+    pub fn render_loop(data: impl RenderLoopClosure) {
         CanvasImpl::render_loop(data)
     }
 
@@ -146,6 +146,12 @@ impl Canvas {
     }
 }
 
+// Note: the closure must have static lifetime because of the constraints imposed by wasm-bindgen:
+// https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html
+pub trait RenderLoopClosure: 'static {
+    fn call(&mut self, x: f64) -> bool;
+}
+
 pub(crate) trait AbstractCanvas {
     fn open(
         title: &str,
@@ -155,7 +161,7 @@ pub(crate) trait AbstractCanvas {
         window_setup: Option<CanvasSetup>,
         out_events: Sender<WindowEvent>,
     ) -> Self;
-    fn render_loop(data: impl FnMut(f64) -> bool + 'static);
+    fn render_loop(data: impl RenderLoopClosure);
     fn poll_events(&mut self);
     fn swap_buffers(&mut self);
     fn size(&self) -> (u32, u32);

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc::Sender;
 
 use crate::context::Context;
 use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent};
-use crate::window::canvas::{CanvasSetup, NumSamples};
+use crate::window::canvas::{CanvasSetup, NumSamples, RenderLoopClosure};
 use crate::window::AbstractCanvas;
 use glutin::{
     self,
@@ -97,9 +97,9 @@ impl AbstractCanvas for GLCanvas {
         }
     }
 
-    fn render_loop(mut callback: impl FnMut(f64) -> bool + 'static) {
+    fn render_loop(mut callback: impl RenderLoopClosure) {
         loop {
-            if !callback(0.0) {
+            if !callback.call(0.0) {
                 break;
             } // XXX: timestamp
         }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,7 +1,7 @@
 //! The window, and things to handle the rendering loop and events.
 
 pub(crate) use self::canvas::AbstractCanvas;
-pub use self::canvas::{Canvas, CanvasSetup, NumSamples};
+pub use self::canvas::{Canvas, CanvasSetup, NumSamples, RenderLoopClosure};
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::gl_canvas::GLCanvas;
 pub use self::state::State;

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::Sender;
 
 use crate::context::Context;
 use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent};
-use crate::window::{AbstractCanvas, CanvasSetup};
+use crate::window::{AbstractCanvas, CanvasSetup, RenderLoopClosure};
 use image::{GenericImage, Pixel};
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
@@ -424,13 +424,13 @@ impl AbstractCanvas for WebGLCanvas {
         }
     }
 
-    fn render_loop(mut callback: impl FnMut(f64) -> bool + 'static) {
+    fn render_loop(mut callback: impl RenderLoopClosure) {
         // See https://rustwasm.github.io/docs/wasm-bindgen/examples/request-animation-frame.html
         if let Some(window) = web_sys::window() {
             let f = Rc::new(RefCell::new(None));
             let g: Rc<RefCell<Option<Closure<_>>>> = f.clone();
             *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-                if callback(0.0) {
+                if callback.call(0.0) {
                     let _ = window.request_animation_frame(
                         f.borrow().as_ref().unwrap().as_ref().unchecked_ref(),
                     );

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -29,7 +29,7 @@ use crate::resource::{
 use crate::scene::{PlanarSceneNode, SceneNode};
 use crate::text::{Font, TextRenderer};
 use crate::window::canvas::CanvasSetup;
-use crate::window::{Canvas, State, RenderLoopClosure};
+use crate::window::{Canvas, RenderLoopClosure, State};
 use image::imageops;
 use image::{GenericImage, Pixel};
 use image::{ImageBuffer, Rgb};


### PR DESCRIPTION
First time contributing to this repo, lemme know if this PR is stylistically okay.

------------------------

After switching my application to use the `State`-based setup (see
examples/persistent_point_cloud.rs for an example), I would get errors
when closing the window:
```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1282`,
 right: `0`', C:\Users\Henry\.cargo\registry\src\github.com-1ecc6299db9ec823\kiss3d-0.31.0\src\resource\effect.rs:93:12
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1282`,
 right: `0`', C:\Users\Henry\.cargo\registry\src\github.com-1ecc6299db9ec823\kiss3d-0.31.0\src\resource\effect.rs:93:12
stack backtrace:
   0:     0x7ff64cfe157e - std::backtrace_rs::backtrace::dbghelp::trace
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\..\..\backtrace\src\backtrace\dbghelp.rs:98
   1:     0x7ff64cfe157e - std::backtrace_rs::backtrace::trace_unsynchronized
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2:     0x7ff64cfe157e - std::sys_common::backtrace::_print_fmt
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\sys_common\backtrace.rs:67
   3:     0x7ff64cfe157e - std::sys_common::backtrace::_print::{{impl}}::fmt
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\sys_common\backtrace.rs:46
   4:     0x7ff64cff626c - core::fmt::write
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\core\src\fmt\mod.rs:1092
   5:     0x7ff64cfdf068 - std::io::Write::write_fmt<std::sys::windows::stdio::Stderr>
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\io\mod.rs:1572
   6:     0x7ff64cfe402d - std::sys_common::backtrace::_print
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\sys_common\backtrace.rs:49
   7:     0x7ff64cfe402d - std::sys_common::backtrace::print
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\sys_common\backtrace.rs:36
   8:     0x7ff64cfe402d - std::panicking::default_hook::{{closure}}
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\panicking.rs:208
   9:     0x7ff64cfe3af9 - std::panicking::default_hook
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\panicking.rs:225
  10:     0x7ff64cfe46d3 - std::panicking::rust_panic_with_hook
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\panicking.rs:591
  11:     0x7ff64cfe4281 - std::panicking::begin_panic_handler::{{closure}}
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\panicking.rs:497
  12:     0x7ff64cfe1e9f - std::sys_common::backtrace::__rust_end_short_backtrace<closure-0,!>
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\sys_common\backtrace.rs:141
  13:     0x7ff64cfe41d9 - std::panicking::begin_panic_handler
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\std\src\panicking.rs:493
  14:     0x7ff64cffdbe0 - core::panicking::panic_fmt
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\core\src\panicking.rs:92
  15:     0x7ff64cff407a - core::fmt::Arguments::new_v1
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\core\src\fmt\mod.rs:314
  16:     0x7ff64cff407a - core::panicking::assert_failed::inner
                               at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53\/library\core\src\panicking.rs:135
  17:     0x7ff64ceb84dd - core::panicking::assert_failed<u32,u32>
                               at C:\Users\Henry\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\panicking.rs:143
  18:     0x7ff64cdf8782 - kiss3d::resource::effect::{{impl}}::drop
                               at C:\Users\Henry\.cargo\registry\src\github.com-1ecc6299db9ec823\kiss3d-0.31.0\src\resource\effect.rs:93
  19:     0x7ff64cd9ce4e - core::ptr::drop_in_place<kiss3d::resource::effect::Effect>
                               at C:\Users\Henry\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ptr\mod.rs:187
  20:     0x7ff64cd9d743 - core::ptr::drop_in_place<kiss3d::renderer::line_renderer::LineRenderer>
```

After enabling the logging in the `glow` crate, I found that the program
for the `LineRenderer` object in my state was suddenly becoming invalid
before I could call `IsProgram` and `DeleteProgram` on it. (Those are
from the `Drop` impl for `Effect`.)

The issued turned out to be that we were dropping the window before the
state, and since the window holds the OpenGL context, when we tried to
drop the state, we got errors.

This diff introduces a new struct that enforces the proper drop order,
and hides it behind a trait.