### PR TITLE
Allow window creation using WindowAttributes.

### DIFF
--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc::Sender;
 use crate::event::{Action, Key, MouseButton, WindowEvent};
 use crate::window::WgpuCanvas;
 use image::{GenericImage, Pixel};
+use winit::window::WindowAttributes;
 
 /// The possible number of samples for multisample anti-aliasing.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -56,15 +57,12 @@ pub struct Canvas {
 impl Canvas {
     /// Open a new window, and initialize the wgpu context.
     pub async fn open(
-        title: &str,
-        hide: bool,
-        width: u32,
-        height: u32,
+        window_attrs: WindowAttributes,
         canvas_setup: Option<CanvasSetup>,
         out_events: Sender<WindowEvent>,
     ) -> Self {
         Canvas {
-            canvas: WgpuCanvas::open(title, hide, width, height, canvas_setup, out_events).await,
+            canvas: WgpuCanvas::open(window_attrs, canvas_setup, out_events).await,
         }
     }
 

--- a/src/window/wgpu_canvas.rs
+++ b/src/window/wgpu_canvas.rs
@@ -90,18 +90,10 @@ pub struct WgpuCanvas {
 impl WgpuCanvas {
     /// Opens a new window and initializes the wgpu context.
     pub async fn open(
-        title: &str,
-        hide: bool,
-        width: u32,
-        height: u32,
+        window_attrs: WindowAttributes,
         canvas_setup: Option<CanvasSetup>,
         out_events: Sender<WindowEvent>,
     ) -> Self {
-        let window_attrs = WindowAttributes::default()
-            .with_title(title)
-            .with_inner_size(LogicalSize::new(width as f64, height as f64))
-            .with_visible(!hide);
-
         let canvas_setup = canvas_setup.unwrap_or(CanvasSetup {
             vsync: true,
             samples: NumSamples::Zero,

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -18,6 +18,8 @@ use crate::window::canvas::CanvasSetup;
 use crate::window::Canvas;
 use glamx::UVec2;
 use image::{GenericImage, Pixel};
+use winit::dpi::LogicalSize;
+use winit::window::WindowAttributes;
 
 #[cfg(feature = "egui")]
 pub(super) use super::egui_integration::EguiContext;
@@ -337,6 +339,21 @@ impl Window {
         Window::do_new(title, false, width, height, Some(setup)).await
     }
 
+    /// Creates a new window with custom attributes.
+    ///
+    /// This allows fine-grained control over window creation.
+    ///
+    /// # Arguments
+    /// * `window_attrs` - The window title
+    ///
+    /// # Returns
+    /// A new `Window` instance
+    pub async fn new_with_window_attributes(
+        window_attrs: WindowAttributes,
+    ) -> Window {
+        Window::do_new_with_window_attributes(window_attrs, None).await
+    }
+
     // TODO: make this pub?
     async fn do_new(
         title: &str,
@@ -345,8 +362,20 @@ impl Window {
         height: u32,
         setup: Option<CanvasSetup>,
     ) -> Window {
+        let window_attrs = WindowAttributes::default()
+            .with_title(title)
+            .with_inner_size(LogicalSize::new(width as f64, height as f64))
+            .with_visible(!hide);
+        Self::do_new_with_window_attributes(window_attrs, setup).await
+    }
+    async fn do_new_with_window_attributes(
+        window_attrs: WindowAttributes,
+        setup: Option<CanvasSetup>,
+    ) -> Window {
         let (event_send, event_receive) = mpsc::channel();
-        let canvas = Canvas::open(title, hide, width, height, setup, event_send).await;
+        let hide = !window_attrs.visible;
+        let canvas = Canvas::open(window_attrs, setup, event_send).await;
+        let (width, height) = canvas.size();
 
         // Track window count for proper cleanup
         Context::increment_window_count();


### PR DESCRIPTION
Add window creation using WindowAttributes while maintaining backward compatibility (i.e., without removing previous window creation functions) by converting parameters (title, width, height and hide) to WindowAttributes.
#363 