### PR TITLE
Implement zoom_step() and set_zoom_step() to PanZoomCamera2d camera.

### DIFF
--- a/src/camera/sidescroll2d.rs
+++ b/src/camera/sidescroll2d.rs
@@ -73,6 +73,16 @@ impl PanZoomCamera2d {
         self.update_projviews();
     }
 
+    /// Gets the zoom step of the camera.
+    pub fn zoom_step(&self) -> f32 {
+        self.zoom_step
+    }
+
+    /// Sets the zoom step of the camera.
+    pub fn set_zoom_step(&mut self, new_zoom_step: f32) {
+        self.zoom_step = new_zoom_step;
+    }
+
     /// Move the camera such that it is centered on a specific point.
     pub fn look_at(&mut self, at: Vec2, zoom: f32) {
         self.at = at;


### PR DESCRIPTION
I added zoom_step() and set_zoom_step() to PanZoomCamera2d camera.
It may be useful to control zoom levels (e.g., configure the increment/decrement step when changing zoom levels).