### PR TITLE
Remove `RenderLoopClosure` trait

### DIFF
--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -70,7 +70,7 @@ impl Canvas {
     }
 
     /// Run the platform-specific render loop.
-    pub fn render_loop(data: impl RenderLoopClosure) {
+    pub fn render_loop(data: impl FnMut(f64) -> bool + 'static) {
         CanvasImpl::render_loop(data)
     }
 
@@ -148,13 +148,6 @@ impl Canvas {
     }
 }
 
-/// Note: the closure must have static lifetime because of the constraints imposed by wasm-bindgen:
-/// https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html
-pub trait RenderLoopClosure: 'static {
-    /// Call the closure
-    fn call(&mut self, x: f64) -> bool;
-}
-
 pub(crate) trait AbstractCanvas {
     fn open(
         title: &str,
@@ -164,7 +157,7 @@ pub(crate) trait AbstractCanvas {
         window_setup: Option<CanvasSetup>,
         out_events: Sender<WindowEvent>,
     ) -> Self;
-    fn render_loop(data: impl RenderLoopClosure);
+    fn render_loop(data: impl FnMut(f64) -> bool + 'static);
     fn poll_events(&mut self);
     fn swap_buffers(&mut self);
     fn size(&self) -> (u32, u32);

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc::Sender;
 
 use crate::context::Context;
 use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent};
-use crate::window::canvas::{CanvasSetup, NumSamples, RenderLoopClosure};
+use crate::window::canvas::{CanvasSetup, NumSamples};
 use crate::window::AbstractCanvas;
 use glutin::{
     self,
@@ -97,9 +97,9 @@ impl AbstractCanvas for GLCanvas {
         }
     }
 
-    fn render_loop(mut callback: impl RenderLoopClosure) {
+    fn render_loop(mut callback: impl FnMut(f64) -> bool + 'static) {
         loop {
-            if !callback.call(0.0) {
+            if !callback(0.0) {
                 break;
             } // XXX: timestamp
         }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -10,7 +10,7 @@ mod window;
 mod window_cache;
 
 pub(crate) use canvas::AbstractCanvas;
-pub use canvas::{Canvas, CanvasSetup, NumSamples, RenderLoopClosure};
+pub use canvas::{Canvas, CanvasSetup, NumSamples};
 #[cfg(not(target_arch = "wasm32"))]
 pub use gl_canvas::GLCanvas;
 pub use state::State;

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::Sender;
 
 use crate::context::Context;
 use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent};
-use crate::window::{AbstractCanvas, CanvasSetup, RenderLoopClosure};
+use crate::window::{AbstractCanvas, CanvasSetup};
 use image::{GenericImage, Pixel};
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, JsValue};
@@ -424,13 +424,13 @@ impl AbstractCanvas for WebGLCanvas {
         }
     }
 
-    fn render_loop(mut callback: impl RenderLoopClosure) {
+    fn render_loop(mut callback: impl FnMut(f64) -> bool + 'static) {
         // See https://rustwasm.github.io/docs/wasm-bindgen/examples/request-animation-frame.html
         if let Some(window) = web_sys::window() {
             let f = Rc::new(RefCell::new(None));
             let g: Rc<RefCell<Option<Closure<_>>>> = f.clone();
             *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
-                if callback.call(0.0) {
+                if callback(0.0) {
                     let _ = window.request_animation_frame(
                         f.borrow().as_ref().unwrap().as_ref().unchecked_ref(),
                     );


### PR DESCRIPTION
I got better at Rust, and realized that we don't need this trait (which I added a year ago). We can just make `RenderLoopClosureImpl` implement `FnMut` and keep the method signatures the same as before.

But then it turns out that you can't implement the `Fn` without some unstable features, so I came up with something else.

This reverses a lot of the changes from #286, but still has the same effect: `cargo run --example persistent_point_cloud` does not give an error when the window is closed (which is what drove me to make that PR in the first place.) But it avoids adding an unnecessary trait that leaks into the public interface.