### PR TITLE
camera: improved arcball translation and zoom

### DIFF
--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -52,6 +52,7 @@ pub struct ArcBall {
     proj_view: Matrix4<f32>,
     inverse_proj_view: Matrix4<f32>,
     last_cursor_pos: Vector2<f32>,
+    last_framebuffer_size: Vector2<u32>,
     coord_system: CoordSystemRh,
 }
 
@@ -91,6 +92,7 @@ impl ArcBall {
             proj: na::zero(),
             proj_view: na::zero(),
             inverse_proj_view: na::zero(),
+            last_framebuffer_size: Vector2::new(800, 600),
             last_cursor_pos: na::zero(),
             coord_system: CoordSystemRh::from_up_axis(Vector3::y_axis()),
         };
@@ -301,14 +303,14 @@ impl ArcBall {
         self.update_projviews();
     }
 
+    // Performs a translation of the camera eye and focus.
+    // The delta coordinates are expected to be normalized to the [-1, 1] range.
     fn handle_right_button_displacement(&mut self, dpos: &Vector2<f32>) {
         let eye = self.eye();
         let dir = (self.at - eye).normalize();
         let tangent = self.coord_system.up_axis.cross(&dir).normalize();
         let bitangent = dir.cross(&tangent);
-        let mult = self.dist / 1000.0;
-
-        self.at = self.at + tangent * (dpos.x * mult) + bitangent * (dpos.y * mult);
+        self.at = self.at + tangent * (dpos.x * self.dist) + bitangent * (dpos.y * self.dist);
         self.update_projviews();
     }
 
@@ -385,7 +387,9 @@ impl Camera for ArcBall {
                     if canvas.get_mouse_button(drag_button) == Action::Press
                         && self.drag_modifiers.map(|m| m == modifiers).unwrap_or(true)
                     {
-                        let dpos = curr_pos - self.last_cursor_pos;
+                        let mut dpos = curr_pos - self.last_cursor_pos;
+                        dpos.x /= self.last_framebuffer_size.x as f32;
+                        dpos.y /= self.last_framebuffer_size.y as f32;
                         self.handle_right_button_displacement(&dpos)
                     }
                 }
@@ -398,6 +402,7 @@ impl Camera for ArcBall {
             }
             WindowEvent::Scroll(_, off, _) => self.handle_scroll(off as f32),
             WindowEvent::FramebufferSize(w, h) => {
+                self.last_framebuffer_size = Vector2::new(w, h);
                 self.projection.set_aspect(w as f32 / h as f32);
                 self.update_projviews();
             }


### PR DESCRIPTION
#### camera: correct translation displacement scale

When dragging to translate (right button), the cursor position change
(in pixels) is scaled down by an arbitrary 1000.0. This should be
scaled by the frame-buffer size, so that the object under the cursor
stays under the cursor.

This commit fixes this; we now normalize the mouse coordinates to the
range [-1,1].

#### camera: improved arcball mouse zoom

This commit improves the mouse zoom for the arcball camera. Currently
the zoom is toward the center point, regardless of the mouse position.
With this change, the zoom is now focused toward the part of the scene
under the cursor.

We achieve this by temporarily translating the camera to change the
focus point.
