### PR TITLE
Fix for github.com/sebcrozet/kiss3d/issues/98

### DIFF
--- a/src/text/renderer.rs
+++ b/src/text/renderer.rs
@@ -160,7 +160,7 @@ impl TextRenderer {
         self.pos.enable();
         self.uvs.enable();
         self.tex.upload(&0);
-        self.invsz.upload(&Vector2::new(1.0 / width, -1.0 / height));
+        self.invsz.upload(&Vector2::new(2.0 / width, -2.0 / height));
 
         verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&self.texture)));
         verify!(ctxt.tex_parameteri(


### PR DESCRIPTION
The normalized OpenGL clip coordinates are defined as follows. The origin is at the center of the view. The horizontal or x-axis ranges left to right from -1 to 1. The vertical or y-axis also ranges bottom to top from -1 to 1.

Device or screen coordinates are a rasterized version of the following. The origin is the top left corner of the view port (window). For a view port of width ϝ and height η, the horizontal or x-axis ranges left to right from 0 to ϝ, and the vertical axis ranges top to botton from from 0 to η.

Clip coordinates map to device coordinates in the following way. Let (x, y) be a position in clip coordinates, and (χ, υ) be the same position in device coordinates. This means that χ = [(ϝ - 0)/(1 - -1)](x - 1) and υ = [(0 - η)/(1 - -1)](y - 1). These reduce to χ = (ϝ/2)(x - 1) and υ = -(η/2)(y - 1), respectively.

The inverse of the transformations are the following. x = 1 + (2/ϝ)x and y = 1 - (2/η)υ.

In both the horizontal and vertical directions, the scale factor is twice (2x) what the previous version in the function method `text::renderer::TextRender::render`.

This should be sufficient to close issue https://github.com/sebcrozet/kiss3d/issues/98. This issue raised two problems. The first, about `camera::Camera::project` not reversing the y-axis, was addressed by #sebcrozet, where they explained that this doesn't make sense in general.  The second, about `window::Window::draw_text` thinking the view port size is twice as large as it actually is, is address by this PR.