### PR TITLE
refactor gl_primative & fix many warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
+authors = ["Sébastien Crozet <developer@crozet.re>"]
 name    = "kiss3d"
-version = "0.31.0"
-authors = [ "Sébastien Crozet <developer@crozet.re>" ]
+version = "0.32.0"
 
-description = "3D graphics engine for Rust."
-repository = "https://github.com/sebcrozet/kiss3d"
-readme = "README.md"
-keywords = [ "3D", "graphics", "OpenGL", "KISS" ]
-license = "BSD-3-Clause"
 autoexamples = true
-edition = "2018"
+description  = "3D graphics engine for Rust."
+edition      = "2018"
+keywords     = ["3D", "graphics", "OpenGL", "KISS"]
+license      = "BSD-3-Clause"
+readme       = "README.md"
+repository   = "https://github.com/sebcrozet/kiss3d"
 
 include = [
     "src/**/*.rs",
@@ -21,7 +21,7 @@ include = [
     "examples/Cargo.toml",
     "Cargo.toml",
     "LICENSE",
-    "Readme.md"
+    "Readme.md",
 ]
 
 
@@ -30,23 +30,23 @@ name = "kiss3d"
 path = "src/lib.rs"
 
 [features]
-conrod = [ "conrod_core" ]
+conrod = ["conrod_core"]
 
 
 [dependencies]
-either       = "1"
-libc         = "0.2"
 bitflags     = "1.2"
-num-traits   = "0.2"
+conrod_core  = { version = "0.71", features = ["wasm-bindgen"], optional = true }
+either       = "1"
+glow         = "0.7"
+image        = "0.23"
+instant      = { version = "0.1", features = ["wasm-bindgen"] }
+libc         = "0.2"
 nalgebra     = "0.29"
 ncollide3d   = "0.32"
-image        = "0.23"
+num-traits   = "0.2"
+rusttype     = { version = "0.9", features = ["gpu_cache"] }
 serde        = "1"
 serde_derive = "1"
-rusttype     = { version = "0.8", features = [ "gpu_cache" ] }
-instant      = { version = "0.1", features = [ "wasm-bindgen" ]}
-conrod_core  = { version = "0.71", features = [ "wasm-bindgen" ], optional = true }
-glow = "0.7"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = "0.26"
@@ -54,11 +54,28 @@ glutin = "0.26"
 # We repeat all three targets instead of any(target_arch = "wasm32", target_arch = "asmjs")
 # to avoid https://github.com/koute/stdweb/issues/135
 [target.wasm32-unknown-unknown.dependencies]
-wasm-bindgen = "0.2"
-web-sys = { version = "0.3", features = [ "console", "KeyEvent", "KeyboardEvent", "MouseEvent", "WheelEvent", "Touch", "TouchEvent", "TouchList", "HtmlCanvasElement", "HtmlElement", "Window", "UiEvent", "Event", "EventTarget", "Element", "DomRect" ] }
 getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+    "console",
+    "KeyEvent",
+    "KeyboardEvent",
+    "MouseEvent",
+    "WheelEvent",
+    "Touch",
+    "TouchEvent",
+    "TouchList",
+    "HtmlCanvasElement",
+    "HtmlElement",
+    "Window",
+    "UiEvent",
+    "Event",
+    "EventTarget",
+    "Element",
+    "DomRect",
+] }
 
 [dev-dependencies]
-rand = "0.8"
+nalgebra   = { version = "0.29", features = ["rand"] }
 ncollide2d = "0.32"
-nalgebra   = { version = "0.29", features = [ "rand" ] }
+rand       = "0.8"

