### PR TITLE
feat: add support for offscreen rendering

### DIFF
--- a/.run/offscreen.run.xml
+++ b/.run/offscreen.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="offscreen" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="dev" />
+    <option name="command" value="run --package kiss3d --example offscreen" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -1,0 +1,24 @@
+use kiss3d::prelude::*;
+use std::path::Path;
+
+// Renders a scene to an image with no window at all.
+#[kiss3d::main]
+async fn main() {
+    let mut surface = OffscreenSurface::new(1024, 768).await;
+    surface.set_background_color(DARK_BLUE);
+
+    let mut camera = OrbitCamera3d::default();
+    let mut scene = SceneNode3d::empty();
+    scene
+        .add_light(Light::point(100.0))
+        .set_position(Vec3::new(0.0, 10.0, 10.0));
+    scene
+        .add_cube(0.2, 0.2, 0.2)
+        .set_color(RED)
+        .rotate(Quat::from_axis_angle(Vec3::Y, 0.785))
+        .rotate(Quat::from_axis_angle(Vec3::X, -0.6f32));
+
+    let img = surface.render_image_3d(&mut scene, &mut camera).await;
+    img.save(Path::new("offscreen.png")).unwrap();
+    println!("Rendered to `offscreen.png` ({:?})", surface.size());
+}

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -42,6 +42,7 @@ EXAMPLES=(
     polyline_strip
     polylines2d
     screenshot
+    offscreen
     recording
     window
     multi_windows

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -90,9 +90,27 @@ impl Canvas {
         }
     }
 
+    /// Open a headless canvas (no window) for off-screen rendering.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn open_headless(
+        width: u32,
+        height: u32,
+        canvas_setup: Option<CanvasSetup>,
+        out_events: Sender<WindowEvent>,
+    ) -> Self {
+        Canvas {
+            canvas: WgpuCanvas::open_headless(width, height, canvas_setup, out_events).await,
+        }
+    }
+
     /// Poll all events that occurred since the last call to this method.
     pub fn poll_events(&mut self) {
         self.canvas.poll_events()
+    }
+
+    /// Resizes the canvas render targets.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.canvas.resize(width, height)
     }
 
     /// Gets the current surface texture for rendering.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -5,6 +5,8 @@ mod drawing;
 #[cfg(feature = "egui")]
 mod egui_integration;
 mod events;
+#[cfg(not(target_arch = "wasm32"))]
+mod offscreen;
 #[cfg(feature = "recording")]
 mod recording;
 mod rendering;
@@ -14,6 +16,8 @@ mod window;
 mod window_cache;
 
 pub use canvas::{Canvas, CanvasSetup, NumSamples};
+#[cfg(not(target_arch = "wasm32"))]
+pub use offscreen::OffscreenSurface;
 #[cfg(feature = "recording")]
 pub use recording::RecordingConfig;
 pub use wgpu_canvas::WgpuCanvas;

--- a/src/window/offscreen.rs
+++ b/src/window/offscreen.rs
@@ -80,7 +80,14 @@ impl OffscreenSurface {
     ) {
         let _ = self
             .window
-            .render(scene, scene_2d, camera, camera_2d, renderer, post_processing)
+            .render(
+                scene,
+                scene_2d,
+                camera,
+                camera_2d,
+                renderer,
+                post_processing,
+            )
             .await;
     }
 

