### PR TITLE
Add line width to planar line renderer

### DIFF
--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -3,7 +3,7 @@ extern crate nalgebra as na;
 
 use kiss3d::light::Light;
 use kiss3d::window::Window;
-use na::Point3;
+use na::{Point2, Point3};
 
 fn main() {
     let mut window = Window::new("Kiss3d: lines");
@@ -15,8 +15,15 @@ fn main() {
         let b = Point3::new(0.0, 0.1, 0.0);
         let c = Point3::new(0.1, -0.1, 0.0);
 
+        window.set_line_width(2.0);
         window.draw_line(&a, &b, &Point3::new(1.0, 0.0, 0.0));
         window.draw_line(&b, &c, &Point3::new(0.0, 1.0, 0.0));
         window.draw_line(&c, &a, &Point3::new(0.0, 0.0, 1.0));
+
+        window.draw_planar_line(
+            &Point2::new(-100.0, -200.0),
+            &Point2::new(100.0, -200.0),
+            &Point3::new(1.0, 1.0, 1.0),
+        );
     }
 }

--- a/src/planar_line_renderer.rs
+++ b/src/planar_line_renderer.rs
@@ -17,6 +17,7 @@ pub struct PlanarLineRenderer {
     proj: ShaderUniform<Matrix3<f32>>,
     colors: GPUVec<Point3<f32>>,
     lines: GPUVec<Point2<f32>>,
+    line_width: f32,
 }
 
 impl PlanarLineRenderer {
@@ -42,6 +43,7 @@ impl PlanarLineRenderer {
                 .get_uniform::<Matrix3<f32>>("proj")
                 .expect("Failed to get shader uniform."),
             shader,
+            line_width: 1.0,
         }
     }
 
@@ -80,6 +82,7 @@ impl PlanarLineRenderer {
 
         let ctxt = Context::get();
         verify!(ctxt.draw_arrays(Context::LINES, 0, self.lines.len() as i32));
+        verify!(ctxt.line_width(self.line_width));
 
         self.pos.disable();
         self.color.disable();
@@ -91,6 +94,11 @@ impl PlanarLineRenderer {
         for colors in self.colors.data_mut().iter_mut() {
             colors.clear()
         }
+    }
+
+    /// Sets the line width for the rendered lines.
+    pub fn set_line_width(&mut self, line_width: f32) {
+        self.line_width = line_width;
     }
 }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -215,7 +215,7 @@ impl Window {
         self.background.z = b;
     }
 
-    /// Set the size of all subsequent points to be drawn until the next time this function is envoked.
+    /// Set the size of all points that will be rendered.
     ///
     /// Unfortunately, not all point sizes are supported by all graphics drivers.
     #[inline]
@@ -223,10 +223,11 @@ impl Window {
         self.point_renderer.set_point_size(pt_size);
     }
 
-    /// Set the width of all subsequent lines to be drawn until the next time this function is envoked.
+    /// Set the width of all lines that will be rendered.
     #[inline]
     pub fn set_line_width(&mut self, line_width: f32) {
         self.line_renderer.set_line_width(line_width);
+        self.planar_line_renderer.set_line_width(line_width);
     }
 
     /// Adds a 3D line to be drawn during the next render.


### PR DESCRIPTION
The planar line renderer does not currently set the line width; when
rendering, it inherits any line width that was set by the 3D line
renderer (if it happened to be used).

This commit adds a line width setting to the planar line renderer; the
`window::set_line_width` method sets it together with the 3D line
width.