--- a/src/context/context.rs
+++ b/src/context/context.rs
@@ -183,7 +183,7 @@ impl Context {
     }
 
     pub fn create_vertex_array(&self) -> Option<VertexArray> {
-        self.ctxt.create_vertex_array().map(|e| VertexArray(e))
+        self.ctxt.create_vertex_array().map(VertexArray)
     }
 
     pub fn delete_vertex_array(&self, vertex_array: Option<&VertexArray>) {
@@ -195,7 +195,7 @@ impl Context {
     }
 
     pub fn create_buffer(&self) -> Option<Buffer> {
-        self.ctxt.create_buffer().map(|e| Buffer(e))
+        self.ctxt.create_buffer().map(Buffer)
     }
 
     pub fn delete_buffer(&self, buffer: Option<&Buffer>) {
@@ -223,11 +223,11 @@ impl Context {
     }
 
     pub fn create_shader(&self, type_: GLenum) -> Option<Shader> {
-        self.ctxt.create_shader(type_).map(|e| Shader(e))
+        self.ctxt.create_shader(type_).map(Shader)
     }
 
     pub fn create_program(&self) -> Option<Program> {
-        self.ctxt.create_program().map(|e| Program(e))
+        self.ctxt.create_program().map(Program)
     }
 
     pub fn delete_program(&self, program: Option<&Program>) {
@@ -301,7 +301,7 @@ impl Context {
     pub fn get_uniform_location(&self, program: &Program, name: &str) -> Option<UniformLocation> {
         self.ctxt
             .get_uniform_location(&program.0, name)
-            .map(|e| UniformLocation(e))
+            .map(UniformLocation)
     }
 
     pub fn viewport(&self, x: i32, y: i32, width: i32, height: i32) {
@@ -313,7 +313,7 @@ impl Context {
     }
 
     pub fn create_framebuffer(&self) -> Option<Framebuffer> {
-        self.ctxt.create_framebuffer().map(|e| Framebuffer(e))
+        self.ctxt.create_framebuffer().map(Framebuffer)
     }
 
     pub fn is_framebuffer(&self, framebuffer: Option<&Framebuffer>) -> bool {
@@ -342,7 +342,7 @@ impl Context {
     }
 
     pub fn create_renderbuffer(&self) -> Option<Renderbuffer> {
-        self.ctxt.create_renderbuffer().map(|b| Renderbuffer(b))
+        self.ctxt.create_renderbuffer().map(Renderbuffer)
     }
 
     pub fn delete_renderbuffer(&self, buffer: Option<&Renderbuffer>) {

--- a/src/context/gl_context.rs
+++ b/src/context/gl_context.rs
@@ -247,19 +247,19 @@ impl AbstractContext for GLContext {
 
     fn delete_program(&self, program: Option<&Self::Program>) {
         if let Some(p) = program {
-            unsafe { self.context.delete_program(p.clone()) }
+            unsafe { self.context.delete_program(*p) }
         }
     }
 
     fn delete_shader(&self, shader: Option<&Self::Shader>) {
         if let Some(s) = shader {
-            unsafe { self.context.delete_shader(s.clone()) }
+            unsafe { self.context.delete_shader(*s) }
         }
     }
 
     fn is_shader(&self, shader: Option<&Self::Shader>) -> bool {
         if let Some(s) = shader {
-            unsafe { self.context.is_shader(s.clone()) }
+            unsafe { self.context.is_shader(*s) }
         } else {
             false
         }
@@ -267,7 +267,7 @@ impl AbstractContext for GLContext {
 
     fn is_program(&self, program: Option<&Self::Program>) -> bool {
         if let Some(p) = program {
-            unsafe { self.context.is_program(p.clone()) }
+            unsafe { self.context.is_program(*p) }
         } else {
             false
         }
@@ -374,7 +374,7 @@ impl AbstractContext for GLContext {
 
     fn delete_framebuffer(&self, framebuffer: Option<&Self::Framebuffer>) {
         if let Some(f) = framebuffer {
-            unsafe { self.context.delete_framebuffer(f.clone()) }
+            unsafe { self.context.delete_framebuffer(*f) }
         }
     }
 
@@ -407,7 +407,7 @@ impl AbstractContext for GLContext {
 
     fn delete_renderbuffer(&self, buffer: Option<&Self::Renderbuffer>) {
         if let Some(b) = buffer {
-            unsafe { self.context.delete_renderbuffer(b.clone()) }
+            unsafe { self.context.delete_renderbuffer(*b) }
         }
     }
 

--- a/src/event/window_event.rs
+++ b/src/event/window_event.rs
@@ -19,32 +19,24 @@ pub enum WindowEvent {
     Touch(u64, f64, f64, TouchAction, Modifiers),
 }
 
+use WindowEvent::*;
 impl WindowEvent {
     /// Tests if this event is related to the keyboard.
     pub fn is_keyboard_event(&self) -> bool {
-        match self {
-            WindowEvent::Key(..) | WindowEvent::Char(..) | WindowEvent::CharModifiers(..) => true,
-            _ => false,
-        }
+        matches!(self, Key(..) | Char(..) | CharModifiers(..))
     }
 
     /// Tests if this event is related to the mouse.
     pub fn is_mouse_event(&self) -> bool {
-        match self {
-            WindowEvent::MouseButton(..)
-            | WindowEvent::CursorPos(..)
-            | WindowEvent::CursorEnter(..)
-            | WindowEvent::Scroll(..) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            MouseButton(..) | CursorPos(..) | CursorEnter(..) | Scroll(..)
+        )
     }
 
     /// Tests if this event is related to the touch.
     pub fn is_touch_event(&self) -> bool {
-        match self {
-            WindowEvent::Touch(..) => true,
-            _ => false,
-        }
+        matches!(self, Touch(..))
     }
 }
 
@@ -244,13 +236,9 @@ bitflags! {
     #[doc = "Key modifiers"]
     #[derive(Serialize, Deserialize)]
     pub struct Modifiers: i32 {
-        #[allow(non_upper_case_globals)]
         const Shift       = 0b0001;
-        #[allow(non_upper_case_globals)]
         const Control     = 0b0010;
-        #[allow(non_upper_case_globals)]
         const Alt         = 0b0100;
-        #[allow(non_upper_case_globals)]
         const Super       = 0b1000;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ Thanks to all the Rustaceans for their help, and their OpenGL bindings.
 
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
-#![warn(non_upper_case_globals)] // FIXME: should be denied.
+#![allow(non_upper_case_globals)]
 #![deny(unused_qualifications)]
 #![warn(missing_docs)] // FIXME: should be denied.
 #![warn(unused_results)]

--- a/src/loader/mtl.rs
+++ b/src/loader/mtl.rs
@@ -124,16 +124,10 @@ fn parse_color(l: usize, mut ws: Words) -> Vector3<f32> {
 }
 
 fn parse_scalar(l: usize, mut ws: Words) -> f32 {
-    let sx = ws
-        .next()
-        .unwrap_or_else(|| error(l, "1 component was expected, found 0."));
-
-    let x: Result<f32, _> = FromStr::from_str(sx);
-
-    let x =
-        x.unwrap_or_else(|e| error(l, &format!("failed to parse `{}' as a f32: {}", sx, e)[..]));
-
-    x
+    ws.next()
+        .unwrap_or_else(|| error(l, "1 component was expected, found 0."))
+        .parse()
+        .unwrap_or_else(|e| error(l, &format!("failed to parse as f32: {}", e)[..]))
 }
 
 /// Material informations read from a `.mtl` file.

--- a/src/planar_camera/fixed_view.rs
+++ b/src/planar_camera/fixed_view.rs
@@ -26,19 +26,16 @@ impl PlanarCamera for FixedView {
     fn handle_event(&mut self, canvas: &Canvas, event: &WindowEvent) {
         let scale = canvas.scale_factor();
 
-        match *event {
-            WindowEvent::FramebufferSize(w, h) => {
-                let diag = Vector3::new(
-                    2.0 * (scale as f32) / (w as f32),
-                    2.0 * (scale as f32) / (h as f32),
-                    1.0,
-                );
-                let inv_diag = Vector3::new(1.0 / diag.x, 1.0 / diag.y, 1.0);
+        if let WindowEvent::FramebufferSize(w, h) = *event {
+            let diag = Vector3::new(
+                2.0 * (scale as f32) / (w as f32),
+                2.0 * (scale as f32) / (h as f32),
+                1.0,
+            );
+            let inv_diag = Vector3::new(1.0 / diag.x, 1.0 / diag.y, 1.0);
 
-                self.proj = Matrix3::from_diagonal(&diag);
-                self.inv_proj = Matrix3::from_diagonal(&inv_diag);
-            }
-            _ => {}
+            self.proj = Matrix3::from_diagonal(&diag);
+            self.inv_proj = Matrix3::from_diagonal(&inv_diag);
         }
     }
 

--- a/src/planar_camera/sidescroll.rs
+++ b/src/planar_camera/sidescroll.rs
@@ -102,7 +102,7 @@ impl Sidescroll {
     }
 
     fn handle_scroll(&mut self, off: f32) {
-        self.zoom = self.zoom / self.zoom_step.pow(off / 120.0);
+        self.zoom /= self.zoom_step.pow(off / 120.0);
         self.update_restrictions();
         self.update_projviews();
     }

--- a/src/resource/effect.rs
+++ b/src/resource/effect.rs
@@ -139,7 +139,7 @@ impl<T: GLPrimitive> ShaderAttribute<T> {
         verify!(Context::get().vertex_attrib_pointer(
             self.id,
             T::size() as i32,
-            T::gl_type(),
+            T::GLTYPE,
             false,
             0,
             0
@@ -165,7 +165,7 @@ impl<T: GLPrimitive> ShaderAttribute<T> {
         verify!(Context::get().vertex_attrib_pointer(
             self.id,
             T::size() as i32,
-            T::gl_type(),
+            T::GLTYPE,
             false,
             ((strides + 1) * mem::size_of::<T2>()) as i32,
             (start_index * mem::size_of::<T2>()) as GLintptr

--- a/src/resource/gl_primitive.rs
+++ b/src/resource/gl_primitive.rs
@@ -1,7 +1,7 @@
 //! Structures that a gpu buffer may contain.
 
 use crate::context::{Context, UniformLocation};
-use std::slice;
+use std::{mem, slice};
 
 use na::{
     Matrix2, Matrix3, Matrix4, Point2, Point3, Point4, Rotation2, Rotation3, Vector2, Vector3,
@@ -11,32 +11,23 @@ use na::{
 #[path = "../error.rs"]
 mod error;
 
-/// An array of primitive types.
-pub enum PrimitiveArray<'a> {
-    /// A array of f32.
-    Float32(&'a [f32]),
-    /// A array of i32.
-    Int32(&'a [i32]),
-    /// A array of u16.
-    UInt16(&'a [u16]),
-}
-
 /// Trait implemented by structures that can be uploaded to a uniform or contained by a gpu array.
 pub unsafe trait GLPrimitive: Copy {
+    /// The type of the elements of the gpu array.
+    type Element;
     /// The Opengl primitive type of this structure content.
-    fn gl_type() -> u32;
+    const GLTYPE: u32;
     /// The number of elements of type `self.gl_type()` this structure stores.
-    fn size() -> u32;
-    /// Uploads the element to a gpu location.
-    fn upload(&self, location: &UniformLocation);
+    fn size() -> u32 {
+        (mem::size_of::<Self>() / mem::size_of::<Self::Element>()) as u32
+    }
     /// Converts an array of `Self` into an array of f32 or i32 primitives.
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
+    fn flatten(array: &[Self]) -> &[Self::Element] {
+        unsafe { slice::from_raw_parts(array.as_ptr() as *const Self::Element, array.len()) }
+    }
+    /// Uploads the element to a gpu location.
+    fn upload(&self, _: &UniformLocation) {
+        unimplemented!()
     }
 }
 
@@ -46,25 +37,8 @@ pub unsafe trait GLPrimitive: Copy {
  *
  */
 unsafe impl GLPrimitive for f32 {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        1
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -73,24 +47,8 @@ unsafe impl GLPrimitive for f32 {
 }
 
 unsafe impl GLPrimitive for i32 {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::INT
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        1
-    }
-
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Int32(slice::from_raw_parts(ptr, len))
-        }
-    }
+    type Element = i32;
+    const GLTYPE: u32 = Context::INT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -98,135 +56,44 @@ unsafe impl GLPrimitive for i32 {
     }
 }
 
-// // unsafe impl GLPrimitive for u32 {
-// //     #[inline]
-// //     fn gl_type(_: Option<u32>) -> u32 {
-// //         Context::UNSIGNED_INT
-// //     }
-
-// //     #[inline]
-// //     fn size(_: Option<u32>) -> u32 {
-// //         1
-// //     }
-
-// //     #[inline]
-// //     fn upload(&self, location: &UniformLocation) {
-// //         verify!(Context::get().uniform1ui(Some(location), self.clone()));
-// //     }
-// // }
-
 /*
  *
  * Impl for matrices
  *
  */
 unsafe impl GLPrimitive for Matrix2<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        4
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * 4;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
-        unsafe {
-            verify!(Context::get().uniform_matrix2fv(Some(location), false, self));
-        }
+        verify!(Context::get().uniform_matrix2fv(Some(location), false, self));
     }
 }
 
 unsafe impl GLPrimitive for Rotation2<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        4
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
-        unsafe {
-            verify!(Context::get().uniform_matrix2fv(Some(location), false, self.matrix()));
-        }
+        verify!(Context::get().uniform_matrix2fv(Some(location), false, self.matrix()));
     }
 }
 
 unsafe impl GLPrimitive for Matrix3<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        9
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * 9;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
-        unsafe {
-            verify!(Context::get().uniform_matrix3fv(Some(location), false, self));
-        }
+        verify!(Context::get().uniform_matrix3fv(Some(location), false, self));
     }
 }
 
 unsafe impl GLPrimitive for Rotation3<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        9
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -237,25 +104,8 @@ unsafe impl GLPrimitive for Rotation3<f32> {
 }
 
 unsafe impl GLPrimitive for Matrix4<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * 16;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        16
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -271,25 +121,8 @@ unsafe impl GLPrimitive for Matrix4<f32> {
  *
  */
 unsafe impl GLPrimitive for Vector4<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * 4;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        4
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -298,25 +131,8 @@ unsafe impl GLPrimitive for Vector4<f32> {
 }
 
 unsafe impl GLPrimitive for Vector3<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * 3;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        3
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -325,25 +141,8 @@ unsafe impl GLPrimitive for Vector3<f32> {
 }
 
 unsafe impl GLPrimitive for Vector2<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * 2;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        2
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -351,65 +150,14 @@ unsafe impl GLPrimitive for Vector2<f32> {
     }
 }
 
-// unsafe impl GLPrimitive for Vector2<u32> {
-//     #[inline]
-//     fn gl_type(_: Option<Vector2<u32>>) -> u32 {
-//         Context::UNSIGNED_INT
-//     }
-
-//     #[inline]
-//     fn size(_: Option<Vector2<u32>>) -> u32 {
-//         2
-//     }
-
-//     #[inline]
-//     fn upload(&self, location: &UniformLocation) {
-//         verify!(Context::get().uniform2ui(Some(location), self.x, self.y));
-//     }
-// }
-
-// unsafe impl GLPrimitive for Vector3<u32> {
-//     #[inline]
-//     fn gl_type(_: Option<Vector3<u32>>) -> u32 {
-//         Context::UNSIGNED_INT
-//     }
-
-//     #[inline]
-//     fn size(_: Option<Vector3<u32>>) -> u32 {
-//         3
-//     }
-
-//     #[inline]
-//     fn upload(&self, location: &UniformLocation) {
-//         verify!(Context::get().uniform3ui(Some(location), self.x, self.y, self.z));
-//     }
-// }
-
 /*
  *
  * Impl for points
  *
  */
 unsafe impl GLPrimitive for Point4<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        4
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -418,25 +166,8 @@ unsafe impl GLPrimitive for Point4<f32> {
 }
 
 unsafe impl GLPrimitive for Point3<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        3
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -445,25 +176,8 @@ unsafe impl GLPrimitive for Point3<f32> {
 }
 
 unsafe impl GLPrimitive for Point2<f32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        2
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -472,25 +186,8 @@ unsafe impl GLPrimitive for Point2<f32> {
 }
 
 unsafe impl GLPrimitive for Point3<i32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::INT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Int32(slice::from_raw_parts(ptr as *const i32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        3
-    }
+    type Element = i32;
+    const GLTYPE: u32 = Context::INT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -499,25 +196,8 @@ unsafe impl GLPrimitive for Point3<i32> {
 }
 
 unsafe impl GLPrimitive for Point2<i32> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::INT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Int32(slice::from_raw_parts(ptr as *const i32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        2
-    }
+    type Element = i32;
+    const GLTYPE: u32 = Context::INT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -526,57 +206,13 @@ unsafe impl GLPrimitive for Point2<i32> {
 }
 
 unsafe impl GLPrimitive for Point2<u16> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::UNSIGNED_SHORT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::UInt16(slice::from_raw_parts(ptr as *const u16, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        2
-    }
-
-    #[inline]
-    fn upload(&self, _: &UniformLocation) {
-        unimplemented!()
-    }
+    type Element = u16;
+    const GLTYPE: u32 = Context::UNSIGNED_SHORT;
 }
 
 unsafe impl GLPrimitive for Point3<u16> {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::UNSIGNED_SHORT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::UInt16(slice::from_raw_parts(ptr as *const u16, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        3
-    }
-
-    #[inline]
-    fn upload(&self, _: &UniformLocation) {
-        unimplemented!()
-    }
+    type Element = u16;
+    const GLTYPE: u32 = Context::UNSIGNED_SHORT;
 }
 
 /*
@@ -585,25 +221,8 @@ unsafe impl GLPrimitive for Point3<u16> {
  *
  */
 unsafe impl GLPrimitive for (f32, f32, f32) {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        3
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
@@ -612,62 +231,11 @@ unsafe impl GLPrimitive for (f32, f32, f32) {
 }
 
 unsafe impl GLPrimitive for (f32, f32) {
-    #[inline]
-    fn gl_type() -> u32 {
-        Context::FLOAT
-    }
-
-    #[inline]
-    fn flatten(array: &[Self]) -> PrimitiveArray {
-        unsafe {
-            let len = array.len() * Self::size() as usize;
-            let ptr = array.as_ptr();
-
-            PrimitiveArray::Float32(slice::from_raw_parts(ptr as *const f32, len))
-        }
-    }
-
-    #[inline]
-    fn size() -> u32 {
-        2
-    }
+    type Element = f32;
+    const GLTYPE: u32 = Context::FLOAT;
 
     #[inline]
     fn upload(&self, location: &UniformLocation) {
         verify!(Context::get().uniform2f(Some(location), self.0, self.1));
     }
 }
-
-// unsafe impl GLPrimitive for (u32, u32) {
-//     #[inline]
-//     fn gl_type(_: Option<(u32, u32)>) -> u32 {
-//         Context::UNSIGNED_INT
-//     }
-
-//     #[inline]
-//     fn size(_: Option<(u32, u32)>) -> u32 {
-//         2
-//     }
-
-//     #[inline]
-//     fn upload(&self, location: &UniformLocation) {
-//         verify!(Context::get().uniform2ui(Some(location), self.0, self.1));
-//     }
-// }
-
-// unsafe impl GLPrimitive for (u32, u32, u32) {
-//     #[inline]
-//     fn gl_type(_: Option<(u32, u32, u32)>) -> u32 {
-//         Context::UNSIGNED_INT
-//     }
-
-//     #[inline]
-//     fn size(_: Option<(u32, u32, u32)>) -> u32 {
-//         3
-//     }
-
-//     #[inline]
-//     fn upload(&self, location: &UniformLocation) {
-//         verify!(Context::get().uniform3ui(Some(location), self.0, self.1, self.2));
-//     }
-// }

--- a/src/resource/mesh.rs
+++ b/src/resource/mesh.rs
@@ -318,18 +318,18 @@ impl Mesh {
                 normal = cross
             }
 
-            normals[f.x as usize] = normals[f.x as usize] + normal;
-            normals[f.y as usize] = normals[f.y as usize] + normal;
-            normals[f.z as usize] = normals[f.z as usize] + normal;
+            normals[f.x as usize] += normal;
+            normals[f.y as usize] += normal;
+            normals[f.z as usize] += normal;
 
-            divisor[f.x as usize] = divisor[f.x as usize] + 1.0;
-            divisor[f.y as usize] = divisor[f.y as usize] + 1.0;
-            divisor[f.z as usize] = divisor[f.z as usize] + 1.0;
+            divisor[f.x as usize] += 1.0;
+            divisor[f.y as usize] += 1.0;
+            divisor[f.z as usize] += 1.0;
         }
 
         // ... and compute the mean
         for (n, divisor) in normals.iter_mut().zip(divisor.iter()) {
-            *n = *n / *divisor
+            *n /= *divisor
         }
     }
 }

--- a/src/resource/mesh_manager.rs
+++ b/src/resource/mesh_manager.rs
@@ -45,7 +45,7 @@ impl MeshManager {
 
     /// Get a mesh with the specified name. Returns `None` if the mesh is not registered.
     pub fn get(&mut self, name: &str) -> Option<Rc<RefCell<Mesh>>> {
-        self.meshes.get(&name.to_string()).map(|t| t.clone())
+        self.meshes.get(&name.to_string()).cloned()
     }
 
     /// Adds a mesh with the specified name to this cache.

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -5,7 +5,7 @@ pub use crate::resource::effect::{Effect, ShaderAttribute, ShaderUniform};
 pub use crate::resource::framebuffer_manager::{
     FramebufferManager, OffscreenBuffers, RenderTarget,
 };
-pub use crate::resource::gl_primitive::{GLPrimitive, PrimitiveArray};
+pub use crate::resource::gl_primitive::GLPrimitive;
 pub use crate::resource::gpu_vector::{AllocationType, BufferType, GPUVec};
 pub use crate::resource::material::{Material, PlanarMaterial};
 pub use crate::resource::material_manager::MaterialManager;

--- a/src/resource/planar_mesh_manager.rs
+++ b/src/resource/planar_mesh_manager.rs
@@ -78,7 +78,7 @@ impl PlanarMeshManager {
 
     /// Get a mesh with the specified name. Returns `None` if the mesh is not registered.
     pub fn get(&mut self, name: &str) -> Option<Rc<RefCell<PlanarMesh>>> {
-        self.meshes.get(&name.to_string()).map(|t| t.clone())
+        self.meshes.get(&name.to_string()).cloned()
     }
 
     /// Adds a mesh with the specified name to this cache.

--- a/src/resource/texture_manager.rs
+++ b/src/resource/texture_manager.rs
@@ -23,10 +23,10 @@ pub enum TextureWrapping {
     ClampToEdge,
 }
 
-impl Into<u32> for TextureWrapping {
+impl From<TextureWrapping> for u32 {
     #[inline]
-    fn into(self) -> u32 {
-        match self {
+    fn from(val: TextureWrapping) -> Self {
+        match val {
             TextureWrapping::Repeat => Context::REPEAT,
             TextureWrapping::MirroredRepeat => Context::MIRRORED_REPEAT,
             TextureWrapping::ClampToEdge => Context::CLAMP_TO_EDGE,
@@ -185,7 +185,7 @@ impl TextureManager {
     /// Allocates a new texture read from a file.
     fn load_texture_from_file(path: &Path) -> (Rc<Texture>, (u32, u32)) {
         TextureManager::load_texture_into_context(image::open(path).unwrap())
-            .expect(path.to_str().unwrap())
+            .unwrap_or_else(|e| panic!("Unable to load texture from file {:?}: {:?}", path, e))
     }
 
     fn load_texture_into_context(

--- a/src/scene/planar_scene_node.rs
+++ b/src/scene/planar_scene_node.rs
@@ -58,14 +58,12 @@ impl PlanarSceneNodeData {
     }
 
     fn remove(&mut self, o: &PlanarSceneNode) {
-        match self.children.iter().rposition(|e| {
-            &*o.data as *const RefCell<PlanarSceneNodeData> as usize
-                == &*e.data as *const RefCell<PlanarSceneNodeData> as usize
-        }) {
-            Some(i) => {
-                let _ = self.children.swap_remove(i);
-            }
-            None => {}
+        if let Some(i) = self
+            .children
+            .iter()
+            .rposition(|e| std::ptr::eq(&*o.data, &*e.data))
+        {
+            let _ = self.children.swap_remove(i);
         }
     }
 
@@ -100,9 +98,8 @@ impl PlanarSceneNodeData {
             self.world_scale = scale.component_mul(&self.local_scale);
         }
 
-        match self.object {
-            Some(ref o) => o.render(&self.world_transform, &self.world_scale, camera),
-            None => {}
+        if let Some(ref o) = self.object {
+            o.render(&self.world_transform, &self.world_scale, camera)
         }
 
         for c in self.children.iter_mut() {
@@ -331,9 +328,8 @@ impl PlanarSceneNodeData {
     /// Applies a closure to each object contained by this node and its children.
     #[inline]
     pub fn apply_to_objects_mut<F: FnMut(&mut PlanarObject)>(&mut self, f: &mut F) {
-        match self.object {
-            Some(ref mut o) => f(o),
-            None => {}
+        if let Some(ref mut o) = self.object {
+            f(o)
         }
 
         for c in self.children.iter_mut() {
@@ -344,9 +340,8 @@ impl PlanarSceneNodeData {
     /// Applies a closure to each object contained by this node and its children.
     #[inline]
     pub fn apply_to_objects<F: FnMut(&PlanarObject)>(&self, f: &mut F) {
-        match self.object {
-            Some(ref o) => f(o),
-            None => {}
+        if let Some(ref o) = self.object {
+            f(o)
         }
 
         for c in self.children.iter() {

--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -58,14 +58,12 @@ impl SceneNodeData {
     }
 
     fn remove(&mut self, o: &SceneNode) {
-        match self.children.iter().rposition(|e| {
-            &*o.data as *const RefCell<SceneNodeData> as usize
-                == &*e.data as *const RefCell<SceneNodeData> as usize
-        }) {
-            Some(i) => {
-                let _ = self.children.swap_remove(i);
-            }
-            None => {}
+        if let Some(i) = self
+            .children
+            .iter()
+            .rposition(|e| std::ptr::eq(&*o.data, &*e.data))
+        {
+            let _ = self.children.swap_remove(i);
         }
     }
 
@@ -102,15 +100,14 @@ impl SceneNodeData {
             self.world_scale = scale.component_mul(&self.local_scale);
         }
 
-        match self.object {
-            Some(ref o) => o.render(
+        if let Some(ref o) = self.object {
+            o.render(
                 &self.world_transform,
                 &self.world_scale,
                 pass,
                 camera,
                 light,
-            ),
-            None => {}
+            )
         }
 
         for c in self.children.iter_mut() {
@@ -368,9 +365,8 @@ impl SceneNodeData {
     /// Applies a closure to each object contained by this node and its children.
     #[inline]
     pub fn apply_to_objects_mut<F: FnMut(&mut Object)>(&mut self, f: &mut F) {
-        match self.object {
-            Some(ref mut o) => f(o),
-            None => {}
+        if let Some(ref mut o) = self.object {
+            f(o)
         }
 
         for c in self.children.iter_mut() {
@@ -381,9 +377,8 @@ impl SceneNodeData {
     /// Applies a closure to each object contained by this node and its children.
     #[inline]
     pub fn apply_to_objects<F: FnMut(&Object)>(&self, f: &mut F) {
-        match self.object {
-            Some(ref o) => f(o),
-            None => {}
+        if let Some(ref o) = self.object {
+            f(o)
         }
 
         for c in self.children.iter() {

--- a/src/text/font.rs
+++ b/src/text/font.rs
@@ -26,7 +26,7 @@ impl Font {
 
     /// Loads a new ttf font from the memory.
     pub fn from_bytes(memory: &[u8]) -> Option<Rc<Font>> {
-        let font = rusttype::Font::from_bytes(memory.to_vec()).unwrap();
+        let font = rusttype::Font::try_from_vec(memory.to_vec()).unwrap();
         Some(Rc::new(Font { font }))
     }
 

--- a/src/text/renderer.rs
+++ b/src/text/renderer.rs
@@ -221,8 +221,7 @@ impl TextRenderer {
                 {
                     let coords = self.coords.data_mut().as_mut().unwrap();
                     for glyph in layout {
-                        if let Some(Some((tex, rect))) = self.cache.rect_for(font_uid, &glyph).ok()
-                        {
+                        if let Ok(Some((tex, rect))) = self.cache.rect_for(font_uid, &glyph) {
                             let min_px = rect.min.x as f32;
                             let min_py = rect.min.y as f32 + vmetrics.ascent;
                             let max_px = rect.max.x as f32;

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -117,10 +117,12 @@ impl Canvas {
         self.canvas.set_cursor_grab(grab);
     }
 
+    /// Set the cursor position.
     pub fn set_cursor_position(&self, x: f64, y: f64) {
         self.canvas.set_cursor_position(x, y);
     }
 
+    /// Toggle the cursor visibility.
     pub fn hide_cursor(&self, hide: bool) {
         self.canvas.hide_cursor(hide);
     }

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -7,10 +7,8 @@ use std::iter::repeat;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::mpsc::{self, Receiver};
-use std::thread;
 use std::time::Duration;
 
-use instant::Instant;
 use na::{Point2, Point3, Vector2, Vector3};
 
 use crate::camera::{ArcBall, Camera};
@@ -77,7 +75,7 @@ pub struct Window {
     framebuffer_manager: FramebufferManager,
     post_process_render_target: RenderTarget,
     #[cfg(not(target_arch = "wasm32"))]
-    curr_time: Instant,
+    curr_time: std::time::Instant,
     planar_camera: Rc<RefCell<FixedView>>,
     camera: Rc<RefCell<ArcBall>>,
     should_close: bool,
@@ -152,11 +150,13 @@ impl Window {
     }
 
     #[inline]
+    /// Set the cursor position.
     pub fn set_cursor_position(&self, x: f64, y: f64) {
         self.canvas.set_cursor_position(x, y);
     }
 
     #[inline]
+    /// Toggle the cursor visibility.
     pub fn hide_cursor(&self, hide: bool) {
         self.canvas.hide_cursor(hide);
     }
@@ -551,7 +551,7 @@ impl Window {
             ),
             framebuffer_manager: FramebufferManager::new(),
             #[cfg(not(target_arch = "wasm32"))]
-            curr_time: Instant::now(),
+            curr_time: std::time::Instant::now(),
             planar_camera: Rc::new(RefCell::new(FixedView::new())),
             camera: Rc::new(RefCell::new(ArcBall::new(
                 Point3::new(0.0f32, 0.0, -1.0),
@@ -1060,9 +1060,8 @@ impl Window {
         planar_camera.update(&self.canvas);
         camera.update(&self.canvas);
 
-        match self.light_mode {
-            Light::StickToCamera => self.set_light(Light::StickToCamera),
-            _ => {}
+        if let Light::StickToCamera = self.light_mode {
+            self.set_light(Light::StickToCamera)
         }
 
         if post_processing.is_some() {
@@ -1123,11 +1122,11 @@ impl Window {
             if let Some(dur) = self.max_dur_per_frame {
                 let elapsed = self.curr_time.elapsed();
                 if elapsed < dur {
-                    thread::sleep(dur - elapsed);
+                    std::thread::sleep(dur - elapsed);
                 }
             }
 
-            self.curr_time = Instant::now();
+            self.curr_time = std::time::Instant::now();
         }
 
         // self.transparent_objects.clear();


### PR DESCRIPTION
- update `rusttype` version to simplify dependency tree & hence improve compile time
- refactor `gl_primative.rs` to make better use of generics
- clean up a lot of misc. warnings/lints