### PR TITLE
Set line width before rendering

### DIFF
--- a/src/planar_line_renderer.rs
+++ b/src/planar_line_renderer.rs
@@ -81,8 +81,8 @@ impl PlanarLineRenderer {
         self.pos.bind_sub_buffer(&mut self.lines, 0, 0);
 
         let ctxt = Context::get();
-        verify!(ctxt.draw_arrays(Context::LINES, 0, self.lines.len() as i32));
         verify!(ctxt.line_width(self.line_width));
+        verify!(ctxt.draw_arrays(Context::LINES, 0, self.lines.len() as i32));
 
         self.pos.disable();
         self.color.disable();

--- a/src/renderer/line_renderer.rs
+++ b/src/renderer/line_renderer.rs
@@ -87,8 +87,8 @@ impl Renderer for LineRenderer {
         self.pos.bind_sub_buffer(&mut self.lines, 1, 0);
 
         let ctxt = Context::get();
-        verify!(ctxt.draw_arrays(Context::LINES, 0, (self.lines.len() / 2) as i32));
         verify!(ctxt.line_width(self.line_width));
+        verify!(ctxt.draw_arrays(Context::LINES, 0, (self.lines.len() / 2) as i32));
 
         self.pos.disable();
         self.color.disable();


### PR DESCRIPTION
This commit fixes a bug in the line renderers: the line width was
being set *after* the draw call. This problem is only visible if some
other custom material changes the line width (otherwise the width from
the last frame stays in effect).