--- a/src/window/offscreen.rs
+++ b/src/window/offscreen.rs
@@ -1,0 +1,136 @@
+//! Off-screen (headless) rendering surface.
+
+use crate::camera::{Camera2d, Camera3d};
+use crate::color::Color;
+use crate::post_processing::PostProcessingEffect;
+use crate::renderer::Renderer3d;
+use crate::scene::{SceneNode2d, SceneNode3d};
+use crate::window::{CanvasSetup, Window};
+use glamx::UVec2;
+use image::{ImageBuffer, Rgb};
+
+/// A headless rendering surface.
+///
+/// Unlike [`Window`], an `OffscreenSurface` creates **no window and no event
+/// loop**: it renders a scene straight into a texture. It therefore works in
+/// environments with no display server (CI, servers, containers), produces no
+/// on-screen flicker, and can render at any resolution — independent of the
+/// display.
+///
+/// The scene graph, cameras, lights and materials are exactly the same as with
+/// [`Window`]. Since there are no input events, interactive cameras stay put;
+/// position the camera programmatically instead.
+///
+/// # Example
+/// ```no_run
+/// use kiss3d::prelude::*;
+///
+/// #[kiss3d::main]
+/// async fn main() {
+///     let mut surface = OffscreenSurface::new(1920, 1080).await;
+///
+///     let mut scene = SceneNode3d::empty();
+///     scene.add_cube(1.0, 1.0, 1.0).set_color(RED);
+///     let mut camera = OrbitCamera3d::default();
+///
+///     surface.render_3d(&mut scene, &mut camera).await;
+///     surface.snap_image().save("out.png").unwrap();
+/// }
+/// ```
+pub struct OffscreenSurface {
+    window: Window,
+}
+
+impl OffscreenSurface {
+    /// Creates a new off-screen surface of the given size, in pixels.
+    pub async fn new(width: u32, height: u32) -> OffscreenSurface {
+        OffscreenSurface {
+            window: Window::do_new_headless(width, height, None).await,
+        }
+    }
+
+    /// Creates a new off-screen surface with custom setup options (e.g. MSAA).
+    pub async fn with_setup(width: u32, height: u32, setup: CanvasSetup) -> OffscreenSurface {
+        OffscreenSurface {
+            window: Window::do_new_headless(width, height, Some(setup)).await,
+        }
+    }
+
+    /// Renders one frame of a 3D scene into the off-screen texture.
+    pub async fn render_3d(&mut self, scene: &mut SceneNode3d, camera: &mut impl Camera3d) {
+        let _ = self.window.render_3d(scene, camera).await;
+    }
+
+    /// Renders one frame of a 2D scene into the off-screen texture.
+    pub async fn render_2d(&mut self, scene: &mut SceneNode2d, camera: &mut impl Camera2d) {
+        let _ = self.window.render_2d(scene, camera).await;
+    }
+
+    /// Renders one frame with full control over the scenes, cameras, an
+    /// optional custom renderer and post-processing effect. See [`Window::render`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn render(
+        &mut self,
+        scene: Option<&mut SceneNode3d>,
+        scene_2d: Option<&mut SceneNode2d>,
+        camera: Option<&mut dyn Camera3d>,
+        camera_2d: Option<&mut dyn Camera2d>,
+        renderer: Option<&mut dyn Renderer3d>,
+        post_processing: Option<&mut dyn PostProcessingEffect>,
+    ) {
+        let _ = self
+            .window
+            .render(scene, scene_2d, camera, camera_2d, renderer, post_processing)
+            .await;
+    }
+
+    /// Renders a 3D scene and returns the resulting image, in one call.
+    pub async fn render_image_3d(
+        &mut self,
+        scene: &mut SceneNode3d,
+        camera: &mut impl Camera3d,
+    ) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
+        self.render_3d(scene, camera).await;
+        self.snap_image()
+    }
+
+    /// Captures the last rendered frame as raw RGB pixel data.
+    pub fn snap(&self, out: &mut Vec<u8>) {
+        self.window.snap(out)
+    }
+
+    /// Captures a rectangular region of the last rendered frame as raw RGB data.
+    pub fn snap_rect(&self, out: &mut Vec<u8>, x: usize, y: usize, width: usize, height: usize) {
+        self.window.snap_rect(out, x, y, width, height)
+    }
+
+    /// Captures the last rendered frame as an image.
+    pub fn snap_image(&self) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
+        self.window.snap_image()
+    }
+
+    /// Resizes the off-screen surface. The next render uses the new size.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        self.window.canvas_mut().resize(width, height);
+    }
+
+    /// The size of the surface, in pixels.
+    pub fn size(&self) -> UVec2 {
+        self.window.size()
+    }
+
+    /// The width of the surface, in pixels.
+    pub fn width(&self) -> u32 {
+        self.window.width()
+    }
+
+    /// The height of the surface, in pixels.
+    pub fn height(&self) -> u32 {
+        self.window.height()
+    }
+
+    /// Sets the background color.
+    pub fn set_background_color(&mut self, color: Color) {
+        self.window.set_background_color(color);
+    }
+}

