### PR TITLE
fix first frame render occasionally failing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bytemuck     = { version = "1", features = ["derive"] }
 egui         = { version = "0.34", optional = true, default-features = true }
 egui-wgpu    = { version = "0.34", optional = true }
 image        = { version = "0.25", default-features = false, features = ["default-formats"] }
+log          = "0.4"
 web-time     = "1"
 kiss3d-macro = { version = "0.36.0", path = "kiss3d-macro" }
 glamx         = { version = "0.2", features = ["bytemuck"] }

--- a/src/camera/sidescroll2d.rs
+++ b/src/camera/sidescroll2d.rs
@@ -186,9 +186,10 @@ impl Camera2d for PanZoomCamera2d {
                 self.last_cursor_pos = curr_pos;
             }
             WindowEvent::Scroll(_, off, modifiers)
-                if (self.zoom_modifier.is_none() || self.zoom_modifier == Some(modifiers)) => {
-                    self.handle_scroll(off as f32)
-                }
+                if (self.zoom_modifier.is_none() || self.zoom_modifier == Some(modifiers)) =>
+            {
+                self.handle_scroll(off as f32)
+            }
             WindowEvent::FramebufferSize(w, h) => {
                 self.proj = Mat3::from_cols(
                     Vec3::new(2.0 * (scale as f32) / (w as f32), 0.0, 0.0),

--- a/src/camera/sidescroll2d.rs
+++ b/src/camera/sidescroll2d.rs
@@ -185,11 +185,10 @@ impl Camera2d for PanZoomCamera2d {
 
                 self.last_cursor_pos = curr_pos;
             }
-            WindowEvent::Scroll(_, off, modifiers) => {
-                if self.zoom_modifier.is_none() || self.zoom_modifier == Some(modifiers) {
+            WindowEvent::Scroll(_, off, modifiers)
+                if (self.zoom_modifier.is_none() || self.zoom_modifier == Some(modifiers)) => {
                     self.handle_scroll(off as f32)
                 }
-            }
             WindowEvent::FramebufferSize(w, h) => {
                 self.proj = Mat3::from_cols(
                     Vec3::new(2.0 * (scale as f32) / (w as f32), 0.0, 0.0),

--- a/src/loader/mtl.rs
+++ b/src/loader/mtl.rs
@@ -77,7 +77,7 @@ pub fn parse(string: &str) -> Vec<MtlMaterial> {
                             curr_material.opacity_map = Some(parse_name(l, words))
                         }
                         _ => {
-                            println!("Warning: unknown line {} ignored: `{}'", l, line);
+                            log::warn!("unknown line {} ignored: `{}'", l, line);
                         }
                     }
                 }

--- a/src/loader/mtl.rs
+++ b/src/loader/mtl.rs
@@ -31,56 +31,54 @@ pub fn parse(string: &str) -> Vec<MtlMaterial> {
 
     for (l, line) in string.lines().enumerate() {
         let mut words = obj::split_words(line);
-        let tag = words.next();
+        let Some(w) = words.next() else {
+            continue;
+        };
+        if w.is_empty() || w.as_bytes()[0] == b'#' {
+            continue;
+        }
 
-        match tag {
-            None => {}
-            Some(w) => {
-                if !w.is_empty() && w.as_bytes()[0] != b'#' {
-                    let mut p = obj::split_words(line).peekable();
-                    let _ = p.next();
+        let mut p = obj::split_words(line).peekable();
+        let _ = p.next();
 
-                    if p.peek().is_none() {
-                        continue;
-                    }
+        if p.peek().is_none() {
+            continue;
+        }
 
-                    match w {
-                        // texture name
-                        "newmtl" => {
-                            let old = mem::replace(
-                                &mut curr_material,
-                                MtlMaterial::new_default(parse_name(l, words)),
-                            );
+        match w {
+            // texture name
+            "newmtl" => {
+                let old = mem::replace(
+                    &mut curr_material,
+                    MtlMaterial::new_default(parse_name(l, words)),
+                );
 
-                            if !old.name.is_empty() {
-                                res.push(old);
-                            }
-                        }
-                        // ambient color
-                        "Ka" => curr_material.ambient = parse_color(l, words),
-                        // diffuse color
-                        "Kd" => curr_material.diffuse = parse_color(l, words),
-                        // specular color
-                        "Ks" => curr_material.specular = parse_color(l, words),
-                        // shininess
-                        "Ns" => curr_material.shininess = parse_scalar(l, words),
-                        // alpha
-                        "d" => curr_material.alpha = parse_scalar(l, words),
-                        // ambient map
-                        "map_Ka" => curr_material.ambient_texture = Some(parse_name(l, words)),
-                        // diffuse texture map
-                        "map_Kd" => curr_material.diffuse_texture = Some(parse_name(l, words)),
-                        // specular texture map
-                        "map_Ks" => curr_material.specular_texture = Some(parse_name(l, words)),
-                        // specular texture map
-                        "map_d" | "map_opacity" => {
-                            curr_material.opacity_map = Some(parse_name(l, words))
-                        }
-                        _ => {
-                            log::warn!("unknown line {} ignored: `{}'", l, line);
-                        }
-                    }
+                if !old.name.is_empty() {
+                    res.push(old);
                 }
+            }
+            // ambient color
+            "Ka" => curr_material.ambient = parse_color(l, words),
+            // diffuse color
+            "Kd" => curr_material.diffuse = parse_color(l, words),
+            // specular color
+            "Ks" => curr_material.specular = parse_color(l, words),
+            // shininess
+            "Ns" => curr_material.shininess = parse_scalar(l, words),
+            // alpha
+            "d" => curr_material.alpha = parse_scalar(l, words),
+            // ambient map
+            "map_Ka" => curr_material.ambient_texture = Some(parse_name(l, words)),
+            // diffuse texture map
+            "map_Kd" => curr_material.diffuse_texture = Some(parse_name(l, words)),
+            // specular texture map
+            "map_Ks" => curr_material.specular_texture = Some(parse_name(l, words)),
+            // specular texture map
+            "map_d" | "map_opacity" => {
+                curr_material.opacity_map = Some(parse_name(l, words))
+            }
+            _ => {
+                log::warn!("unknown line {} ignored: `{}'", l, line);
             }
         }
     }

--- a/src/loader/mtl.rs
+++ b/src/loader/mtl.rs
@@ -74,9 +74,7 @@ pub fn parse(string: &str) -> Vec<MtlMaterial> {
             // specular texture map
             "map_Ks" => curr_material.specular_texture = Some(parse_name(l, words)),
             // specular texture map
-            "map_d" | "map_opacity" => {
-                curr_material.opacity_map = Some(parse_name(l, words))
-            }
+            "map_d" | "map_opacity" => curr_material.opacity_map = Some(parse_name(l, words)),
             _ => {
                 log::warn!("unknown line {} ignored: `{}'", l, line);
             }

--- a/src/loader/obj.rs
+++ b/src/loader/obj.rs
@@ -531,11 +531,7 @@ fn reformat(
     )));
 
     let mut meshes = Vec::new();
-    for ((fs, name), mtl) in resfs
-        .into_iter()
-        .zip(names)
-        .zip(mtls)
-    {
+    for ((fs, name), mtl) in resfs.into_iter().zip(names).zip(mtls) {
         if !fs.is_empty() {
             let fs = Arc::new(RwLock::new(GPUVec::new(
                 fs,

--- a/src/loader/obj.rs
+++ b/src/loader/obj.rs
@@ -141,58 +141,57 @@ pub fn parse(
 
     for (l, line) in string.lines().enumerate() {
         let mut words = split_words(line);
-        let tag = words.next();
-        match tag {
-            None => {}
-            Some(w) => {
-                if !w.is_empty() && w.as_bytes()[0] != b'#' {
-                    match w {
-                        "v" => coords.push(parse_v_or_vn(l, words)),
-                        "vn" => {
-                            if !ignore_normals {
-                                normals.push(parse_v_or_vn(l, words))
-                            }
-                        }
-                        "f" => parse_f(
-                            l,
-                            words,
-                            &coords[..],
-                            &uvs[..],
-                            &normals[..],
-                            &mut ignore_uvs,
-                            &mut ignore_normals,
-                            &mut groups_ids,
-                            curr_group,
-                        ),
-                        "vt" => {
-                            if !ignore_uvs {
-                                uvs.push(parse_vt(l, words))
-                            }
-                        }
-                        "g" => {
-                            curr_group = parse_g(l, words, basename, &mut groups, &mut groups_ids);
-                            let _ = curr_mtl
-                                .as_ref()
-                                .map(|mtl| group2mtl.insert(curr_group, mtl.clone()));
-                        }
-                        "mtllib" => parse_mtllib(l, words, mtl_base_dir, &mut mtllib),
-                        "usemtl" => {
-                            curr_group = parse_usemtl(
-                                l,
-                                words,
-                                curr_group,
-                                &mtllib,
-                                &mut group2mtl,
-                                &mut groups,
-                                &mut groups_ids,
-                                &mut curr_mtl,
-                            )
-                        }
-                        _ => {
-                            log::warn!("unknown line {} ignored: `{}'", l, line);
-                        }
-                    }
+        let Some(w) = words.next() else {
+            continue;
+        };
+        if w.is_empty() || w.as_bytes()[0] == b'#' {
+            continue;
+        }
+
+        match w {
+            "v" => coords.push(parse_v_or_vn(l, words)),
+            "vn" => {
+                if !ignore_normals {
+                    normals.push(parse_v_or_vn(l, words))
                 }
+            }
+            "f" => parse_f(
+                l,
+                words,
+                &coords[..],
+                &uvs[..],
+                &normals[..],
+                &mut ignore_uvs,
+                &mut ignore_normals,
+                &mut groups_ids,
+                curr_group,
+            ),
+            "vt" => {
+                if !ignore_uvs {
+                    uvs.push(parse_vt(l, words))
+                }
+            }
+            "g" => {
+                curr_group = parse_g(l, words, basename, &mut groups, &mut groups_ids);
+                let _ = curr_mtl
+                    .as_ref()
+                    .map(|mtl| group2mtl.insert(curr_group, mtl.clone()));
+            }
+            "mtllib" => parse_mtllib(l, words, mtl_base_dir, &mut mtllib),
+            "usemtl" => {
+                curr_group = parse_usemtl(
+                    l,
+                    words,
+                    curr_group,
+                    &mtllib,
+                    &mut group2mtl,
+                    &mut groups,
+                    &mut groups_ids,
+                    &mut curr_mtl,
+                )
+            }
+            _ => {
+                log::warn!("unknown line {} ignored: `{}'", l, line);
             }
         }
     }
@@ -534,8 +533,8 @@ fn reformat(
     let mut meshes = Vec::new();
     for ((fs, name), mtl) in resfs
         .into_iter()
-        .zip(names.into_iter())
-        .zip(mtls.into_iter())
+        .zip(names)
+        .zip(mtls)
     {
         if !fs.is_empty() {
             let fs = Arc::new(RwLock::new(GPUVec::new(

--- a/src/loader/obj.rs
+++ b/src/loader/obj.rs
@@ -48,7 +48,7 @@ fn error(line: usize, err: &str) -> ! {
 }
 
 fn warn(line: usize, err: &str) {
-    println!("At line {}: {}", line, err)
+    log::warn!("at line {}: {}", line, err)
 }
 
 /// Parses an OBJ file and returns the meshes it contains.
@@ -189,7 +189,7 @@ pub fn parse(
                             )
                         }
                         _ => {
-                            println!("Warning: unknown line {} ignored: `{}'", l, line);
+                            log::warn!("unknown line {} ignored: `{}'", l, line);
                         }
                     }
                 }
@@ -198,11 +198,11 @@ pub fn parse(
     }
 
     if uvs.is_empty() && ignore_uvs {
-        println!("Warning: some texture coordinates are missing. Dropping texture coordinates infos for every vertex.");
+        log::warn!("some texture coordinates are missing. Dropping texture coordinates infos for every vertex.");
     }
 
     if normals.is_empty() && ignore_normals {
-        println!("Warning: some normals are missing. Dropping normals infos for every vertex.");
+        log::warn!("some normals are missing. Dropping normals infos for every vertex.");
     }
 
     reformat(

--- a/src/resource/framebuffer_manager.rs
+++ b/src/resource/framebuffer_manager.rs
@@ -111,7 +111,9 @@ impl OffscreenBuffers {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
             view_formats: &[],
         });
 

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -193,6 +193,14 @@ impl Canvas {
         self.canvas.copy_frame_to_readback(frame)
     }
 
+    /// Copies an arbitrary texture into the readback texture used by `read_pixels`.
+    ///
+    /// The source texture must have `COPY_SRC` usage and the same size and
+    /// format as the surface.
+    pub fn copy_texture_to_readback(&self, src: &wgpu::Texture) {
+        self.canvas.copy_texture_to_readback(src)
+    }
+
     /// Reads pixels from the readback texture into the provided buffer.
     /// Returns RGB data (3 bytes per pixel).
     pub fn read_pixels(&self, out: &mut Vec<u8>, x: usize, y: usize, width: usize, height: usize) {

--- a/src/window/egui_integration.rs
+++ b/src/window/egui_integration.rs
@@ -133,13 +133,12 @@ impl Window {
                         modifiers: self.get_egui_modifiers(),
                     });
             }
-            WindowEvent::Char(ch)
-                if !ch.is_control() => {
-                    self.egui_context
-                        .raw_input
-                        .events
-                        .push(egui::Event::Text(ch.to_string()));
-                }
+            WindowEvent::Char(ch) if !ch.is_control() => {
+                self.egui_context
+                    .raw_input
+                    .events
+                    .push(egui::Event::Text(ch.to_string()));
+            }
             WindowEvent::Key(key, action, _modifiers) => {
                 if let Some(egui_key) = self.translate_key_to_egui(key) {
                     self.egui_context.raw_input.events.push(egui::Event::Key {

--- a/src/window/egui_integration.rs
+++ b/src/window/egui_integration.rs
@@ -133,14 +133,13 @@ impl Window {
                         modifiers: self.get_egui_modifiers(),
                     });
             }
-            WindowEvent::Char(ch) => {
-                if !ch.is_control() {
+            WindowEvent::Char(ch)
+                if !ch.is_control() => {
                     self.egui_context
                         .raw_input
                         .events
                         .push(egui::Event::Text(ch.to_string()));
                 }
-            }
             WindowEvent::Key(key, action, _modifiers) => {
                 if let Some(egui_key) = self.translate_key_to_egui(key) {
                     self.egui_context.raw_input.events.push(egui::Event::Key {

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -104,15 +104,22 @@ impl Window {
         mut renderer: Option<&mut dyn Renderer3d>,
         mut post_processing: Option<&mut dyn PostProcessingEffect>,
     ) -> bool {
-        // Acquire the surface texture first. A just-created window may not be
-        // presentable yet, so `acquire_next_frame` retries until it is.
-        let frame = match self.acquire_next_frame() {
-            Some(frame) => frame,
-            None => return !self.should_close(),
+        // A visible window renders into its surface; a hidden window has no
+        // presentable surface, so it renders into an offscreen texture that
+        // `snap` and recording can still read back.
+        let offscreen = self.hidden;
+
+        // Acquire the surface texture for visible windows. A just-created
+        // window may not be presentable yet, so `acquire_next_frame` retries
+        // until it is.
+        let frame = if offscreen {
+            None
+        } else {
+            match self.acquire_next_frame() {
+                Some(frame) => Some(frame),
+                None => return !self.should_close(),
+            }
         };
-        let frame_view = frame
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
 
         // Read the size only now: while retrying, a pending resize event may
         // have been processed and the surface reconfigured.
@@ -127,27 +134,64 @@ impl Window {
         // No need to update the light position here - it's computed per-frame
         // in the material's prepare() based on the camera position
 
+        // `OffscreenBuffers` are never multisampled, so offscreen rendering
+        // always uses a single sample (a hidden window is not antialiased).
+        let sample_count = if offscreen { 1 } else { self.canvas.sample_count() };
+
         let ctxt = Context::get();
         let mut encoder = ctxt.create_command_encoder(Some("kiss3d_frame_encoder"));
 
-        // Resize post-process render target if needed
+        // Resize the offscreen render targets if needed.
         self.post_process_render_target
             .resize(w, h, self.canvas.surface_format());
-
-        // Determine which views to render to
-        let (color_view, depth_view) = if post_processing.is_some() {
-            // Render to offscreen buffer for post-processing
-            match &self.post_process_render_target {
-                RenderTarget::Offscreen(o) => (&o.color_view, &o.depth_view),
-                RenderTarget::Screen => {
-                    // Shouldn't happen, but fallback to main view
-                    (&frame_view, self.canvas.depth_view())
-                }
+        if offscreen {
+            if self.offscreen_output_target.is_none() {
+                self.offscreen_output_target =
+                    Some(self.framebuffer_manager.new_render_target(w, h, true));
             }
-        } else {
-            (&frame_view, self.canvas.depth_view())
+            self.offscreen_output_target
+                .as_mut()
+                .unwrap()
+                .resize(w, h, self.canvas.surface_format());
+        }
+
+        // The view that receives the final composited image: the surface
+        // texture for a visible window, the offscreen color texture otherwise.
+        let frame_view = match &frame {
+            Some(frame) => frame
+                .texture
+                .create_view(&wgpu::TextureViewDescriptor::default()),
+            None => self
+                .offscreen_output_target
+                .as_ref()
+                .expect("offscreen render target was just created")
+                .color_view()
+                .expect("offscreen render target is never the screen")
+                .clone(),
         };
-        let (color_view, depth_view) = (color_view.clone(), depth_view.clone());
+
+        // Determine which views the scene is rendered into.
+        let (color_view, depth_view) = if post_processing.is_some() {
+            // Render to the offscreen buffer for post-processing.
+            match &self.post_process_render_target {
+                RenderTarget::Offscreen(o) => (o.color_view.clone(), o.depth_view.clone()),
+                // Shouldn't happen, but fall back to the final view.
+                RenderTarget::Screen => (frame_view.clone(), self.canvas.depth_view().clone()),
+            }
+        } else if offscreen {
+            let o = self
+                .offscreen_output_target
+                .as_ref()
+                .expect("offscreen render target was just created");
+            (
+                frame_view.clone(),
+                o.depth_view()
+                    .expect("offscreen render target is never the screen")
+                    .clone(),
+            )
+        } else {
+            (frame_view.clone(), self.canvas.depth_view().clone())
+        };
 
         // Clear the render target at the start of the frame
         {
@@ -205,7 +249,7 @@ impl Window {
             {
                 let render_context = RenderContext {
                     surface_format: self.canvas.surface_format(),
-                    sample_count: self.canvas.sample_count(),
+                    sample_count,
                     viewport_width: w,
                     viewport_height: h,
                 };
@@ -288,7 +332,7 @@ impl Window {
         {
             let context_2d = RenderContext2d {
                 surface_format: self.canvas.surface_format(),
-                sample_count: self.canvas.sample_count(),
+                sample_count,
                 viewport_width: w,
                 viewport_height: h,
             };
@@ -336,7 +380,7 @@ impl Window {
                     encoder: &mut encoder,
                     color_view: &color_view,
                     surface_format: self.canvas.surface_format(),
-                    sample_count: self.canvas.sample_count(),
+                    sample_count,
                     viewport_width: w,
                     viewport_height: h,
                 };
@@ -374,7 +418,7 @@ impl Window {
                 encoder: &mut encoder,
                 color_view: &frame_view,
                 surface_format: self.canvas.surface_format(),
-                sample_count: self.canvas.sample_count(),
+                sample_count,
                 viewport_width: w,
                 viewport_height: h,
             };
@@ -397,15 +441,31 @@ impl Window {
             );
         }
 
-        // Copy frame to readback texture for snap/snap_rect functionality
-        self.canvas.copy_frame_to_readback(&frame);
+        // Copy the rendered image into the readback texture so `snap`,
+        // `snap_rect` and recording can read it back.
+        match &frame {
+            Some(frame) => self.canvas.copy_frame_to_readback(frame),
+            None => {
+                let color = self
+                    .offscreen_output_target
+                    .as_ref()
+                    .expect("offscreen render target was just created")
+                    .color_texture()
+                    .expect("offscreen render target is never the screen")
+                    .clone();
+                self.canvas.copy_texture_to_readback(&color);
+            }
+        }
 
         // Capture frame for video recording if enabled
         #[cfg(feature = "recording")]
         self.capture_frame_if_recording();
 
-        // Present the frame
-        self.canvas.present(frame);
+        // Present the frame (visible windows only; a hidden window has no
+        // presentable surface).
+        if let Some(frame) = frame {
+            self.canvas.present(frame);
+        }
         #[cfg(target_arch = "wasm32")]
         {
             use wasm_bindgen::JsCast;

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -17,6 +17,16 @@ use crate::scene::{SceneNode2d, SceneNode3d};
 
 use super::Window;
 
+/// Grace period during which the first frame keeps retrying surface acquisition
+/// before giving up. A freshly created window — particularly on macOS — may need
+/// the event loop to be pumped a few times before its surface is presentable.
+#[cfg(not(target_arch = "wasm32"))]
+const STARTUP_SURFACE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Delay between surface acquisition attempts while waiting for the first frame.
+#[cfg(not(target_arch = "wasm32"))]
+const SURFACE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
+
 impl Window {
     /// Renders one frame of a 3D scene.
     ///
@@ -94,6 +104,18 @@ impl Window {
         mut renderer: Option<&mut dyn Renderer3d>,
         mut post_processing: Option<&mut dyn PostProcessingEffect>,
     ) -> bool {
+        // Acquire the surface texture first. A just-created window may not be
+        // presentable yet, so `acquire_next_frame` retries until it is.
+        let frame = match self.acquire_next_frame() {
+            Some(frame) => frame,
+            None => return !self.should_close(),
+        };
+        let frame_view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Read the size only now: while retrying, a pending resize event may
+        // have been processed and the surface reconfigured.
         let w = self.width();
         let h = self.height();
 
@@ -104,18 +126,6 @@ impl Window {
 
         // No need to update the light position here - it's computed per-frame
         // in the material's prepare() based on the camera position
-
-        // Get the surface texture
-        let frame = match self.canvas.get_current_texture() {
-            Some(frame) => frame,
-            None => {
-                eprintln!("Failed to acquire surface texture");
-                return !self.should_close();
-            }
-        };
-        let frame_view = frame
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
 
         let ctxt = Context::get();
         let mut encoder = ctxt.create_command_encoder(Some("kiss3d_frame_encoder"));
@@ -415,6 +425,53 @@ impl Window {
         }
 
         !self.should_close()
+    }
+
+    /// Acquires the surface texture for the next frame.
+    ///
+    /// Returns `None` when no frame is available and the caller should skip
+    /// rendering. Until the first frame has been rendered, this retries —
+    /// pumping window events between attempts — for up to a couple of seconds,
+    /// because a freshly created window may need the event loop to run a few
+    /// times before its surface becomes presentable. Once a frame has been
+    /// acquired, a later failure (e.g. a minimized window) skips the frame
+    /// immediately instead of stalling.
+    fn acquire_next_frame(&mut self) -> Option<wgpu::SurfaceTexture> {
+        if let Some(frame) = self.canvas.get_current_texture() {
+            self.first_frame = false;
+            return Some(frame);
+        }
+
+        // The window has rendered before: treat this as a transient failure
+        // and skip the frame without stalling.
+        if !self.first_frame {
+            return None;
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        return None;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let deadline = std::time::Instant::now() + STARTUP_SURFACE_TIMEOUT;
+            loop {
+                std::thread::sleep(SURFACE_RETRY_INTERVAL);
+                self.canvas.poll_events();
+
+                if let Some(frame) = self.canvas.get_current_texture() {
+                    self.first_frame = false;
+                    return Some(frame);
+                }
+
+                if std::time::Instant::now() >= deadline {
+                    log::warn!(
+                        "could not acquire a surface texture within \
+                         {STARTUP_SURFACE_TIMEOUT:?}; the window failed to become ready"
+                    );
+                    return None;
+                }
+            }
+        }
     }
 
     fn render_scene(

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -136,7 +136,11 @@ impl Window {
 
         // `OffscreenBuffers` are never multisampled, so offscreen rendering
         // always uses a single sample (a hidden window is not antialiased).
-        let sample_count = if offscreen { 1 } else { self.canvas.sample_count() };
+        let sample_count = if offscreen {
+            1
+        } else {
+            self.canvas.sample_count()
+        };
 
         let ctxt = Context::get();
         let mut encoder = ctxt.create_command_encoder(Some("kiss3d_frame_encoder"));
@@ -149,10 +153,11 @@ impl Window {
                 self.offscreen_output_target =
                     Some(self.framebuffer_manager.new_render_target(w, h, true));
             }
-            self.offscreen_output_target
-                .as_mut()
-                .unwrap()
-                .resize(w, h, self.canvas.surface_format());
+            self.offscreen_output_target.as_mut().unwrap().resize(
+                w,
+                h,
+                self.canvas.surface_format(),
+            );
         }
 
         // The view that receives the final composited image: the surface

--- a/src/window/wgpu_canvas.rs
+++ b/src/window/wgpu_canvas.rs
@@ -982,14 +982,26 @@ impl WgpuCanvas {
         }
     }
 
-    /// Copies the frame texture to the readback texture for later reading.
+    /// Copies the surface frame texture into the readback texture for later
+    /// reading via [`read_pixels`](Self::read_pixels).
     pub fn copy_frame_to_readback(&self, frame: &wgpu::SurfaceTexture) {
+        self.copy_texture_to_readback(&frame.texture);
+    }
+
+    /// Copies an arbitrary texture into the readback texture used by
+    /// [`read_pixels`](Self::read_pixels).
+    ///
+    /// The source texture must have `COPY_SRC` usage and the same size and
+    /// format as the surface. This is how a hidden window, which renders into
+    /// an offscreen texture rather than a surface, makes its frame available
+    /// to `snap`/`snap_rect`.
+    pub fn copy_texture_to_readback(&self, src: &wgpu::Texture) {
         let ctxt = Context::get();
         let mut encoder = ctxt.create_command_encoder(Some("readback_copy_encoder"));
 
         encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
-                texture: &frame.texture,
+                texture: src,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -43,9 +43,13 @@ pub struct Window {
     pub(super) point_renderer: PointRenderer3d,
     pub(super) polyline_renderer: PolylineRenderer3d,
     pub(super) text_renderer: TextRenderer,
-    #[allow(dead_code)]
     pub(super) framebuffer_manager: FramebufferManager,
     pub(super) post_process_render_target: RenderTarget,
+    /// Offscreen render target used when the window is hidden, so `snap` and
+    /// recording work without a presentable surface. Created on first use.
+    pub(super) offscreen_output_target: Option<RenderTarget>,
+    /// Whether the window is hidden. Hidden windows render offscreen.
+    pub(super) hidden: bool,
     pub(super) should_close: bool,
     /// `true` until the first surface texture has been successfully acquired.
     /// While set, frame acquisition retries (pumping window events) instead of
@@ -182,6 +186,7 @@ impl Window {
     /// The window continues to exist and can be shown again later.
     #[inline]
     pub fn hide(&mut self) {
+        self.hidden = true;
         self.canvas.hide()
     }
 
@@ -190,6 +195,7 @@ impl Window {
     /// Use [`hide()`](Self::hide) to hide it again.
     #[inline]
     pub fn show(&mut self) {
+        self.hidden = false;
         self.canvas.show()
     }
 
@@ -294,6 +300,11 @@ impl Window {
     /// The window is created but not displayed. Use [`show()`](Self::show) to make it visible.
     /// The default size is 800x600 pixels.
     ///
+    /// While hidden, the window renders off-screen instead of to its surface,
+    /// so [`snap`](Self::snap), [`snap_image`](Self::snap_image) and recording
+    /// work without ever displaying anything — this is how kiss3d does
+    /// offscreen rendering.
+    ///
     /// # Arguments
     /// * `title` - The window title
     ///
@@ -306,6 +317,11 @@ impl Window {
     /// Creates a new hidden window with custom dimensions.
     ///
     /// The window is created but not displayed. Use [`show()`](Self::show) to make it visible.
+    ///
+    /// While hidden, the window renders off-screen instead of to its surface,
+    /// so [`snap`](Self::snap), [`snap_image`](Self::snap_image) and recording
+    /// work without ever displaying anything — this is how kiss3d does
+    /// offscreen rendering.
     ///
     /// # Arguments
     /// * `title` - The window title
@@ -442,6 +458,8 @@ impl Window {
             #[cfg(feature = "egui")]
             egui_context: EguiContext::new(),
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
+            offscreen_output_target: None,
+            hidden: hide,
             framebuffer_manager,
             #[cfg(feature = "recording")]
             recording: None,

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -47,6 +47,10 @@ pub struct Window {
     pub(super) framebuffer_manager: FramebufferManager,
     pub(super) post_process_render_target: RenderTarget,
     pub(super) should_close: bool,
+    /// `true` until the first surface texture has been successfully acquired.
+    /// While set, frame acquisition retries (pumping window events) instead of
+    /// skipping, so a freshly created window reliably renders its first frame.
+    pub(super) first_frame: bool,
     pub(super) close_key: Option<Key>,
     pub(super) close_modifiers: Option<Modifiers>,
     #[cfg(feature = "egui")]
@@ -422,6 +426,7 @@ impl Window {
         let framebuffer_manager = FramebufferManager::new();
         let mut usr_window = Window {
             should_close: false,
+            first_frame: true,
             close_key: Some(Key::Escape),
             close_modifiers: None,
             canvas,


### PR DESCRIPTION
On some platforms, acquiring the render frame can occasionally take a few milliseconds, resulting in broken rendering during the first few render loops. This PRs ensures that we wait for the frame to be available so that the first render loop actually works. This is useful for application that, for example, just want to render a scene once to save it to a file.