### PR TITLE
Update camera.rs

### DIFF
--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -5,7 +5,7 @@ use kiss3d::camera::{ArcBall, FirstPerson};
 use kiss3d::event::{Action, Key, WindowEvent};
 use kiss3d::light::Light;
 use kiss3d::window::Window;
-use na::Point3;
+use kiss3d::nalgebra::Point3;
 
 fn main() {
     let eye = Point3::new(10.0f32, 10.0, 10.0);

--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -4,8 +4,8 @@ extern crate nalgebra as na;
 use kiss3d::camera::{ArcBall, FirstPerson};
 use kiss3d::event::{Action, Key, WindowEvent};
 use kiss3d::light::Light;
-use kiss3d::window::Window;
 use kiss3d::nalgebra::Point3;
+use kiss3d::window::Window;
 
 fn main() {
     let eye = Point3::new(10.0f32, 10.0, 10.0);


### PR DESCRIPTION
change `Point3`'s reference from `nalgebra` to `kiss3d::nalgebra`


when I ran the camera example, this error occurs

```
error[E0308]: mismatched types
  --> src\main.rs:52:13
   |
52 |             &Point3::new(0.0, 0.0, 1.0),
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `kiss3d::nalgebra::OPoint`, found struct `na::OPoint`
   |
   = note: expected reference `&kiss3d::nalgebra::OPoint<f32, kiss3d::nalgebra::Const<3_usize>>`
              found reference `&na::OPoint<{float}, na::Const<3_usize>>`
   = note: perhaps two different versions of crate `nalgebra` are being used?

For more information about this error, try `rustc --explain E0308`.
error: could not compile `kisstest` due to 13 previous errors
```

It can run after change.

first time pull request, sorry if I missed something