--- a/src/window/wgpu_canvas.rs
+++ b/src/window/wgpu_canvas.rs
@@ -59,10 +59,10 @@ enum PendingEvent {
 /// A unified canvas based on wgpu that works on both native and web platforms.
 #[allow(dead_code)]
 pub struct WgpuCanvas {
-    window: Arc<Window>,
+    window: Option<Arc<Window>>,
     #[cfg(not(target_arch = "wasm32"))]
-    window_id: winit::window::WindowId,
-    surface: wgpu::Surface<'static>,
+    window_id: Option<winit::window::WindowId>,
+    surface: Option<wgpu::Surface<'static>>,
     surface_config: wgpu::SurfaceConfiguration,
     cursor_pos: Option<(f64, f64)>,
     key_states: [Action; Key::Unknown as usize + 1],
@@ -586,10 +586,10 @@ impl WgpuCanvas {
         let window_id = window.id();
 
         WgpuCanvas {
-            window,
+            window: Some(window),
             #[cfg(not(target_arch = "wasm32"))]
-            window_id,
-            surface,
+            window_id: Some(window_id),
+            surface: Some(surface),
             surface_config,
             cursor_pos: None,
             key_states: [Action::Release; Key::Unknown as usize + 1],
@@ -607,6 +607,142 @@ impl WgpuCanvas {
             #[cfg(target_arch = "wasm32")]
             _event_closures,
         }
+    }
+
+    /// Opens a headless canvas: a wgpu context with no window and no surface,
+    /// for off-screen rendering. Works without a display server.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn open_headless(
+        width: u32,
+        height: u32,
+        canvas_setup: Option<CanvasSetup>,
+        out_events: Sender<WindowEvent>,
+    ) -> Self {
+        let canvas_setup = canvas_setup.unwrap_or_default();
+        let width = width.max(1);
+        let height = height.max(1);
+
+        // Reuse the wgpu context if one already exists (e.g. a window was
+        // created first); otherwise create a surface-less one.
+        let surface_format = if Context::is_initialized() {
+            Context::get().surface_format
+        } else {
+            let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::all(),
+                ..wgpu::InstanceDescriptor::new_without_display_handle()
+            });
+
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::default(),
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .expect("Failed to find an appropriate adapter");
+
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor {
+                    label: Some("kiss3d headless device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::default(),
+                    memory_hints: wgpu::MemoryHints::default(),
+                    trace: wgpu::Trace::Off,
+                    experimental_features: ExperimentalFeatures::default(),
+                })
+                .await
+                .expect("Failed to create device");
+
+            // No surface to query for a preferred format; pick a widely
+            // supported non-sRGB format (gamma is handled in shaders).
+            let surface_format = wgpu::TextureFormat::Rgba8Unorm;
+            Context::init(instance, device, queue, adapter, surface_format);
+            surface_format
+        };
+
+        let ctxt = Context::get();
+        let sample_count = canvas_setup.samples as u32;
+
+        // Kept only to carry the size and format; no surface is configured.
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            format: surface_format,
+            width,
+            height,
+            present_mode: wgpu::PresentMode::AutoNoVsync,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+
+        let (depth_texture, depth_view) =
+            Self::create_depth_texture(&ctxt.device, width, height, sample_count);
+        let (msaa_texture, msaa_view) = if sample_count > 1 {
+            let (tex, view) =
+                Self::create_msaa_texture(&ctxt.device, width, height, surface_format, sample_count);
+            (Some(tex), Some(view))
+        } else {
+            (None, None)
+        };
+        let readback_texture =
+            Self::create_readback_texture(&ctxt.device, width, height, surface_format);
+
+        WgpuCanvas {
+            window: None,
+            window_id: None,
+            surface: None,
+            surface_config,
+            cursor_pos: None,
+            key_states: [Action::Release; Key::Unknown as usize + 1],
+            button_states: [Action::Release; MouseButton::Button8 as usize + 1],
+            out_events,
+            modifiers_state: ModifiersState::default(),
+            depth_texture,
+            depth_view,
+            msaa_texture,
+            msaa_view,
+            sample_count,
+            readback_texture,
+        }
+    }
+
+    /// Resizes the canvas render targets.
+    ///
+    /// For an off-screen (headless) canvas this is the only way to change the
+    /// render size, since there is no window to emit resize events.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        let width = width.max(1);
+        let height = height.max(1);
+        if self.surface_config.width == width && self.surface_config.height == height {
+            return;
+        }
+
+        let ctxt = Context::get();
+        self.surface_config.width = width;
+        self.surface_config.height = height;
+        if let Some(surface) = &self.surface {
+            surface.configure(&ctxt.device, &self.surface_config);
+        }
+
+        let (depth_texture, depth_view) =
+            Self::create_depth_texture(&ctxt.device, width, height, self.sample_count);
+        self.depth_texture = depth_texture;
+        self.depth_view = depth_view;
+
+        if self.sample_count > 1 {
+            let (msaa_texture, msaa_view) = Self::create_msaa_texture(
+                &ctxt.device,
+                width,
+                height,
+                self.surface_config.format,
+                self.sample_count,
+            );
+            self.msaa_texture = Some(msaa_texture);
+            self.msaa_view = Some(msaa_view);
+        }
+
+        self.readback_texture =
+            Self::create_readback_texture(&ctxt.device, width, height, self.surface_config.format);
     }
 
     fn create_depth_texture(
@@ -692,6 +828,11 @@ impl WgpuCanvas {
 
     /// Polls events from the window system.
     pub fn poll_events(&mut self) {
+        // A headless canvas has no window and no event loop; nothing to poll.
+        if self.window.is_none() {
+            return;
+        }
+
         #[cfg(not(target_arch = "wasm32"))]
         {
             use winit::platform::pump_events::EventLoopExtPumpEvents;
@@ -826,7 +967,7 @@ impl WgpuCanvas {
             let events = PENDING_WINDOW_EVENTS.with(|storage| {
                 storage
                     .borrow_mut()
-                    .remove(&self.window_id)
+                    .remove(&self.window_id.unwrap())
                     .unwrap_or_default()
             });
 
@@ -853,7 +994,9 @@ impl WgpuCanvas {
                         // Resize surface
                         self.surface_config.width = width;
                         self.surface_config.height = height;
-                        self.surface.configure(&ctxt.device, &self.surface_config);
+                        if let Some(surface) = &self.surface {
+                            surface.configure(&ctxt.device, &self.surface_config);
+                        }
 
                         // Recreate depth texture
                         let (new_depth, new_depth_view) = Self::create_depth_texture(
@@ -893,7 +1036,7 @@ impl WgpuCanvas {
         #[cfg(target_arch = "wasm32")]
         {
             // Check for resize - compare current window size to surface config
-            let current_size = self.window.inner_size();
+            let current_size = self.window.as_ref().unwrap().inner_size();
             if current_size.width > 0
                 && current_size.height > 0
                 && (current_size.width != self.surface_config.width
@@ -904,7 +1047,9 @@ impl WgpuCanvas {
                 // Resize surface
                 self.surface_config.width = current_size.width;
                 self.surface_config.height = current_size.height;
-                self.surface.configure(&ctxt.device, &self.surface_config);
+                if let Some(surface) = &self.surface {
+                    surface.configure(&ctxt.device, &self.surface_config);
+                }
 
                 // Recreate depth texture
                 let (new_depth, new_depth_view) = Self::create_depth_texture(
@@ -965,14 +1110,15 @@ impl WgpuCanvas {
 
     /// Gets the current surface texture for rendering.
     pub fn get_current_texture(&self) -> Option<wgpu::SurfaceTexture> {
-        match self.surface.get_current_texture() {
+        let surface = self.surface.as_ref()?;
+        match surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(texture)
             | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => Some(texture),
             wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 // Reconfigure and retry once
                 let ctxt = Context::get();
-                self.surface.configure(&ctxt.device, &self.surface_config);
-                match self.surface.get_current_texture() {
+                surface.configure(&ctxt.device, &self.surface_config);
+                match surface.get_current_texture() {
                     wgpu::CurrentSurfaceTexture::Success(texture)
                     | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => Some(texture),
                     _ => None,
@@ -1162,12 +1308,14 @@ impl WgpuCanvas {
 
     /// The scale factor.
     pub fn scale_factor(&self) -> f64 {
-        self.window.scale_factor()
+        self.window.as_ref().map_or(1.0, |window| window.scale_factor())
     }
 
     /// Set the window title.
     pub fn set_title(&mut self, title: &str) {
-        self.window.set_title(title)
+        if let Some(window) = &self.window {
+            window.set_title(title);
+        }
     }
 
     /// Set the window icon.
@@ -1178,7 +1326,9 @@ impl WgpuCanvas {
             rgba.extend_from_slice(&pixel.to_rgba().0);
         }
         let icon = Icon::from_rgba(rgba, width, height).unwrap();
-        self.window.set_window_icon(Some(icon))
+        if let Some(window) = &self.window {
+            window.set_window_icon(Some(icon));
+        }
     }
 
     /// Set the cursor grabbing behaviour.
@@ -1189,29 +1339,37 @@ impl WgpuCanvas {
         } else {
             CursorGrabMode::None
         };
-        let _ = self.window.set_cursor_grab(mode);
+        if let Some(window) = &self.window {
+            let _ = window.set_cursor_grab(mode);
+        }
     }
 
     /// Set the cursor position.
     pub fn set_cursor_position(&self, x: f64, y: f64) {
-        let _ = self
-            .window
-            .set_cursor_position(winit::dpi::PhysicalPosition::new(x, y));
+        if let Some(window) = &self.window {
+            let _ = window.set_cursor_position(winit::dpi::PhysicalPosition::new(x, y));
+        }
     }
 
     /// Toggle the cursor visibility.
     pub fn hide_cursor(&self, hide: bool) {
-        self.window.set_cursor_visible(!hide)
+        if let Some(window) = &self.window {
+            window.set_cursor_visible(!hide);
+        }
     }
 
     /// Hide the window.
     pub fn hide(&mut self) {
-        self.window.set_visible(false)
+        if let Some(window) = &self.window {
+            window.set_visible(false);
+        }
     }
 
     /// Show the window.
     pub fn show(&mut self) {
-        self.window.set_visible(true)
+        if let Some(window) = &self.window {
+            window.set_visible(true);
+        }
     }
 
     /// The state of a mouse button.

--- a/src/window/wgpu_canvas.rs
+++ b/src/window/wgpu_canvas.rs
@@ -678,8 +678,13 @@ impl WgpuCanvas {
         let (depth_texture, depth_view) =
             Self::create_depth_texture(&ctxt.device, width, height, sample_count);
         let (msaa_texture, msaa_view) = if sample_count > 1 {
-            let (tex, view) =
-                Self::create_msaa_texture(&ctxt.device, width, height, surface_format, sample_count);
+            let (tex, view) = Self::create_msaa_texture(
+                &ctxt.device,
+                width,
+                height,
+                surface_format,
+                sample_count,
+            );
             (Some(tex), Some(view))
         } else {
             (None, None)
@@ -1308,7 +1313,9 @@ impl WgpuCanvas {
 
     /// The scale factor.
     pub fn scale_factor(&self) -> f64 {
-        self.window.as_ref().map_or(1.0, |window| window.scale_factor())
+        self.window
+            .as_ref()
+            .map_or(1.0, |window| window.scale_factor())
     }
 
     /// Set the window title.

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -471,6 +471,49 @@ impl Window {
 
         usr_window
     }
+
+    /// Creates a headless window: a render target backed by no actual window,
+    /// for off-screen rendering. Powers [`OffscreenSurface`](crate::window::OffscreenSurface).
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(super) async fn do_new_headless(
+        width: u32,
+        height: u32,
+        setup: Option<CanvasSetup>,
+    ) -> Window {
+        let (event_send, event_receive) = mpsc::channel();
+        let canvas = Canvas::open_headless(width, height, setup, event_send).await;
+        let (width, height) = canvas.size();
+
+        Context::increment_window_count();
+        WindowCache::populate();
+
+        let framebuffer_manager = FramebufferManager::new();
+        Window {
+            should_close: false,
+            first_frame: true,
+            close_key: None,
+            close_modifiers: None,
+            canvas,
+            events: Rc::new(event_receive),
+            unhandled_events: Rc::new(RefCell::new(Vec::new())),
+            ambient_intensity: 0.2,
+            background: BLACK,
+            polyline_renderer_2d: PolylineRenderer2d::new(),
+            point_renderer_2d: PointRenderer2d::new(),
+            point_renderer: PointRenderer3d::new(),
+            polyline_renderer: PolylineRenderer3d::new(),
+            text_renderer: TextRenderer::new(),
+            #[cfg(feature = "egui")]
+            egui_context: EguiContext::new(),
+            post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
+            offscreen_output_target: None,
+            // A headless window has no surface; always render off-screen.
+            hidden: true,
+            framebuffer_manager,
+            #[cfg(feature = "recording")]
+            recording: None,
+        }
+    }
 }
 
 impl Drop for Window {


### PR DESCRIPTION
This makes it possible to render to an offscreen surface, without opening a window (and without any winit event loop).
This also adds a new example for offscreen rendering.