### PR TITLE
Remove check for asmjs architecture

### DIFF
--- a/src/resource/framebuffer_manager.rs
+++ b/src/resource/framebuffer_manager.rs
@@ -169,7 +169,7 @@ impl FramebufferManager {
         verify!(ctxt.bind_texture(Context::TEXTURE_2D, None));
 
         /* Depth buffer */
-        if create_depth_texture && cfg!(not(any(target_arch = "wasm32", target_arch = "asmjs"))) {
+        if create_depth_texture && cfg!(not(target_arch = "wasm32")) {
             verify!(ctxt.active_texture(Context::TEXTURE1));
             let fbo_depth = verify!(ctxt.create_texture().expect("Failed to create a texture."));
             verify!(ctxt.bind_texture(Context::TEXTURE_2D, Some(&fbo_depth)));


### PR DESCRIPTION
Rust used to support asmjs as a target, but now the support for asmjs has been removed from the list of valid target architectures. This could be because Rust is moving forward with wasm (WebAssembly) as the primary target for web development instead of asm.js.

The support for the asmjs target was removed in Rust 1.60.0, which was released in March 2022. I cannot longer build with rustc 1.81.0 (eeb90cda1 2024-09-04)
.



