### PR TITLE
Added to SceneNode to use new_empty() as a default

### DIFF
--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -582,6 +582,12 @@ impl SceneNodeData {
     }
 }
 
+impl Default for SceneNode {
+    fn default() -> SceneNode {
+        SceneNode::new_empty()
+    }
+}
+
 impl SceneNode {
     /// Creates a new scene node that is not rooted.
     pub fn new(


### PR DESCRIPTION
for #296 

Maybe new_empty() should be removed so there aren't two functions doing the same thing? But that would be a breaking change.