### PR TITLE
Improved 2D rendering effects

### DIFF
--- a/.run/blend_modes2d (web).run.xml
+++ b/.run/blend_modes2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="blend_modes2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example blend_modes2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/blend_modes2d.run.xml
+++ b/.run/blend_modes2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="blend_modes2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example blend_modes2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/effect_chain2d (web).run.xml
+++ b/.run/effect_chain2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="effect_chain2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example effect_chain2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/effect_chain2d.run.xml
+++ b/.run/effect_chain2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="effect_chain2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example effect_chain2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/global_illumination2d (web).run.xml
+++ b/.run/global_illumination2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="global_illumination2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example global_illumination2d --features egui --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/global_illumination2d.run.xml
+++ b/.run/global_illumination2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="global_illumination2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example global_illumination2d --features egui" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/lighting2d (web).run.xml
+++ b/.run/lighting2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="lighting2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example lighting2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/lighting2d.run.xml
+++ b/.run/lighting2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="lighting2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example lighting2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/post_processing2d (web).run.xml
+++ b/.run/post_processing2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="post_processing2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example post_processing2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/post_processing2d.run.xml
+++ b/.run/post_processing2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="post_processing2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example post_processing2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/robot_view (web).run.xml
+++ b/.run/robot_view (web).run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="robot_view (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example robot_view --features egui,rt_switcher --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/robot_view.run.xml
+++ b/.run/robot_view.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="robot_view" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example robot_view --features egui,rt_switcher" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/skinning2d (web).run.xml
+++ b/.run/skinning2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="skinning2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example skinning2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/skinning2d.run.xml
+++ b/.run/skinning2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="skinning2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example skinning2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/sprites2d (web).run.xml
+++ b/.run/sprites2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="sprites2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example sprites2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/sprites2d.run.xml
+++ b/.run/sprites2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="sprites2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example sprites2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/tilemap2d (web).run.xml
+++ b/.run/tilemap2d (web).run.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="tilemap2d (web)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package kiss3d --example tilemap2d --target wasm32-unknown-unknown" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <envs />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/tilemap2d.run.xml
+++ b/.run/tilemap2d.run.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="tilemap2d" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="release" />
+    <option name="command" value="run --package kiss3d --example tilemap2d" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Reflection probes (baked image or runtime cube capture), parallax-corrected: `Window::add_reflection_probe`, `capture_reflection_probe`, `set_reflection_probe_image`, `set_reflection_capture_layers`.
 - Screen-space reflections: `Window::set_ssr_enabled` / `ssr_settings_mut`, with per-object `Object3d::set_ssr(SsrMaterial)`.
 - Planar mirror reflectors integrated into the default PBR material: `SceneNode3d::add_reflector`, `Object3d::set_reflector` and `set_reflector_*`.
+- Reflector captures render every phase, not just opaque surfaces: transparent (alpha < 1) objects are drawn into mirrors with the same weighted-blended OIT as the main pass, and refractive glass is drawn refracting the mirrored scene behind it (one snapshot layer).
 - Screen-space ambient occlusion: `Window::set_ssao_enabled` / `ssao_settings_mut`.
 - Screen-space refractive transmission (glass): `Window::set_transmission_enabled` / `transmission_settings_mut`.
 - Examples: `reflections`, `mirror`, `mirror_sphere`.
@@ -112,6 +113,12 @@
 - Bumped `glamx` dependency: 0.2 → 0.3. ([#384](https://github.com/dimforge/kiss3d/pull/384))
 
 ## New Features
+
+### Off-screen rendering on the web + zero-copy egui display
+
+- `OffscreenSurface` now exists on wasm: creation and all GPU-side rendering (`render_3d`, `raytrace_3d`, ...) work in the browser. Only the CPU read-backs (`snap_*`, `render_image_*`) remain native-only (they must block on the GPU).
+- `OffscreenSurface::output_view` exposes the surface's final (post-tonemap) texture, and `Window::register_egui_texture` / `unregister_egui_texture` register any wgpu texture view with the window's egui renderer — so an offscreen surface can be displayed live in an egui UI with zero GPU→CPU copies, on native and web alike.
+- GPU-only AOV visualization: `Window::render_aov_3d` / `OffscreenSurface::render_aov_3d` render depth (fixed-range grayscale), normals or colorized segmentation as a display-ready image into the surface's output texture, with no read-back. The `robot_view` example uses all of the above.
 
 ### Off-screen Rendering ([#382](https://github.com/dimforge/kiss3d/pull/382))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+# Unreleased
+
+## Breaking Changes
+
+- The window no longer closes on <kbd>Escape</kbd> by default (`close_key` now defaults to `None` instead of `Some(Key::Escape)`). Call `Window::rebind_close_key(Some(Key::Escape))` to restore the previous behavior.
+
+## New Features
+
+### 2D rendering
+
+A suite of new 2D features, all sharing the existing `SceneNode2d` scene graph, `Camera2d` and HDR film (so bloom and tonemapping already apply to 2D content):
+
+- **Sprites, sprite sheets & 9-slice**: `SceneNode2d::sprite` / `add_sprite` (textured quads), `set_uv_rect`, and animation-frame selection via `SpriteSheet` (`SpriteSheet::new`, `frame_uv`) with `set_sprite_frame`. Nine-slice scaling through `nine_slice` / `add_nine_slice` and `Border` (`Border::uniform` / `symmetric`). Example: `sprites2d`.
+- **Per-object blend modes**: `Object2d::set_blend` and `SceneNode2d::set_blend` / `set_blend_recursive` with `Blend2d` (`Alpha`, `PremultipliedAlpha`, `Additive`, `Multiply`, `Screen`, `Opaque`). Example: `blend_modes2d`.
+- **Dynamic 2D lighting & normal-mapped sprites**: a new `light2d` module with up to `MAX_LIGHTS_2D` (16) point/spot `Light2d`s (`Light2d::point` / `spot` / `with_height`, `Light2dKind`) plus ambient, managed by the thread-local `Light2dManager`. `LitMaterial2d` shades sprites with per-pixel diffuse + Blinn-Phong specular from a normal map (flat sprites still pick up radial falloff and spot cones): `SceneNode2d::lit_sprite` / `add_lit_sprite`, `set_normal_map_from_file`, `set_lit_params` (`LitParams`). Example: `lighting2d`.
+- **Tilemaps**: `Tilemap` bakes a grid of `SpriteSheet` frames into a single-draw-call mesh (`Tilemap::new`, `set_tile`, `fill`, `node`; `Tilemap::EMPTY` cells are skipped/transparent). Example: `tilemap2d`.
+- **Skeletal mesh deformation (2D GPU skinning)**: `SkinnedMesh2d` binds vertices (`SkinVertex2d`) to up to `MAX_JOINTS_2D` (32) bones (`Bone2d`) with up to four weights each, blending per-bone joint matrices on the GPU (Spine/DragonBones-style). Pose with `set_bone_local` / `set_transform`, then `update()` once per frame. Example: `skinning2d`.
+- **Screen-space 2D global illumination**: `Gi2d`, a post-processing effect that ray-marches per-pixel irradiance against analytic emitter/occluder discs (`GiEmitter2d`, `GiOccluder2d`) for soft shadows and colored light bleed with no light/shadow bookkeeping. Configurable rays, resolution scale and temporal blend, with an optional radiance-cascade solver (`set_radiance_cascades`) and jump-flood SDF occluders (`set_sdf_occluders`). Applied via `Window::render_2d_with`. Example: `global_illumination2d`.
+- **CRT post-processing**: `post_processing::Crt` (screen curvature, chromatic aberration, scanlines, vignette), run over a 2D scene with the new `Window::render_2d_with`. Example: `post_processing2d`. Chain it with other effects (e.g. `Gi2d` → `Crt`) via `render_2d_with_chain`; example: `effect_chain2d`.
+- Über-shader specialization now also covers the 2D object material (`ObjectMaterial2d`): objects using the default white texture automatically get an untextured shader variant (higher GPU occupancy), textured objects get the textured variant — no API change.
+
+### Off-screen rendering on the web + zero-copy egui display
+
+- `OffscreenSurface` now exists on wasm: creation and all GPU-side rendering (`render_3d`, `raytrace_3d`, ...) work in the browser. Only the CPU read-backs (`snap_*`, `render_image_*`) remain native-only (they must block on the GPU).
+- `OffscreenSurface::output_view` exposes the surface's final (post-tonemap) texture, and `Window::register_egui_texture` / `unregister_egui_texture` register any wgpu texture view with the window's egui renderer — so an offscreen surface can be displayed live in an egui UI with zero GPU→CPU copies, on native and web alike.
+- GPU-only AOV visualization: `Window::render_aov_3d` / `OffscreenSurface::render_aov_3d` render depth (fixed-range grayscale), normals or colorized segmentation as a display-ready image into the surface's output texture, with no read-back. The `robot_view` example uses all of the above.
+
+### Rendering & platform
+
+- Chain multiple post-processing effects (ping-pong): `Window::render_chain` / `render_3d_with_chain` / `render_2d_with_chain` and `OffscreenSurface::render_chain` take a slice of effects applied in order. The existing single-effect `render` / `render_2d_with` are retained as thin wrappers (an empty slice is the no-effect path).
+- Reflector captures render every phase, not just opaque surfaces: transparent (alpha < 1) objects are drawn into mirrors with the same weighted-blended OIT as the main pass, and refractive glass is drawn refracting the mirrored scene behind it (one snapshot layer).
+- `CanvasSetup::required_features` (a `wgpu::Features`) requests extra GPU device features on top of the ones kiss3d enables by default. Unsupported features are silently dropped (masked against the adapter) so device creation never fails on an unavailable one.
+
+## Bug Fixes
+
+- Fixed rendered content appearing see-through against the page (a white background) on browsers that composite the canvas with the page (Firefox): the on-screen surface now forces opaque output alpha, while offscreen / snapshot / embedding targets keep the scene's real alpha.
+- Fixed `GpuVector` not reallocating its buffer when an existing allocation lacked a newly-required usage flag.
+
 # v0.44.0
 
 ## Breaking Changes
@@ -37,7 +75,6 @@
 - Reflection probes (baked image or runtime cube capture), parallax-corrected: `Window::add_reflection_probe`, `capture_reflection_probe`, `set_reflection_probe_image`, `set_reflection_capture_layers`.
 - Screen-space reflections: `Window::set_ssr_enabled` / `ssr_settings_mut`, with per-object `Object3d::set_ssr(SsrMaterial)`.
 - Planar mirror reflectors integrated into the default PBR material: `SceneNode3d::add_reflector`, `Object3d::set_reflector` and `set_reflector_*`.
-- Reflector captures render every phase, not just opaque surfaces: transparent (alpha < 1) objects are drawn into mirrors with the same weighted-blended OIT as the main pass, and refractive glass is drawn refracting the mirrored scene behind it (one snapshot layer).
 - Screen-space ambient occlusion: `Window::set_ssao_enabled` / `ssao_settings_mut`.
 - Screen-space refractive transmission (glass): `Window::set_transmission_enabled` / `transmission_settings_mut`.
 - Examples: `reflections`, `mirror`, `mirror_sphere`.
@@ -113,12 +150,6 @@
 - Bumped `glamx` dependency: 0.2 → 0.3. ([#384](https://github.com/dimforge/kiss3d/pull/384))
 
 ## New Features
-
-### Off-screen rendering on the web + zero-copy egui display
-
-- `OffscreenSurface` now exists on wasm: creation and all GPU-side rendering (`render_3d`, `raytrace_3d`, ...) work in the browser. Only the CPU read-backs (`snap_*`, `render_image_*`) remain native-only (they must block on the GPU).
-- `OffscreenSurface::output_view` exposes the surface's final (post-tonemap) texture, and `Window::register_egui_texture` / `unregister_egui_texture` register any wgpu texture view with the window's egui renderer — so an offscreen surface can be displayed live in an egui UI with zero GPU→CPU copies, on native and web alike.
-- GPU-only AOV visualization: `Window::render_aov_3d` / `OffscreenSurface::render_aov_3d` render depth (fixed-range grayscale), normals or colorized segmentation as a display-ready image into the surface's output texture, with no read-back. The `robot_view` example uses all of the above.
 
 ### Off-screen Rendering ([#382](https://github.com/dimforge/kiss3d/pull/382))
 

--- a/examples/blend_modes2d.rs
+++ b/examples/blend_modes2d.rs
@@ -1,0 +1,45 @@
+use kiss3d::prelude::*;
+
+// Demonstrates the 2D surface blend modes (`Blend2d`). Overlapping translucent
+// circles are composited with, from left to right: alpha, additive, screen and
+// multiply blending — so you can see how each mode combines the overlaps.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: 2D blend modes").await;
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 2.0);
+    let mut scene = SceneNode2d::empty();
+
+    // (label position, blend mode, base color triple) for each cluster.
+    let clusters = [
+        (-330.0, Blend2d::Alpha, [RED, GREEN, BLUE]),
+        (-110.0, Blend2d::Additive, [RED, GREEN, BLUE]),
+        (110.0, Blend2d::Screen, [RED, GREEN, BLUE]),
+        (330.0, Blend2d::Multiply, [WHITE, CYAN, YELLOW]),
+    ];
+
+    // Three overlapping circles per cluster, arranged in a small triangle.
+    let offsets = [
+        Vec2::new(0.0, 32.0),
+        Vec2::new(-28.0, -18.0),
+        Vec2::new(28.0, -18.0),
+    ];
+
+    let mut groups = Vec::new();
+    for (cx, blend, colors) in clusters {
+        let mut group = scene.add_group();
+        for (off, color) in offsets.iter().zip(colors) {
+            group
+                .add_circle(46.0)
+                .translate(Vec2::new(cx, 0.0) + *off)
+                .set_color(Color { a: 0.7, ..color })
+                .set_blend(blend);
+        }
+        groups.push(group);
+    }
+
+    while window.render_2d(&mut scene, &mut camera).await {
+        for group in &mut groups {
+            group.append_rotation(0.005);
+        }
+    }
+}

--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -18,15 +18,12 @@ async fn main() {
 
         // update the current camera.
         for event in window.events().iter() {
-            match event.value {
-                WindowEvent::Key(key, Action::Release, _) => {
-                    if key == Key::Numpad1 {
-                        use_arc_ball = true
-                    } else if key == Key::Numpad2 {
-                        use_arc_ball = false
-                    }
+            if let WindowEvent::Key(key, Action::Release, _) = event.value {
+                if key == Key::Numpad1 {
+                    use_arc_ball = true
+                } else if key == Key::Numpad2 {
+                    use_arc_ball = false
                 }
-                _ => {}
             }
         }
 

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -54,6 +54,12 @@ pub struct NormalMaterialGpuData {
     object_bind_group: Option<wgpu::BindGroup>,
 }
 
+impl Default for NormalMaterialGpuData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NormalMaterialGpuData {
     pub fn new() -> Self {
         let ctxt = Context::get();
@@ -99,6 +105,12 @@ pub struct NormalMaterial {
     pipeline: PipelineCache,
     frame_bind_group_layout: wgpu::BindGroupLayout,
     object_bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl Default for NormalMaterial {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NormalMaterial {

--- a/examples/effect_chain2d.rs
+++ b/examples/effect_chain2d.rs
@@ -1,0 +1,60 @@
+use kiss3d::post_processing::{Crt, Gi2d, GiEmitter2d, GiOccluder2d, PostProcessingEffect};
+use kiss3d::prelude::*;
+
+// Demonstrates chaining multiple post-processing effects with `render_2d_with_chain`:
+// screen-space global illumination (`Gi2d`) feeds its lit result into a CRT
+// stylizer (`Crt`). Each effect is a full-screen pass; the chain ping-pongs between
+// two targets and the last writes the frame.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: chained 2D post-processing").await;
+    window.set_background_color(Color::new(0.0, 0.0, 0.0, 1.0));
+    window.set_bloom_enabled(true);
+
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 1.5);
+    let mut scene = SceneNode2d::empty();
+
+    // A surface plus a couple of occluders for the GI pass to shadow.
+    scene
+        .add_rectangle(1400.0, 1000.0)
+        .set_color(Color::new(0.8, 0.82, 0.9, 1.0));
+    let occluder_pos = [Vec2::new(-150.0, 30.0), Vec2::new(140.0, -50.0)];
+    let occluder_radius = 55.0;
+    let occluders: Vec<GiOccluder2d> = occluder_pos
+        .iter()
+        .map(|&p| {
+            scene
+                .add_circle(occluder_radius)
+                .translate(p)
+                .set_color(Color::new(0.04, 0.04, 0.05, 1.0));
+            GiOccluder2d::new(p, occluder_radius)
+        })
+        .collect();
+
+    let glow = Color::new(2.6, 1.4, 0.4, 1.0);
+    let mut emitter = scene.add_circle(20.0);
+    emitter.set_color(glow);
+
+    let mut gi = Gi2d::new();
+    gi.set_ambient(Color::new(0.05, 0.05, 0.07, 1.0));
+    gi.set_rays(48);
+    gi.set_occluders(&occluders);
+
+    let mut crt = Crt::new();
+    crt.set_curvature(0.16);
+    crt.set_scanlines(0.25, 700.0);
+
+    let mut t = 0.0f32;
+    while {
+        gi.set_camera(&camera);
+        let mut chain: [&mut dyn PostProcessingEffect; 2] = [&mut gi, &mut crt];
+        window
+            .render_2d_with_chain(&mut scene, &mut camera, &mut chain)
+            .await
+    } {
+        t += 0.012;
+        let pos = Vec2::new(t.cos() * 280.0, t.sin() * 200.0);
+        emitter.set_position(pos);
+        gi.set_emitters(&[GiEmitter2d::new(pos, 20.0, glow, 3.0)]);
+    }
+}

--- a/examples/global_illumination2d.rs
+++ b/examples/global_illumination2d.rs
@@ -1,0 +1,158 @@
+//! Screen-space 2D global illumination (`Gi2d`): emitter discs light a surface,
+//! occluder discs cast soft shadows, and light bleeds in color. A bright orbiting
+//! emitter sweeps moving penumbras across a field of occluders.
+//!
+//! An egui panel exposes every `Gi2d` dial — solver (direct ray-march vs. radiance
+//! cascades), jump-flood SDF occluders, ambient, resolution scale, march steps/
+//! distance, rays-per-pixel and temporal blend (direct solver), and cascade levels /
+//! base directions (cascade solver) — plus the emitter intensity.
+//!
+//! Run with the `egui` feature: `cargo run --features egui --example global_illumination2d`.
+
+#[cfg(not(feature = "egui"))]
+#[kiss3d::main]
+async fn main() {
+    panic!(
+        "The 'egui' feature must be enabled: cargo run --features egui --example global_illumination2d"
+    );
+}
+
+#[cfg(feature = "egui")]
+#[kiss3d::main]
+async fn main() {
+    use kiss3d::post_processing::{Gi2d, GiEmitter2d, GiOccluder2d};
+    use kiss3d::prelude::*;
+
+    let mut window = Window::new("Kiss3d: 2D global illumination").await;
+    window.set_background_color(Color::new(0.0, 0.0, 0.0, 1.0));
+    window.set_bloom_enabled(true);
+
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 1.5);
+    let mut scene = SceneNode2d::empty();
+
+    // A large surface to catch the light (GI modulates whatever is drawn).
+    scene
+        .add_rectangle(1600.0, 1200.0)
+        .set_color(Color::new(0.85, 0.85, 0.9, 1.0));
+
+    // A grid of static occluder discs, drawn dark and registered with the GI solver.
+    // Kept under `MAX_OCCLUDERS` (64): a 5-row by 11-column grid = 55 discs.
+    let occluder_radius = 26.0;
+    let mut occluders: Vec<GiOccluder2d> = Vec::new();
+    for row in -2..=2 {
+        for col in -5..=5 {
+            let stagger = if row % 2 == 0 { 0.0 } else { 55.0 };
+            let p = Vec2::new(col as f32 * 110.0 + stagger, row as f32 * 95.0);
+            scene
+                .add_circle(occluder_radius)
+                .translate(p)
+                .set_color(Color::new(0.05, 0.05, 0.06, 1.0));
+            occluders.push(GiOccluder2d::new(p, occluder_radius));
+        }
+    }
+
+    // A static warm emitter, plus a moving bright emitter we orbit each frame.
+    let warm = Color::new(1.5, 0.7, 0.2, 1.0);
+    let cool = Color::new(0.4, 0.8, 2.0, 1.0);
+    scene
+        .add_circle(22.0)
+        .set_color(warm)
+        .translate(Vec2::new(-260.0, -200.0));
+
+    let mut mover = scene.add_circle(20.0);
+    mover.set_color(cool);
+
+    let mut gi = Gi2d::new();
+    gi.set_occluders(&occluders);
+
+    // Live-editable GI settings (defaults match Gi2d::new()).
+    let mut use_cascades = false;
+    let mut use_sdf = true;
+    let mut ambient = [0.06f32, 0.06, 0.08];
+    let mut resolution_scale = 2u32;
+    let mut max_steps = 32u32;
+    let mut max_distance = 2000.0f32;
+    let mut emitter_intensity = 3.0f32;
+    let mut rays = 8u32;
+    let mut temporal_blend = 0.85f32;
+    let mut cascade_levels = 5u32;
+    let mut base_directions = 16u32;
+
+    let mut t = 0.0f32;
+    while !window.should_close() {
+        t += 0.012;
+        let mover_pos = Vec2::new(t.cos() * 300.0, t.sin() * 220.0);
+        mover.set_position(mover_pos);
+        gi.set_emitters(&[
+            GiEmitter2d::new(Vec2::new(-260.0, -200.0), 22.0, warm, emitter_intensity * 0.85),
+            GiEmitter2d::new(mover_pos, 20.0, cool, emitter_intensity),
+        ]);
+
+        window.draw_ui(|ctx| {
+            egui::Window::new("Global Illumination").show(ctx, |ui| {
+                ui.label(if use_cascades {
+                    "solver: radiance cascades"
+                } else {
+                    "solver: direct ray-march"
+                });
+                ui.checkbox(&mut use_cascades, "Radiance cascades");
+                ui.checkbox(&mut use_sdf, "Jump-flood SDF occluders");
+
+                ui.separator();
+                ui.label("Common");
+                ui.horizontal(|ui| {
+                    ui.label("ambient");
+                    ui.color_edit_button_rgb(&mut ambient);
+                });
+                ui.add(egui::Slider::new(&mut resolution_scale, 1..=4).text("resolution scale (1/n)"));
+                ui.add(egui::Slider::new(&mut max_steps, 8..=128).text("max march steps"));
+                ui.add(egui::Slider::new(&mut max_distance, 200.0..=4000.0).text("max distance"));
+                ui.add(egui::Slider::new(&mut emitter_intensity, 0.0..=8.0).text("emitter intensity"));
+
+                ui.separator();
+                ui.label("Direct ray-march");
+                ui.add_enabled(
+                    !use_cascades,
+                    egui::Slider::new(&mut rays, 1..=64).text("rays / pixel"),
+                );
+                ui.add_enabled(
+                    !use_cascades,
+                    egui::Slider::new(&mut temporal_blend, 0.0..=0.95).text("temporal blend"),
+                );
+
+                ui.separator();
+                ui.label("Radiance cascades");
+                ui.add_enabled(
+                    use_cascades,
+                    egui::Slider::new(&mut cascade_levels, 1..=8).text("cascade levels"),
+                );
+                ui.add_enabled_ui(use_cascades, |ui| {
+                    egui::ComboBox::from_label("base directions")
+                        .selected_text(format!("{base_directions}"))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut base_directions, 4, "4");
+                            ui.selectable_value(&mut base_directions, 16, "16");
+                            ui.selectable_value(&mut base_directions, 64, "64");
+                        });
+                });
+            });
+        });
+
+        // Apply the panel state to the GI effect.
+        gi.set_radiance_cascades(use_cascades);
+        gi.set_sdf_occluders(use_sdf);
+        gi.set_ambient(Color::new(ambient[0], ambient[1], ambient[2], 1.0));
+        gi.set_resolution_scale(resolution_scale);
+        gi.set_max_steps(max_steps);
+        gi.set_max_distance(max_distance);
+        gi.set_rays(rays);
+        gi.set_temporal_blend(temporal_blend);
+        gi.set_cascade_count(cascade_levels);
+        gi.set_cascade_base_directions(base_directions);
+
+        gi.set_camera(&camera);
+        if !window.render_2d_with(&mut scene, &mut camera, &mut gi).await {
+            break;
+        }
+    }
+}

--- a/examples/global_illumination2d.rs
+++ b/examples/global_illumination2d.rs
@@ -84,7 +84,12 @@ async fn main() {
         let mover_pos = Vec2::new(t.cos() * 300.0, t.sin() * 220.0);
         mover.set_position(mover_pos);
         gi.set_emitters(&[
-            GiEmitter2d::new(Vec2::new(-260.0, -200.0), 22.0, warm, emitter_intensity * 0.85),
+            GiEmitter2d::new(
+                Vec2::new(-260.0, -200.0),
+                22.0,
+                warm,
+                emitter_intensity * 0.85,
+            ),
             GiEmitter2d::new(mover_pos, 20.0, cool, emitter_intensity),
         ]);
 
@@ -104,10 +109,14 @@ async fn main() {
                     ui.label("ambient");
                     ui.color_edit_button_rgb(&mut ambient);
                 });
-                ui.add(egui::Slider::new(&mut resolution_scale, 1..=4).text("resolution scale (1/n)"));
+                ui.add(
+                    egui::Slider::new(&mut resolution_scale, 1..=4).text("resolution scale (1/n)"),
+                );
                 ui.add(egui::Slider::new(&mut max_steps, 8..=128).text("max march steps"));
                 ui.add(egui::Slider::new(&mut max_distance, 200.0..=4000.0).text("max distance"));
-                ui.add(egui::Slider::new(&mut emitter_intensity, 0.0..=8.0).text("emitter intensity"));
+                ui.add(
+                    egui::Slider::new(&mut emitter_intensity, 0.0..=8.0).text("emitter intensity"),
+                );
 
                 ui.separator();
                 ui.label("Direct ray-march");
@@ -151,7 +160,10 @@ async fn main() {
         gi.set_cascade_base_directions(base_directions);
 
         gi.set_camera(&camera);
-        if !window.render_2d_with(&mut scene, &mut camera, &mut gi).await {
+        if !window
+            .render_2d_with(&mut scene, &mut camera, &mut gi)
+            .await
+        {
             break;
         }
     }

--- a/examples/lighting2d.rs
+++ b/examples/lighting2d.rs
@@ -1,0 +1,68 @@
+use kiss3d::light2d::{Light2d, Light2dManager};
+use kiss3d::prelude::*;
+
+// Demonstrates dynamic 2D lighting: a grid of lit sprites (LitMaterial2d) under
+// several moving colored point lights and a sweeping spot light, plus a dim
+// ambient term. With a normal map the sprites would shade per-pixel; here they are
+// flat, so you see each light's smooth radial falloff and the spot's cone.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: 2D lighting").await;
+    window.set_background_color(Color::new(0.0, 0.0, 0.0, 1.0));
+
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 2.5);
+    let mut scene = SceneNode2d::empty();
+
+    // A grid of flat gray lit tiles to catch the light.
+    let tile = 64.0;
+    let gap = 4.0;
+    for gy in -4..=4 {
+        for gx in -6..=6 {
+            scene
+                .add_lit_sprite(tile, tile)
+                .set_color(Color::new(0.8, 0.8, 0.85, 1.0))
+                .set_lit_params(LitParams::default().with_specular(0.4, 32.0))
+                .translate(Vec2::new(
+                    gx as f32 * (tile + gap),
+                    gy as f32 * (tile + gap),
+                ));
+        }
+    }
+
+    Light2dManager::get_global_manager(|m| m.set_ambient(Color::new(0.06, 0.06, 0.08, 1.0)));
+
+    let mut t = 0.0f32;
+    while window.render_2d(&mut scene, &mut camera).await {
+        t += 0.016;
+
+        let red = Light2d::point(
+            Vec2::new(t.cos() * 260.0, t.sin() * 160.0),
+            Color::new(1.0, 0.3, 0.2, 1.0),
+            3.0,
+            260.0,
+        )
+        .with_height(70.0);
+
+        let blue = Light2d::point(
+            Vec2::new((t * 1.3 + 2.0).cos() * 220.0, (t * 0.9).cos() * 180.0),
+            Color::new(0.3, 0.5, 1.0, 1.0),
+            3.0,
+            260.0,
+        )
+        .with_height(70.0);
+
+        // A spot light sweeping its aim direction around.
+        let spot = Light2d::spot(
+            Vec2::new(0.0, 220.0),
+            Vec2::new((t * 0.7).sin() * 0.6, -1.0),
+            Color::new(1.0, 1.0, 0.8, 1.0),
+            4.0,
+            420.0,
+            0.25,
+            0.5,
+        )
+        .with_height(60.0);
+
+        Light2dManager::get_global_manager(|m| m.set_lights(&[red, blue, spot]));
+    }
+}

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -44,12 +44,12 @@ async fn main() {
     let mut counter = 0usize;
 
     while !window.should_close() {
-        if time % 200 == 0 {
+        if time.is_multiple_of(200) {
             time = 0;
             counter = (counter + 1) % 4;
         }
 
-        time = time + 1;
+        time += 1;
 
         let _ = match counter {
             0 => {

--- a/examples/post_processing2d.rs
+++ b/examples/post_processing2d.rs
@@ -1,0 +1,46 @@
+use kiss3d::prelude::*;
+use kiss3d::post_processing::Crt;
+
+// Demonstrates the 2D post-processing stack: HDR bloom (bright, >1.0 colors bleed
+// light) plus a CRT stylization effect (curvature, chromatic aberration, scanlines
+// and vignette) applied via `render_2d_with`.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: 2D post-processing").await;
+    window.set_background_color(Color::new(0.02, 0.02, 0.05, 1.0));
+    window.set_bloom_enabled(true);
+
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 2.0);
+    let mut scene = SceneNode2d::empty();
+
+    // Over-bright HDR colors (components > 1) so the bloom pass picks them up.
+    let neon_orange = Color::new(3.0, 1.2, 0.1, 1.0);
+    let neon_cyan = Color::new(0.1, 2.4, 3.0, 1.0);
+    let neon_pink = Color::new(3.0, 0.4, 1.8, 1.0);
+
+    scene
+        .add_rectangle(240.0, 120.0)
+        .set_color(neon_cyan)
+        .translate(Vec2::new(-180.0, 110.0));
+
+    scene
+        .add_circle(70.0)
+        .set_color(neon_orange)
+        .translate(Vec2::new(170.0, 100.0));
+
+    let mut pulse = scene
+        .add_circle(60.0)
+        .set_color(neon_pink)
+        .translate(Vec2::new(0.0, -120.0));
+
+    let mut crt = Crt::new();
+    crt.set_curvature(0.18);
+    crt.set_scanlines(0.3, 600.0);
+
+    let mut t = 0.0f32;
+    while window.render_2d_with(&mut scene, &mut camera, &mut crt).await {
+        t += 0.05;
+        let s = 1.0 + 0.25 * (0.5 + 0.5 * t.sin());
+        pulse.set_local_scale(s, s);
+    }
+}

--- a/examples/post_processing2d.rs
+++ b/examples/post_processing2d.rs
@@ -1,5 +1,5 @@
-use kiss3d::prelude::*;
 use kiss3d::post_processing::Crt;
+use kiss3d::prelude::*;
 
 // Demonstrates the 2D post-processing stack: HDR bloom (bright, >1.0 colors bleed
 // light) plus a CRT stylization effect (curvature, chromatic aberration, scanlines
@@ -38,7 +38,10 @@ async fn main() {
     crt.set_scanlines(0.3, 600.0);
 
     let mut t = 0.0f32;
-    while window.render_2d_with(&mut scene, &mut camera, &mut crt).await {
+    while window
+        .render_2d_with(&mut scene, &mut camera, &mut crt)
+        .await
+    {
         t += 0.05;
         let s = 1.0 + 0.25 * (0.5 + 0.5 * t.sin());
         pulse.set_local_scale(s, s);

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -27,6 +27,6 @@ async fn main() {
         });
         c.recompute_normals();
 
-        time = time + 0.016;
+        time += 0.016;
     }
 }

--- a/examples/robot_view.rs
+++ b/examples/robot_view.rs
@@ -1,0 +1,529 @@
+//! A "robot" assembled from primitives drives a figure-eight through a small
+//! arena. A picture-in-picture panel in the top-right corner shows the scene
+//! through the robot's onboard camera, with an egui combo box to switch the
+//! sensor between regular color, path-traced, depth, normals (world or camera
+//! space) and segmentation rendering.
+//!
+//! The obstacles use a variety of materials — chrome and copper mirrors, clear
+//! and frosted glass, gold, emissive panels, subsurface scattering, and a
+//! mirror wall panel — that show their full effect (reflections, refraction,
+//! soft shadows, bounce light) in the raytraced mode. An equirectangular
+//! skybox provides the environment: it enables image-based lighting in the
+//! rasterized view (so metals reflect the sky there too) and serves as the
+//! path tracer's environment light.
+//!
+//! The robot's eye is an [`OffscreenSurface`] sharing the window's GPU context
+//! and scene graph: the color mode re-renders the scene from the robot camera,
+//! the raytraced mode runs the path tracer (accumulation keeps refining while
+//! the robot is paused), and the other modes use the GPU AOV visualization
+//! (`render_aov_3d`). The surface's output texture is registered directly with
+//! the window's egui renderer (`register_egui_texture`), so the feed never
+//! leaves the GPU — which is also what makes this demo web-compatible.
+
+#[cfg(not(feature = "egui"))]
+#[kiss3d::main]
+async fn main() {
+    panic!("The 'egui' feature must be enabled for this example to work.")
+}
+
+#[cfg(feature = "egui")]
+#[kiss3d::main]
+async fn main() {
+    use kiss3d::prelude::*;
+    use kiss3d::renderer::RayTracer;
+    use std::f32::consts::{FRAC_PI_2, PI, TAU};
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::path::Path;
+
+    /// What the robot's onboard camera displays.
+    #[derive(PartialEq, Clone, Copy)]
+    enum ViewMode {
+        Color,
+        Raytraced,
+        Depth,
+        Normals,
+        CameraNormals,
+        Segmentation,
+    }
+
+    impl ViewMode {
+        const ALL: [ViewMode; 6] = [
+            ViewMode::Color,
+            ViewMode::Raytraced,
+            ViewMode::Depth,
+            ViewMode::Normals,
+            ViewMode::CameraNormals,
+            ViewMode::Segmentation,
+        ];
+
+        fn label(self) -> &'static str {
+            match self {
+                ViewMode::Color => "Color",
+                ViewMode::Raytraced => "Raytraced",
+                ViewMode::Depth => "Depth",
+                ViewMode::Normals => "Normals (world)",
+                ViewMode::CameraNormals => "Normals (camera)",
+                ViewMode::Segmentation => "Segmentation",
+            }
+        }
+    }
+
+    const PIP_W: u32 = 320;
+    const PIP_H: u32 = 240;
+    // Depth is mapped to grayscale over a fixed range (in world units) so the
+    // visualization doesn't flicker as the per-frame min/max changes.
+    const DEPTH_RANGE: f32 = 16.0;
+
+    let mut window = Window::new_with_size("Kiss3d: robot view", 1280, 800).await;
+    window.set_background_color(Color::new(0.05, 0.06, 0.09, 1.0));
+    window.set_ambient(0.2);
+
+    // The robot's eye: a small headless surface. It reuses the window's wgpu
+    // context, so both can render the same scene graph.
+    let mut pip = OffscreenSurface::new(PIP_W, PIP_H).await;
+    pip.set_background_color(Color::new(0.05, 0.06, 0.09, 1.0));
+    pip.set_ambient(0.2);
+
+    // The skybox enables image-based lighting in the rasterized views and is
+    // the path tracer's environment. It is per-surface, so set it on both the
+    // main window and the robot's eye.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        window.set_skybox_from_file(Path::new("./examples/media/skybox.png"));
+        pip.window_mut()
+            .set_skybox_from_file(Path::new("./examples/media/skybox.png"));
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        window.set_skybox_from_memory(include_bytes!("media/skybox.png"));
+        pip.window_mut()
+            .set_skybox_from_memory(include_bytes!("media/skybox.png"));
+    }
+
+    let mut scene = SceneNode3d::empty();
+
+    scene
+        .add_light(
+            Light::directional(Vec3::new(-0.5, -1.0, -0.4))
+                .with_color(Color::new(1.0, 0.96, 0.85, 1.0))
+                .with_intensity(2.5),
+        )
+        .set_position(Vec3::new(0.0, 8.0, 0.0));
+    scene
+        .add_light(
+            Light::point(40.0)
+                .with_color(Color::new(0.4, 0.45, 0.6, 1.0))
+                .with_intensity(1.5)
+                .with_casts_shadows(false),
+        )
+        .set_position(Vec3::new(6.0, 5.0, -6.0));
+
+    // === Arena: ground, walls and a few obstacles ===
+    // Slightly glossy ground so the raytraced view picks up reflections of the
+    // emissive and metallic obstacles.
+    let mut ground = scene
+        .add_cube(20.0, 0.2, 20.0)
+        .set_position(Vec3::new(0.0, -0.1, 0.0))
+        .set_color(Color::new(0.45, 0.47, 0.5, 1.0))
+        .set_roughness(0.35);
+    ground.apply_to_object_mut(&mut |o| o.set_segmentation_id(1));
+
+    let walls = vec![
+        (Vec3::new(20.0, 1.6, 0.4), Vec3::new(0.0, 0.8, 9.8)),
+        (Vec3::new(20.0, 1.6, 0.4), Vec3::new(0.0, 0.8, -9.8)),
+        (Vec3::new(0.4, 1.6, 20.0), Vec3::new(9.8, 0.8, 0.0)),
+        (Vec3::new(0.4, 1.6, 20.0), Vec3::new(-9.8, 0.8, 0.0)),
+    ];
+    for (i, (size, pos)) in walls.into_iter().enumerate() {
+        let mut wall = scene
+            .add_cube(size.x, size.y, size.z)
+            .set_position(pos)
+            .set_color(Color::new(0.3, 0.32, 0.38, 1.0));
+        wall.apply_to_object_mut(&mut |o| o.set_segmentation_id(2 + i as u32));
+    }
+
+    // Obstacles with a variety of materials. Their full effect (mirror
+    // reflections, refraction, emission, subsurface) shows in the raytraced
+    // view mode. Positions are chosen to stay clear of the robot's
+    // figure-eight path (the two pillars sit at the centers of its lobes).
+
+    // Transparent colored pillar.
+    scene
+        .add_cylinder(0.6, 2.8)
+        .set_position(Vec3::new(4.0, 1.4, 0.0))
+        .set_color(Color::new(0.1, 0.92, 0.7, 0.75))
+        .set_metallic(1.0)
+        .set_roughness(0.03)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(10));
+
+    // Emissive pillar: an area light in the raytraced view.
+    scene
+        .add_cylinder(0.6, 2.8)
+        .set_position(Vec3::new(-4.0, 1.4, 0.0))
+        .set_color(ORANGE)
+        .set_emissive(Color::new(3.0, 1.4, 0.4, 1.0))
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(11));
+
+    // Clear glass sphere: refraction.
+    scene
+        .add_sphere(0.8)
+        .set_position(Vec3::new(8.0, 0.8, 2.5))
+        .set_color(WHITE)
+        .set_bsdf(Bsdf::Glass)
+        .set_ior(1.5)
+        .set_transmission(1.0)
+        .set_roughness(0.0)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(12));
+
+    // Brushed gold cone.
+    scene
+        .add_cone(0.8, 1.8)
+        .set_position(Vec3::new(-8.0, 0.9, -2.0))
+        .set_color(Color::new(1.0, 0.85, 0.4, 1.0))
+        .set_bsdf(Bsdf::Metal)
+        .set_metallic(1.0)
+        .set_specular_tint(Color::new(1.0, 0.82, 0.45, 1.0))
+        .set_roughness(0.15)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(13));
+
+    // Frosted glass cube, slightly aqua-tinted: rough refraction. Sits near the
+    // middle of the arena so the pillars and the passing robot are seen blurred
+    // through it.
+    scene
+        .add_cube(1.5, 1.5, 1.5)
+        .set_position(Vec3::new(0.0, 0.75, -3.0))
+        .set_color(Color::new(0.75, 0.2, 0.92, 1.0))
+        .set_bsdf(Bsdf::Glass)
+        .set_ior(2.45)
+        .set_thickness(1.0)
+        .set_transmission(1.0)
+        .set_roughness(0.3)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(14));
+
+    // Waxy capsule: subsurface scattering.
+    scene
+        .add_capsule(0.45, 1.2)
+        .set_position(Vec3::new(-7.0, 1.05, 4.5))
+        .set_color(Color::new(0.9, 0.4, 0.4, 1.0))
+        .set_subsurface(0.8, 0.5)
+        .set_roughness(0.5)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(15));
+
+    // Matte plastic cube.
+    scene
+        .add_cube(2.5, 1.5, 1.0)
+        .set_position(Vec3::new(0.0, 0.75, 5.8))
+        .set_color(TEAL)
+        .set_roughness(0.9)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(16));
+
+    // Copper mirror sphere.
+    scene
+        .add_sphere(1.0)
+        .set_position(Vec3::new(0.0, 1.0, -6.0))
+        .set_color(Color::new(0.95, 0.55, 0.35, 1.0))
+        .set_metallic(1.0)
+        .set_specular_tint(Color::new(0.95, 0.6, 0.4, 1.0))
+        .set_roughness(0.08)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(17));
+
+    // Glossy plastic cone: sharp specular highlights.
+    scene
+        .add_cone(0.7, 1.2)
+        .set_position(Vec3::new(3.2, 0.6, -5.5))
+        .set_color(DODGER_BLUE)
+        .set_roughness(0.15)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(18));
+
+    // Small emissive "bulb".
+    scene
+        .add_sphere(0.5)
+        .set_position(Vec3::new(-3.0, 0.5, 5.5))
+        .set_color(YELLOW_GREEN)
+        .set_emissive(Color::new(1.2, 2.5, 0.6, 1.0))
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(19));
+
+    // Mirror panel on the north wall: a planar reflector quad, rotated so its
+    // normal faces the arena (-Z). The rasterized views render a true mirror
+    // image of the scene — robot included — into it every frame, and the path
+    // tracer reflects it like polished metal. The robot slows down and stares
+    // at it for a few seconds when passing nearby.
+    let mirror_pos = Vec3::new(4.0, 1.2, 9.55);
+    scene
+        .add_reflector(4.5, 2.4)
+        .set_position(mirror_pos)
+        .set_rotation(Quat::from_rotation_y(PI))
+        .set_color(Color::new(0.85, 0.88, 0.95, 1.0))
+        .set_metallic(1.0)
+        .set_roughness(0.05)
+        .apply_to_object_mut(&mut |o| o.set_segmentation_id(20));
+
+    // === The robot, built from primitives (local forward is +Z) ===
+    const WHEEL_RADIUS: f32 = 0.25;
+
+    let mut robot = scene.add_group();
+    robot
+        .add_cube(0.9, 0.4, 1.3)
+        .set_position(Vec3::new(0.0, 0.45, 0.0))
+        .set_color(Color::new(0.75, 0.78, 0.82, 1.0));
+    robot
+        .add_cylinder(0.08, 0.2)
+        .set_position(Vec3::new(0.0, 0.75, 0.1))
+        .set_color(Color::new(0.2, 0.2, 0.22, 1.0));
+
+    // The head swivels left/right to "scan" the environment; the onboard
+    // camera follows it.
+    let mut head = robot.add_group();
+    head.set_position(Vec3::new(0.0, 0.95, 0.1));
+    head.add_cube(0.5, 0.4, 0.5)
+        .set_color(Color::new(0.85, 0.87, 0.9, 1.0));
+    head.add_cylinder(0.09, 0.1)
+        .set_rotation(Quat::from_rotation_x(FRAC_PI_2))
+        .set_position(Vec3::new(0.0, 0.05, 0.3))
+        .set_color(Color::new(0.1, 0.6, 0.8, 1.0));
+
+    robot
+        .add_cylinder(0.02, 0.5)
+        .set_position(Vec3::new(-0.25, 0.9, -0.5))
+        .set_color(Color::new(0.2, 0.2, 0.22, 1.0));
+    robot
+        .add_sphere(0.05)
+        .set_position(Vec3::new(-0.25, 1.18, -0.5))
+        .set_color(RED);
+
+    let mut wheels = Vec::new();
+    for (x, z) in [(-0.55, 0.45), (0.55, 0.45), (-0.55, -0.45), (0.55, -0.45)] {
+        wheels.push(
+            robot
+                .add_cylinder(WHEEL_RADIUS, 0.14)
+                .set_position(Vec3::new(x, WHEEL_RADIUS, z))
+                .set_color(Color::new(0.12, 0.12, 0.14, 1.0)),
+        );
+    }
+    robot.apply_to_objects_mut_recursive(&mut |o| o.set_segmentation_id(99));
+
+    // === Cameras ===
+    let mut main_camera = OrbitCamera3d::new(Vec3::new(10.0, 8.0, 10.0), Vec3::ZERO);
+    // The robot's eye; never receives input events, it is repositioned
+    // programmatically every frame.
+    let mut robot_camera = FirstPersonCamera3d::new_with_frustum(
+        60.0f32.to_radians(),
+        0.05,
+        100.0,
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec3::Z,
+    );
+
+    // Path tracer for the raytraced view mode. Accumulation resets
+    // automatically whenever the robot camera moves, so the feed stays live;
+    // pausing the robot lets it converge.
+    let mut raytracer = RayTracer::new();
+    raytracer.set_max_bounces(6);
+
+    // The PiP display: register the offscreen surface's output texture
+    // directly with the window's egui renderer. The robot's view never leaves
+    // the GPU — no per-frame read-back or re-upload.
+    let mut pip_tex = window.register_egui_texture(&pip.output_view(), wgpu::FilterMode::Linear);
+    // Allocated PiP resolution vs the size wanted by the (resizable) panel.
+    let mut pip_size = (PIP_W, PIP_H);
+    let mut pip_desired = pip_size;
+
+    // === UI state ===
+    let mut mode = ViewMode::Color;
+    let mut paused = false;
+    let mut show_robot_in_pip = true;
+    let mut rt_samples = 8u32;
+    // Set when the trajectory slider scrubbed `u`, so the wheels don't roll
+    // across the jump.
+    let mut scrubbed = false;
+    // User-controlled angular offset added to the head's scripted orientation.
+    let mut look_offset = 0.0f32;
+
+    // The figure-eight the robot patrols.
+    let path = |u: f32| Vec3::new(6.0 * u.sin(), 0.0, 3.5 * (2.0 * u).sin());
+
+    let mut t = 0.0f32;
+    let mut u = 0.0f32; // path parameter (integrated, so the speed can vary)
+    let mut wheel_spin = 0.0f32;
+    let mut last_pos = path(0.0);
+
+    // Head-scan state: the head normally sweeps left/right, but when the wall
+    // mirror comes roughly ahead the robot slows down and stares at it for a
+    // few seconds, the head tracking it well past the heading as it drives by.
+    const GAZE_ACQUIRE: f32 = 1.0; // bearing under which the robot notices the mirror
+    const GAZE_TRACK_LIMIT: f32 = 2.0; // max head swivel while staring, radians
+    const GAZE_TIME: f32 = 7.0; // how long one stare lasts, seconds
+    const GAZE_SLOWDOWN: f32 = 0.70; // path-speed factor while staring
+    let mut head_yaw = 0.0f32;
+    let mut gaze_timer = 0.0f32; // > 0 while staring at the mirror
+    let mut gaze_cooldown = 0.0f32; // delay before the next lock-on
+
+    while window.render_3d(&mut scene, &mut main_camera).await {
+        if !paused {
+            t += 0.016;
+            // Drive along the path; the robot slows down while staring at the
+            // mirror, which also stretches the stare's geometric window.
+            let speed = if gaze_timer > 0.0 { GAZE_SLOWDOWN } else { 1.0 };
+            u += 0.016 * 0.45 * speed;
+        }
+
+        // Heading along the path tangent.
+        let pos = path(u);
+        let dir = (path(u + 0.01) - pos).normalize();
+        let yaw = dir.x.atan2(dir.z);
+        let rot = Quat::from_rotation_y(yaw);
+        robot.set_position(pos).set_rotation(rot);
+
+        // Don't roll the wheels across a trajectory-slider jump.
+        if scrubbed {
+            last_pos = pos;
+            scrubbed = false;
+        }
+
+        // Roll the wheels by the distance traveled.
+        wheel_spin += (pos - last_pos).length() / WHEEL_RADIUS;
+        last_pos = pos;
+        for wheel in &mut wheels {
+            wheel.set_rotation(Quat::from_rotation_x(wheel_spin) * Quat::from_rotation_z(FRAC_PI_2));
+        }
+
+        // Swivel the head, and place the onboard camera just in front of its lens.
+        // Bearing of the mirror relative to the robot's heading, in [-pi, pi].
+        let to_mirror = mirror_pos - (pos + Vec3::Y);
+        let rel_mirror_yaw =
+            (to_mirror.x.atan2(to_mirror.z) - yaw + PI).rem_euclid(TAU) - PI;
+        let mirror_in_range =
+            rel_mirror_yaw.abs() < GAZE_ACQUIRE && to_mirror.length() < 12.0;
+        if !paused {
+            let dt = 0.016;
+            if gaze_timer > 0.0 {
+                gaze_timer -= dt;
+                // Done staring (or the robot turned so far away that even the
+                // fully swiveled head lost the mirror): resume scanning, and
+                // don't re-lock immediately.
+                if gaze_timer <= 0.0 || rel_mirror_yaw.abs() > GAZE_TRACK_LIMIT + 0.3 {
+                    gaze_timer = 0.0;
+                    gaze_cooldown = 8.0;
+                }
+            } else if gaze_cooldown > 0.0 {
+                gaze_cooldown -= dt;
+            } else if mirror_in_range {
+                gaze_timer = GAZE_TIME;
+            }
+
+            let target = if gaze_timer > 0.0 {
+                rel_mirror_yaw.clamp(-GAZE_TRACK_LIMIT, GAZE_TRACK_LIMIT)
+            } else {
+                (t * 1.2).sin() * 0.6
+            };
+            // Ease toward the target so lock-on/release looks like a head turn.
+            head_yaw += (target - head_yaw) * 0.08;
+        }
+        // The head's final orientation: the scripted scan/gaze angle plus the
+        // user-controlled offset from the "Look offset" slider.
+        let scan = head_yaw + look_offset;
+        head.set_rotation(Quat::from_rotation_y(scan));
+        let scan_rot = rot * Quat::from_rotation_y(scan);
+        let eye = pos + rot * Vec3::new(0.0, 1.0, 0.1) + scan_rot * Vec3::new(0.0, 0.0, 0.42);
+        let look = scan_rot * Vec3::new(0.0, -0.12, 1.0);
+        robot_camera.look_at(eye, eye + look * 5.0);
+
+        // Apply a PiP panel resize: re-render at the displayed resolution so an
+        // enlarged panel stays sharp. The resize reallocates the surface's
+        // output texture, so the egui registration must be refreshed.
+        if pip_desired != pip_size {
+            pip.resize(pip_desired.0, pip_desired.1);
+            window.unregister_egui_texture(pip_tex);
+            pip_tex =
+                window.register_egui_texture(&pip.output_view(), wgpu::FilterMode::Linear);
+            pip_size = pip_desired;
+        }
+
+        // Render what the robot sees into the PiP texture. Every mode stays on
+        // the GPU: the beauty/raytraced passes render into the surface's output
+        // target, and the AOV modes use the GPU visualization.
+        if !show_robot_in_pip {
+            robot.set_visible(false);
+        }
+        match mode {
+            ViewMode::Color => {
+                pip.render_3d(&mut scene, &mut robot_camera).await;
+            }
+            ViewMode::Raytraced => {
+                raytracer.set_samples_per_frame(rt_samples);
+                pip.raytrace_3d(&mut scene, &mut robot_camera, &mut raytracer)
+                    .await;
+            }
+            ViewMode::Depth => {
+                pip.render_aov_3d(AovKind::Depth, &mut scene, &mut robot_camera, DEPTH_RANGE);
+            }
+            ViewMode::Normals => {
+                pip.render_aov_3d(AovKind::Normals, &mut scene, &mut robot_camera, 0.0);
+            }
+            ViewMode::CameraNormals => {
+                pip.render_aov_3d(AovKind::CameraNormals, &mut scene, &mut robot_camera, 0.0);
+            }
+            ViewMode::Segmentation => {
+                pip.render_aov_3d(AovKind::Segmentation, &mut scene, &mut robot_camera, 0.0);
+            }
+        }
+        robot.set_visible(true);
+
+        window.draw_ui(|ctx| {
+            egui::Window::new("Robot eye")
+                .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-10.0, 10.0))
+                .resizable(true)
+                .default_width(PIP_W as f32)
+                .collapsible(false)
+                .show(ctx, |ui| {
+                    // The image fills the panel width at a 4:3 aspect; the
+                    // surface is re-rendered at this size (in physical pixels)
+                    // so enlarging the panel keeps the feed sharp.
+                    let img_w = ui.available_width().max(120.0);
+                    let img_h = img_w * (PIP_H as f32 / PIP_W as f32);
+                    ui.image((pip_tex, egui::vec2(img_w, img_h)));
+                    let ppp = ui.ctx().pixels_per_point();
+                    pip_desired = (
+                        ((img_w * ppp).round() as u32).max(64),
+                        ((img_h * ppp).round() as u32).max(48),
+                    );
+                    egui::ComboBox::from_label("Mode")
+                        .selected_text(mode.label())
+                        .show_ui(ui, |ui| {
+                            for m in ViewMode::ALL {
+                                ui.selectable_value(&mut mode, m, m.label());
+                            }
+                        });
+                    // Scrub the robot along its figure-eight (one lap = 1.0).
+                    // Auto-play keeps advancing from wherever it is dropped.
+                    let mut lap = u.rem_euclid(TAU) / TAU;
+                    if ui
+                        .add(egui::Slider::new(&mut lap, 0.0..=1.0).text("Position"))
+                        .changed()
+                    {
+                        u = lap * TAU;
+                        scrubbed = true;
+                    }
+                    // Turn the head relative to its scripted orientation.
+                    let mut look_deg = look_offset.to_degrees();
+                    if ui
+                        .add(
+                            egui::Slider::new(&mut look_deg, -180.0..=180.0)
+                                .suffix("°")
+                                .text("Look offset"),
+                        )
+                        .changed()
+                    {
+                        look_offset = look_deg.to_radians();
+                    }
+                    if mode == ViewMode::Raytraced {
+                        ui.add(
+                            egui::Slider::new(&mut rt_samples, 1..=32).text("Samples/frame"),
+                        );
+                    }
+                    ui.checkbox(&mut show_robot_in_pip, "Show robot body");
+                    ui.checkbox(&mut paused, "Pause robot");
+                });
+        });
+    }
+}

--- a/examples/robot_view.rs
+++ b/examples/robot_view.rs
@@ -384,16 +384,15 @@ async fn main() {
         wheel_spin += (pos - last_pos).length() / WHEEL_RADIUS;
         last_pos = pos;
         for wheel in &mut wheels {
-            wheel.set_rotation(Quat::from_rotation_x(wheel_spin) * Quat::from_rotation_z(FRAC_PI_2));
+            wheel
+                .set_rotation(Quat::from_rotation_x(wheel_spin) * Quat::from_rotation_z(FRAC_PI_2));
         }
 
         // Swivel the head, and place the onboard camera just in front of its lens.
         // Bearing of the mirror relative to the robot's heading, in [-pi, pi].
         let to_mirror = mirror_pos - (pos + Vec3::Y);
-        let rel_mirror_yaw =
-            (to_mirror.x.atan2(to_mirror.z) - yaw + PI).rem_euclid(TAU) - PI;
-        let mirror_in_range =
-            rel_mirror_yaw.abs() < GAZE_ACQUIRE && to_mirror.length() < 12.0;
+        let rel_mirror_yaw = (to_mirror.x.atan2(to_mirror.z) - yaw + PI).rem_euclid(TAU) - PI;
+        let mirror_in_range = rel_mirror_yaw.abs() < GAZE_ACQUIRE && to_mirror.length() < 12.0;
         if !paused {
             let dt = 0.016;
             if gaze_timer > 0.0 {
@@ -434,8 +433,7 @@ async fn main() {
         if pip_desired != pip_size {
             pip.resize(pip_desired.0, pip_desired.1);
             window.unregister_egui_texture(pip_tex);
-            pip_tex =
-                window.register_egui_texture(&pip.output_view(), wgpu::FilterMode::Linear);
+            pip_tex = window.register_egui_texture(&pip.output_view(), wgpu::FilterMode::Linear);
             pip_size = pip_desired;
         }
 
@@ -517,9 +515,7 @@ async fn main() {
                         look_offset = look_deg.to_radians();
                     }
                     if mode == ViewMode::Raytraced {
-                        ui.add(
-                            egui::Slider::new(&mut rt_samples, 1..=32).text("Samples/frame"),
-                        );
+                        ui.add(egui::Slider::new(&mut rt_samples, 1..=32).text("Samples/frame"));
                     }
                     ui.checkbox(&mut show_robot_in_pip, "Show robot body");
                     ui.checkbox(&mut paused, "Pause robot");

--- a/examples/skinning2d.rs
+++ b/examples/skinning2d.rs
@@ -21,7 +21,10 @@ async fn main() {
         for &x in &[-half_w, half_w] {
             verts.push(SkinVertex2d {
                 position: Vec2::new(x, row as f32 * seg_h),
-                uv: Vec2::new((x + half_w) / (2.0 * half_w), 1.0 - row as f32 / segments as f32),
+                uv: Vec2::new(
+                    (x + half_w) / (2.0 * half_w),
+                    1.0 - row as f32 / segments as f32,
+                ),
                 joints: [row as u32, 0, 0, 0],
                 weights: [1.0, 0.0, 0.0, 0.0],
             });

--- a/examples/skinning2d.rs
+++ b/examples/skinning2d.rs
@@ -1,0 +1,66 @@
+use kiss3d::builtin::{Bone2d, SkinVertex2d, SkinnedMesh2d};
+use kiss3d::prelude::*;
+use std::path::Path;
+
+// Demonstrates 2D skeletal deformation with GPU skinning: a textured strip is bound
+// to a chain of bones, and a traveling sine wave along the chain makes it ripple
+// like a banner / tentacle. The deformation happens entirely on the GPU.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: 2D skeletal skinning").await;
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 2.0);
+    let mut scene = SceneNode2d::empty();
+
+    let segments = 10usize; // bone chain length
+    let seg_h = 40.0f32;
+    let half_w = 40.0f32;
+
+    // One vertex row per bone, two columns; each row is fully weighted to its bone.
+    let mut verts = Vec::new();
+    for row in 0..=segments {
+        for &x in &[-half_w, half_w] {
+            verts.push(SkinVertex2d {
+                position: Vec2::new(x, row as f32 * seg_h),
+                uv: Vec2::new((x + half_w) / (2.0 * half_w), 1.0 - row as f32 / segments as f32),
+                joints: [row as u32, 0, 0, 0],
+                weights: [1.0, 0.0, 0.0, 0.0],
+            });
+        }
+    }
+    // Two triangles per segment quad.
+    let mut faces = Vec::new();
+    for row in 0..segments as u32 {
+        let b = row * 2;
+        faces.push([b, b + 1, b + 3]);
+        faces.push([b, b + 3, b + 2]);
+    }
+    // Bone chain: root at the base, each bone offset one segment up from its parent.
+    let mut bones = vec![Bone2d {
+        parent: None,
+        local: Pose2::IDENTITY,
+    }];
+    for i in 1..=segments {
+        bones.push(Bone2d {
+            parent: Some(i - 1),
+            local: Pose2::from_translation(Vec2::new(0.0, seg_h)),
+        });
+    }
+
+    let mut skinned = SkinnedMesh2d::new(verts, faces, bones);
+    skinned.set_transform(Pose2::from_translation(Vec2::new(0.0, -200.0)));
+    skinned
+        .node()
+        .set_texture_from_file(Path::new("./examples/media/kitten.png"), "kitten");
+    scene.add_child(skinned.node());
+
+    let mut t = 0.0f32;
+    while window.render_2d(&mut scene, &mut camera).await {
+        t += 0.05;
+        // Travel a bend wave up the chain (the root stays fixed).
+        for i in 1..=segments {
+            let angle = 0.35 * (t + i as f32 * 0.6).sin();
+            skinned.set_bone_local(i, Pose2::new(Vec2::new(0.0, seg_h), angle));
+        }
+        skinned.update();
+    }
+}

--- a/examples/sprites2d.rs
+++ b/examples/sprites2d.rs
@@ -1,0 +1,47 @@
+use kiss3d::prelude::*;
+use std::path::Path;
+
+// Demonstrates sprites: a plain sprite quad, sprite-sheet frame animation
+// (`SpriteSheet` + `set_sprite_frame`), and a 9-slice panel whose corners keep
+// their size while the center stretches. The kitten texture stands in for both a
+// 2x2 sheet and a 9-slice panel so the example needs no extra assets.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: 2D sprites").await;
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 2.0);
+    let mut scene = SceneNode2d::empty();
+
+    let kitten = Path::new("./examples/media/kitten.png");
+
+    // A plain sprite quad showing the whole texture.
+    scene
+        .add_sprite(160.0, 160.0)
+        .translate(Vec2::new(-260.0, 0.0))
+        .set_texture_from_file(kitten, "kitten");
+
+    // The same texture treated as a 2x2 sprite sheet; we cycle through its 4 frames.
+    let sheet = SpriteSheet::new(2, 2);
+    let mut animated = scene
+        .add_sprite(160.0, 160.0)
+        .set_texture_with_name("kitten");
+    animated.set_sprite_frame(&sheet, 0);
+
+    // A 9-slice panel, scaled wide: corners keep their size, edges/center stretch.
+    scene
+        .add_nine_slice(
+            Vec2::new(360.0, 160.0),
+            Border::uniform(28.0),
+            Border::uniform(0.25),
+        )
+        .translate(Vec2::new(240.0, 0.0))
+        .set_texture_with_name("kitten");
+
+    let mut frame = 0u32;
+    while window.render_2d(&mut scene, &mut camera).await {
+        // Advance the sprite-sheet animation a few times per second.
+        if frame % 20 == 0 {
+            animated.set_sprite_frame(&sheet, frame / 20);
+        }
+        frame = frame.wrapping_add(1);
+    }
+}

--- a/examples/sprites2d.rs
+++ b/examples/sprites2d.rs
@@ -39,7 +39,7 @@ async fn main() {
     let mut frame = 0u32;
     while window.render_2d(&mut scene, &mut camera).await {
         // Advance the sprite-sheet animation a few times per second.
-        if frame % 20 == 0 {
+        if frame.is_multiple_of(20) {
             animated.set_sprite_frame(&sheet, frame / 20);
         }
         frame = frame.wrapping_add(1);

--- a/examples/tilemap2d.rs
+++ b/examples/tilemap2d.rs
@@ -1,0 +1,40 @@
+use kiss3d::prelude::*;
+use std::path::Path;
+
+// Demonstrates the `Tilemap`: a grid of tiles drawn from one texture atlas as a
+// single mesh / draw call. The kitten texture stands in for a 2x2 tile atlas (its
+// four quadrants), and an animated wave reshuffles the tile indices each frame.
+#[kiss3d::main]
+async fn main() {
+    let mut window = Window::new("Kiss3d: 2D tilemap").await;
+    let mut camera = PanZoomCamera2d::new(Vec2::ZERO, 1.0);
+    let mut scene = SceneNode2d::empty();
+
+    let columns = 16;
+    let rows = 12;
+    let sheet = SpriteSheet::new(2, 2); // 4 tiles
+    let mut tilemap = Tilemap::new(columns, rows, Vec2::new(44.0, 44.0), sheet);
+
+    // The atlas texture, assigned to the tilemap's node.
+    tilemap
+        .node()
+        .set_texture_from_file(Path::new("./examples/media/kitten.png"), "kitten");
+    scene.add_child(tilemap.node());
+
+    let mut frame = 0u32;
+    while window.render_2d(&mut scene, &mut camera).await {
+        // A few times per second, rewrite the whole grid with a moving diagonal
+        // wave selecting one of the four atlas tiles per cell.
+        if frame % 8 == 0 {
+            let phase = frame / 8;
+            let mut indices = Vec::with_capacity((columns * rows) as usize);
+            for row in 0..rows {
+                for col in 0..columns {
+                    indices.push((col + row + phase) % 4);
+                }
+            }
+            tilemap.fill(&indices);
+        }
+        frame = frame.wrapping_add(1);
+    }
+}

--- a/examples/tilemap2d.rs
+++ b/examples/tilemap2d.rs
@@ -25,7 +25,7 @@ async fn main() {
     while window.render_2d(&mut scene, &mut camera).await {
         // A few times per second, rewrite the whole grid with a moving diagonal
         // wave selecting one of the four atlas tiles per cell.
-        if frame % 8 == 0 {
+        if frame.is_multiple_of(8) {
             let phase = frame / 8;
             let mut indices = Vec::with_capacity((columns * rows) as usize);
             for row in 0..rows {

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -12,6 +12,7 @@ EXAMPLES=(
     primitives
     primitives_scale
     primitives2d
+    blend_modes2d
     clustered_lights
     wireframe
     lines

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -13,6 +13,7 @@ EXAMPLES=(
     primitives_scale
     primitives2d
     blend_modes2d
+    sprites2d
     clustered_lights
     wireframe
     lines

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -14,6 +14,7 @@ EXAMPLES=(
     primitives2d
     blend_modes2d
     sprites2d
+    post_processing2d
     clustered_lights
     wireframe
     lines

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -79,6 +79,7 @@ EXAMPLES=(
     multi_windows
     ui
     inspector
+    robot_view
 )
 
 echo "Running ${#EXAMPLES[@]} kiss3d examples..."

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -16,6 +16,7 @@ EXAMPLES=(
     sprites2d
     post_processing2d
     lighting2d
+    tilemap2d
     clustered_lights
     wireframe
     lines

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -17,6 +17,7 @@ EXAMPLES=(
     post_processing2d
     lighting2d
     tilemap2d
+    skinning2d
     clustered_lights
     wireframe
     lines

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -17,6 +17,7 @@ EXAMPLES=(
     post_processing2d
     lighting2d
     global_illumination2d
+    effect_chain2d
     tilemap2d
     skinning2d
     clustered_lights

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -16,6 +16,7 @@ EXAMPLES=(
     sprites2d
     post_processing2d
     lighting2d
+    global_illumination2d
     tilemap2d
     skinning2d
     clustered_lights

--- a/run_all_examples.sh
+++ b/run_all_examples.sh
@@ -15,6 +15,7 @@ EXAMPLES=(
     blend_modes2d
     sprites2d
     post_processing2d
+    lighting2d
     clustered_lights
     wireframe
     lines

--- a/src/builtin/aov.rs
+++ b/src/builtin/aov.rs
@@ -89,6 +89,10 @@ pub struct AovRenderer {
     object_bind_group_layout: wgpu::BindGroupLayout,
     object_uniform_buffer: DynamicUniformBuffer<ObjectUniforms>,
     object_bind_group: wgpu::BindGroup,
+
+    /// GPU-only AOV visualization (raw values → display colors); created on
+    /// first use of [`AovRenderer::visualize`].
+    visualize: Option<AovVisualize>,
 }
 
 impl AovRenderer {
@@ -246,7 +250,34 @@ impl AovRenderer {
             object_bind_group_layout,
             object_uniform_buffer,
             object_bind_group,
+            visualize: None,
         }
+    }
+
+    /// Renders the raw AOV in `raw_view` (of format [`AovKind::format`]) as a
+    /// display-ready image into `target_view` (of format `target_format`):
+    /// depth as fixed-range grayscale over `[0, depth_range]` world units
+    /// (near = bright, background = black), normals as RGB, segmentation ids
+    /// as distinct golden-ratio colors. Entirely on the GPU — no read-back.
+    pub fn visualize_into(
+        &mut self,
+        kind: AovKind,
+        encoder: &mut wgpu::CommandEncoder,
+        raw_view: &wgpu::TextureView,
+        target_view: &wgpu::TextureView,
+        target_format: wgpu::TextureFormat,
+        depth_range: f32,
+    ) {
+        if self
+            .visualize
+            .as_ref()
+            .is_some_and(|v| v.target_format != target_format)
+        {
+            self.visualize = None;
+        }
+        self.visualize
+            .get_or_insert_with(|| AovVisualize::new(target_format))
+            .render(kind, encoder, raw_view, target_view, depth_range);
     }
 
     fn make_object_bind_group(
@@ -439,4 +470,203 @@ struct DrawItem {
     normals: wgpu::Buffer,
     faces: wgpu::Buffer,
     num_indices: u32,
+}
+
+/// Uniforms of the AOV visualization pass (see `aov_visualize.wgsl`).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct VisUniforms {
+    /// `x`: float mode (0 = depth, 1 = normals); `y`: depth range;
+    /// `z`: 1.0 when the target format is sRGB.
+    params: [f32; 4],
+}
+
+/// Fullscreen pass turning a raw AOV texture into a display-ready image.
+///
+/// Two pipelines: one sampling the float AOV texture (depth/normals) and one
+/// sampling the integer segmentation texture. Owned by [`AovRenderer`].
+struct AovVisualize {
+    target_format: wgpu::TextureFormat,
+    layout_float: wgpu::BindGroupLayout,
+    layout_seg: wgpu::BindGroupLayout,
+    pipeline_float: wgpu::RenderPipeline,
+    pipeline_seg: wgpu::RenderPipeline,
+    uniform_buffer: wgpu::Buffer,
+}
+
+impl AovVisualize {
+    fn new(target_format: wgpu::TextureFormat) -> AovVisualize {
+        let ctxt = Context::get();
+
+        let uniform_entry = wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let texture_entry = |binding: u32, sample_type: wgpu::TextureSampleType| {
+            wgpu::BindGroupLayoutEntry {
+                binding,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            }
+        };
+
+        let layout_float = ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("aov_visualize_float_layout"),
+            entries: &[
+                uniform_entry,
+                texture_entry(1, wgpu::TextureSampleType::Float { filterable: false }),
+            ],
+        });
+        let layout_seg = ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("aov_visualize_seg_layout"),
+            entries: &[
+                uniform_entry,
+                texture_entry(2, wgpu::TextureSampleType::Uint),
+            ],
+        });
+
+        let shader = ctxt.create_shader_module(
+            Some("aov_visualize_shader"),
+            include_str!("aov_visualize.wgsl"),
+        );
+
+        let make_pipeline = |layout: &wgpu::BindGroupLayout, fs_entry: &str, label: &str| {
+            let pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(label),
+                bind_group_layouts: &[Some(layout)],
+                immediate_size: 0,
+            });
+            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some(fs_entry),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: target_format,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        let pipeline_float =
+            make_pipeline(&layout_float, "fs_float", "aov_visualize_float_pipeline");
+        let pipeline_seg = make_pipeline(&layout_seg, "fs_seg", "aov_visualize_seg_pipeline");
+
+        let uniform_buffer = ctxt.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("aov_visualize_uniform_buffer"),
+            size: std::mem::size_of::<VisUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        AovVisualize {
+            target_format,
+            layout_float,
+            layout_seg,
+            pipeline_float,
+            pipeline_seg,
+            uniform_buffer,
+        }
+    }
+
+    fn render(
+        &self,
+        kind: AovKind,
+        encoder: &mut wgpu::CommandEncoder,
+        raw_view: &wgpu::TextureView,
+        target_view: &wgpu::TextureView,
+        depth_range: f32,
+    ) {
+        let ctxt = Context::get();
+        let float_mode = match kind {
+            AovKind::Depth => 0.0,
+            _ => 1.0,
+        };
+        let is_srgb = if self.target_format.is_srgb() { 1.0 } else { 0.0 };
+        ctxt.write_buffer(
+            &self.uniform_buffer,
+            0,
+            bytemuck::bytes_of(&VisUniforms {
+                params: [float_mode, depth_range, is_srgb, 0.0],
+            }),
+        );
+
+        let seg = kind == AovKind::Segmentation;
+        let bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("aov_visualize_bind_group"),
+            layout: if seg { &self.layout_seg } else { &self.layout_float },
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.uniform_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: if seg { 2 } else { 1 },
+                    resource: wgpu::BindingResource::TextureView(raw_view),
+                },
+            ],
+        });
+
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("aov_visualize_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(if seg {
+            &self.pipeline_seg
+        } else {
+            &self.pipeline_float
+        });
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
 }

--- a/src/builtin/aov.rs
+++ b/src/builtin/aov.rs
@@ -508,8 +508,8 @@ impl AovVisualize {
             },
             count: None,
         };
-        let texture_entry = |binding: u32, sample_type: wgpu::TextureSampleType| {
-            wgpu::BindGroupLayoutEntry {
+        let texture_entry =
+            |binding: u32, sample_type: wgpu::TextureSampleType| wgpu::BindGroupLayoutEntry {
                 binding,
                 visibility: wgpu::ShaderStages::FRAGMENT,
                 ty: wgpu::BindingType::Texture {
@@ -518,8 +518,7 @@ impl AovVisualize {
                     multisampled: false,
                 },
                 count: None,
-            }
-        };
+            };
 
         let layout_float = ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("aov_visualize_float_layout"),
@@ -620,7 +619,11 @@ impl AovVisualize {
             AovKind::Depth => 0.0,
             _ => 1.0,
         };
-        let is_srgb = if self.target_format.is_srgb() { 1.0 } else { 0.0 };
+        let is_srgb = if self.target_format.is_srgb() {
+            1.0
+        } else {
+            0.0
+        };
         ctxt.write_buffer(
             &self.uniform_buffer,
             0,
@@ -632,7 +635,11 @@ impl AovVisualize {
         let seg = kind == AovKind::Segmentation;
         let bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("aov_visualize_bind_group"),
-            layout: if seg { &self.layout_seg } else { &self.layout_float },
+            layout: if seg {
+                &self.layout_seg
+            } else {
+                &self.layout_float
+            },
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,

--- a/src/builtin/aov_visualize.wgsl
+++ b/src/builtin/aov_visualize.wgsl
@@ -1,0 +1,87 @@
+// Visualizes raw AOV buffers (linear depth, encoded normals, segmentation ids)
+// as display-ready colors, with a fullscreen triangle.
+//
+// Two fragment entry points share the vertex stage: `fs_float` reads the float
+// AOV texture (depth or normals, selected by `params.x`), `fs_seg` reads the
+// integer segmentation texture. Each pipeline's bind group layout only covers
+// the bindings its entry point uses.
+//
+// params:
+//   x: float mode (0 = depth, 1 = normals)
+//   y: depth range in world units (depth mode only)
+//   z: 1.0 when the target is an sRGB format. The visualization is computed in
+//      display space (matching the CPU `snap_*` images); linearizing it first
+//      makes the hardware sRGB encode round-trip to the intended value.
+
+struct VisUniforms {
+    params: vec4<f32>,
+}
+
+@group(0) @binding(0) var<uniform> uni: VisUniforms;
+@group(0) @binding(1) var t_float: texture_2d<f32>;
+@group(0) @binding(2) var t_seg: texture_2d<u32>;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    // Fullscreen triangle.
+    var out: VsOut;
+    let uv = vec2<f32>(f32((vi << 1u) & 2u), f32(vi & 2u));
+    out.pos = vec4<f32>(uv * 2.0 - 1.0, 0.0, 1.0);
+    return out;
+}
+
+fn to_target(color: vec3<f32>) -> vec4<f32> {
+    if uni.params.z > 0.5 {
+        return vec4<f32>(pow(color, vec3<f32>(2.2)), 1.0);
+    }
+    return vec4<f32>(color, 1.0);
+}
+
+@fragment
+fn fs_float(in: VsOut) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(in.pos.xy);
+    let texel = textureLoad(t_float, coord, 0);
+    if uni.params.x < 0.5 {
+        // Depth: nearer = brighter over [0, range]; background (0) = black.
+        let d = texel.r;
+        var v = 0.0;
+        if d > 0.0 {
+            v = 1.0 - clamp(d / max(uni.params.y, 1.0e-6), 0.0, 1.0);
+        }
+        return to_target(vec3<f32>(v));
+    }
+    // Normals: already encoded to [0, 1].
+    return to_target(texel.rgb);
+}
+
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> vec3<f32> {
+    let i = floor(h * 6.0);
+    let f = h * 6.0 - i;
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let t = v * (1.0 - (1.0 - f) * s);
+    switch i32(i) % 6 {
+        case 0: { return vec3<f32>(v, t, p); }
+        case 1: { return vec3<f32>(q, v, p); }
+        case 2: { return vec3<f32>(p, v, t); }
+        case 3: { return vec3<f32>(p, q, v); }
+        case 4: { return vec3<f32>(t, p, v); }
+        default: { return vec3<f32>(v, p, q); }
+    }
+}
+
+@fragment
+fn fs_seg(in: VsOut) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(in.pos.xy);
+    let id = textureLoad(t_seg, coord, 0).r;
+    if id == 0u {
+        return to_target(vec3<f32>(0.0));
+    }
+    // Golden-ratio hue stepping, matching the CPU `snap_segmentation_colored`.
+    let hue = fract(f32(id) * 0.618034);
+    return to_target(hsv_to_rgb(hue, 0.65, 0.95));
+}

--- a/src/builtin/crt.wgsl
+++ b/src/builtin/crt.wgsl
@@ -1,0 +1,83 @@
+import package::common::fullscreen_uv_from_clip;
+// CRT stylization post-process: screen curvature (barrel distortion), chromatic
+// aberration, scanlines and a vignette. Reads the rendered scene and writes the
+// stylized image to the output. Knobs come from `CrtUniforms`; any term can be
+// disabled by zeroing its strength.
+
+@group(0) @binding(0)
+var t_fbo: texture_2d<f32>;
+@group(0) @binding(1)
+var s_fbo: sampler;
+
+struct CrtUniforms {
+    // Barrel-distortion strength (0 = flat).
+    curvature: f32,
+    // Chromatic-aberration strength (UV units at the screen edge).
+    aberration: f32,
+    // Scanline darkening intensity in [0, 1].
+    scanline_intensity: f32,
+    // Number of scanlines down the screen.
+    scanline_count: f32,
+    // Vignette strength in [0, 1].
+    vignette: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+}
+
+@group(1) @binding(0)
+var<uniform> uniforms: CrtUniforms;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    out.tex_coord = fullscreen_uv_from_clip(vertex.position);
+    return out;
+}
+
+// Barrel-distort UVs around the screen center to fake a curved CRT tube.
+fn curve(uv: vec2<f32>, amount: f32) -> vec2<f32> {
+    var c = uv * 2.0 - vec2<f32>(1.0);
+    let offset = c.yx * c.yx * amount;
+    c += c * offset;
+    return c * 0.5 + vec2<f32>(0.5);
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let uv = curve(in.tex_coord, uniforms.curvature);
+
+    // Outside the curved tube reads as black (the bezel).
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    }
+
+    // Chromatic aberration: offset the R/B taps outward from the center, scaled by
+    // distance so the fringing grows toward the edges.
+    let from_center = uv - vec2<f32>(0.5);
+    let offset = from_center * uniforms.aberration;
+    let r = textureSample(t_fbo, s_fbo, uv + offset).r;
+    let g = textureSample(t_fbo, s_fbo, uv).g;
+    let b = textureSample(t_fbo, s_fbo, uv - offset).b;
+    var color = vec3<f32>(r, g, b);
+
+    // Scanlines: a sinusoidal darkening along rows.
+    let scan = sin(uv.y * uniforms.scanline_count * 3.14159265);
+    color *= 1.0 - uniforms.scanline_intensity * (0.5 + 0.5 * scan);
+
+    // Vignette: darken toward the corners.
+    let vig = 1.0 - uniforms.vignette * dot(from_center, from_center) * 2.0;
+    color *= clamp(vig, 0.0, 1.0);
+
+    return vec4<f32>(color, 1.0);
+}

--- a/src/builtin/default.wgsl
+++ b/src/builtin/default.wgsl
@@ -1551,6 +1551,12 @@ struct OitOutput {
 // blending directly, so transparency is order-independent (no sorting).
 @fragment
 fn fs_oit(in: VertexOutput) -> OitOutput {
+    // Reflector capture: clip geometry behind the mirror plane (the plane is
+    // zeroed — a no-op — outside captures), same as `fs_main`.
+    if dot(frame.clip_plane.xyz, frame.clip_plane.xyz) > 0.0
+        && dot(frame.clip_plane.xyz, in.world_pos) + frame.clip_plane.w < 0.0 {
+        discard;
+    }
     let c = shade(in);
     let a = c.a;
     // Depth-based weight: nearer fragments dominate (McGuire eq. 9). `view_pos.z`

--- a/src/builtin/gi2d_cascade.wgsl
+++ b/src/builtin/gi2d_cascade.wgsl
@@ -1,0 +1,200 @@
+import package::common::unpack_mat3;
+// One level of 2D Radiance Cascades (decoupled layout).
+//
+// Each cascade is a texture packing a grid of probes; each probe owns an `e x e` tile
+// of texels, one per ray direction. Probe spacing `s` and direction-tile edge `e`
+// scale independently per level (s doubles, e doubles → direction count quadruples),
+// so the cascade texture stays the same size while spacing and angular resolution are
+// chosen independently — letting us keep a fine probe grid AND many directions. A
+// texel marches its probe's ray over a radial interval against the emitter/occluder
+// discs, then merges the higher cascade's continuation (the 4 finer-angle directions,
+// bilinearly interpolated across the 4 nearest upper probes at this probe's position).
+
+const MAX_EMITTERS: u32 = 32u;
+const MAX_OCCLUDERS: u32 = 64u;
+const TAU: f32 = 6.2831853;
+
+struct Emitter {
+    pos_radius: vec4<f32>,
+    color: vec4<f32>,
+}
+
+struct Occluder {
+    pos_radius: vec4<f32>,
+}
+
+// Reused from gi2d_field.wgsl (the same field uniform buffer is bound).
+struct FieldUniforms {
+    inv_vp_0: vec4<f32>,
+    inv_vp_1: vec4<f32>,
+    inv_vp_2: vec4<f32>,
+    prev_vp_0: vec4<f32>,
+    prev_vp_1: vec4<f32>,
+    prev_vp_2: vec4<f32>,
+    cur_vp_0: vec4<f32>,
+    cur_vp_1: vec4<f32>,
+    cur_vp_2: vec4<f32>,
+    params: vec4<f32>,
+    flags: vec4<f32>,
+    counts: vec4<f32>,
+    emitters: array<Emitter, MAX_EMITTERS>,
+    occluders: array<Occluder, MAX_OCCLUDERS>,
+}
+
+struct CascadeParams {
+    // dir-tile edge e_c, probe spacing s_c (field px), fieldW, fieldH
+    v0: vec4<f32>,
+    // upper dir-tile edge e_up, upper spacing s_up, up_probesX, up_probesY
+    v1: vec4<f32>,
+    // start_c, end_c, max_steps, is_top
+    v2: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var t_upper: texture_2d<f32>;
+
+@group(1) @binding(0)
+var<uniform> p: CascadeParams;
+
+@group(2) @binding(0)
+var<uniform> field: FieldUniforms;
+
+@group(3) @binding(0)
+var t_sdf: texture_2d<f32>;
+@group(3) @binding(1)
+var s_sdf: sampler;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    return out;
+}
+
+fn unproject(uv: vec2<f32>) -> vec2<f32> {
+    let clip = vec2<f32>(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0);
+    let inv = mat3x3<f32>(field.inv_vp_0.xyz, field.inv_vp_1.xyz, field.inv_vp_2.xyz);
+    let h = inv * vec3<f32>(clip, 1.0);
+    return h.xy / h.z;
+}
+
+// Distance to the nearest occluder at world point `q`: a jump-flooded SDF texture
+// fetch when `use_sdf`, otherwise the analytic minimum over the occluder discs.
+fn occluder_distance(q: vec2<f32>) -> f32 {
+    if (field.flags.x > 0.5) {
+        let clip = mat3x3<f32>(field.cur_vp_0.xyz, field.cur_vp_1.xyz, field.cur_vp_2.xyz)
+            * vec3<f32>(q, 1.0);
+        let uv = vec2<f32>((clip.x + 1.0) * 0.5, (1.0 - clip.y) * 0.5);
+        if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+            return 1e9;
+        }
+        // Bias the unsigned field so it crosses zero just outside the surface.
+        return textureSampleLevel(t_sdf, s_sdf, uv, 0.0).r - field.flags.y;
+    }
+    let num_o = u32(field.counts.y);
+    var d = 1e9;
+    for (var i = 0u; i < num_o; i = i + 1u) {
+        let o = field.occluders[i];
+        d = min(d, length(q - o.pos_radius.xy) - o.pos_radius.z);
+    }
+    return d;
+}
+
+// March a ray over [start, end): returns (radiance.rgb, transmittance).
+fn march_interval(origin: vec2<f32>, dir: vec2<f32>, start: f32, end: f32, max_steps: u32) -> vec4<f32> {
+    let num_e = u32(field.counts.x);
+
+    var t = start;
+    for (var step = 0u; step < max_steps; step = step + 1u) {
+        let q = origin + dir * t;
+
+        var d_emit = 1e9;
+        var ei = 0u;
+        for (var i = 0u; i < num_e; i = i + 1u) {
+            let e = field.emitters[i];
+            let d = length(q - e.pos_radius.xy) - e.pos_radius.z;
+            if (d < d_emit) {
+                d_emit = d;
+                ei = i;
+            }
+        }
+        let d_occ = occluder_distance(q);
+
+        if (d_emit <= 0.0) {
+            let e = field.emitters[ei];
+            return vec4<f32>(e.color.rgb * e.pos_radius.w, 0.0);
+        }
+        if (d_occ <= 0.0) {
+            return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        }
+
+        t += max(min(d_emit, d_occ), 0.5);
+        if (t >= end) {
+            return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+    }
+    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+fn read_upper(probe: vec2<i32>, dir: i32, e: i32, probes: vec2<i32>) -> vec4<f32> {
+    let pc = clamp(probe, vec2<i32>(0), probes - vec2<i32>(1));
+    let coord = pc * e + vec2<i32>(dir % e, dir / e);
+    return textureLoad(t_upper, coord, 0);
+}
+
+@fragment
+fn fs_main(@builtin(position) frag: vec4<f32>) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(frag.xy);
+    let e_c = i32(p.v0.x);
+    let s_c = p.v0.y;
+    let field_size = p.v0.zw;
+
+    let probe = coord / e_c;
+    let within = coord - probe * e_c;
+    let dir = within.y * e_c + within.x;
+    let dir_count = e_c * e_c;
+
+    let probe_px = (vec2<f32>(probe) + 0.5) * s_c;
+    let origin = unproject(probe_px / field_size);
+    let angle = TAU * (f32(dir) + 0.5) / f32(dir_count);
+    let rdir = vec2<f32>(cos(angle), sin(angle));
+
+    let near = march_interval(origin, rdir, p.v2.x, p.v2.y, u32(p.v2.z));
+
+    // Top cascade: nothing above to merge.
+    if (p.v2.w > 0.5 || near.a <= 0.0) {
+        return near;
+    }
+
+    let e_up = i32(p.v1.x);
+    let s_up = p.v1.y;
+    let up_probes = vec2<i32>(i32(p.v1.z), i32(p.v1.w));
+    // This probe's position in the upper probe grid (both in field pixels).
+    let pf = probe_px / s_up - vec2<f32>(0.5);
+    let p0 = vec2<i32>(floor(pf));
+    let fr = pf - floor(pf);
+    let w00 = (1.0 - fr.x) * (1.0 - fr.y);
+    let w10 = fr.x * (1.0 - fr.y);
+    let w01 = (1.0 - fr.x) * fr.y;
+    let w11 = fr.x * fr.y;
+
+    var cont = vec4<f32>(0.0);
+    for (var k = 0; k < 4; k = k + 1) {
+        let ud = dir * 4 + k;
+        cont += w00 * read_upper(p0 + vec2<i32>(0, 0), ud, e_up, up_probes);
+        cont += w10 * read_upper(p0 + vec2<i32>(1, 0), ud, e_up, up_probes);
+        cont += w01 * read_upper(p0 + vec2<i32>(0, 1), ud, e_up, up_probes);
+        cont += w11 * read_upper(p0 + vec2<i32>(1, 1), ud, e_up, up_probes);
+    }
+    cont *= 0.25;
+
+    return vec4<f32>(near.rgb + near.a * cont.rgb, near.a * cont.a);
+}

--- a/src/builtin/gi2d_cascade_composite.wgsl
+++ b/src/builtin/gi2d_cascade_composite.wgsl
@@ -1,0 +1,75 @@
+import package::common::fullscreen_uv_from_clip;
+// Resolves cascade 0 of the radiance cascades into per-pixel irradiance and modulates
+// the scene by it. For each pixel we find the surrounding cascade-0 probes (grid
+// spacing `s0`), average each probe's `e0 x e0` direction tile into that probe's
+// irradiance, bilinearly interpolate across the four nearest probes, and multiply the
+// scene by ambient + irradiance.
+
+@group(0) @binding(0)
+var t_scene: texture_2d<f32>;
+@group(0) @binding(1)
+var s_scene: sampler;
+
+@group(1) @binding(0)
+var t_cascade0: texture_2d<f32>;
+
+struct CompositeUniforms {
+    // e0, dir_count0 (= e0*e0), probesX0, probesY0
+    v0: vec4<f32>,
+    // fieldW, fieldH, s0, _
+    v1: vec4<f32>,
+    ambient: vec4<f32>,
+}
+
+@group(2) @binding(0)
+var<uniform> u: CompositeUniforms;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    out.tex_coord = fullscreen_uv_from_clip(vertex.position);
+    return out;
+}
+
+fn probe_irradiance(probe: vec2<i32>, e: i32, dir_count: i32, probes: vec2<i32>) -> vec3<f32> {
+    let pc = clamp(probe, vec2<i32>(0), probes - vec2<i32>(1));
+    var sum = vec3<f32>(0.0);
+    for (var d = 0; d < dir_count; d = d + 1) {
+        let coord = pc * e + vec2<i32>(d % e, d / e);
+        sum += textureLoad(t_cascade0, coord, 0).rgb;
+    }
+    return sum / f32(dir_count);
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let e0 = i32(u.v0.x);
+    let dir_count = i32(u.v0.y);
+    let probes = vec2<i32>(i32(u.v0.z), i32(u.v0.w));
+    let field_size = u.v1.xy;
+    let s0 = u.v1.z;
+
+    let pix = in.tex_coord * field_size;
+    let pf = pix / s0 - vec2<f32>(0.5);
+    let p0 = vec2<i32>(floor(pf));
+    let fr = pf - floor(pf);
+
+    let i00 = probe_irradiance(p0 + vec2<i32>(0, 0), e0, dir_count, probes);
+    let i10 = probe_irradiance(p0 + vec2<i32>(1, 0), e0, dir_count, probes);
+    let i01 = probe_irradiance(p0 + vec2<i32>(0, 1), e0, dir_count, probes);
+    let i11 = probe_irradiance(p0 + vec2<i32>(1, 1), e0, dir_count, probes);
+    let irradiance = mix(mix(i00, i10, fr.x), mix(i01, i11, fr.x), fr.y);
+
+    let scene = textureSample(t_scene, s_scene, in.tex_coord).rgb;
+    return vec4<f32>(scene * (u.ambient.rgb + irradiance), 1.0);
+}

--- a/src/builtin/gi2d_composite.wgsl
+++ b/src/builtin/gi2d_composite.wgsl
@@ -1,0 +1,48 @@
+import package::common::fullscreen_uv_from_clip;
+// Full-resolution composite for 2D global illumination: samples the rendered scene
+// and the low-resolution irradiance field (bilinearly upsampled by the sampler) and
+// modulates the scene by ambient + irradiance — soft shadows and colored bleed.
+
+@group(0) @binding(0)
+var t_scene: texture_2d<f32>;
+@group(0) @binding(1)
+var s_scene: sampler;
+
+@group(1) @binding(0)
+var t_gi: texture_2d<f32>;
+@group(1) @binding(1)
+var s_gi: sampler;
+
+struct CompositeUniforms {
+    // ambient.rgb, _
+    ambient: vec4<f32>,
+}
+
+@group(2) @binding(0)
+var<uniform> u: CompositeUniforms;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    out.tex_coord = fullscreen_uv_from_clip(vertex.position);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let scene = textureSample(t_scene, s_scene, in.tex_coord).rgb;
+    // The GI field is lower-resolution; the linear sampler upsamples it bilinearly.
+    let irradiance = textureSampleLevel(t_gi, s_gi, in.tex_coord, 0.0).rgb;
+    let lit = scene * (u.ambient.rgb + irradiance);
+    return vec4<f32>(lit, 1.0);
+}

--- a/src/builtin/gi2d_field.wgsl
+++ b/src/builtin/gi2d_field.wgsl
@@ -1,0 +1,177 @@
+import package::common::{unpack_mat3, fullscreen_uv_from_clip};
+// 2D global-illumination irradiance field (low-resolution, temporally accumulated).
+//
+// For each (low-res) pixel we ray-march a jittered fan against the analytic emitters
+// and either the analytic occluder discs or, when `use_sdf` is set, a jump-flooded
+// occluder distance field (one texture fetch per step, so the cost is independent of
+// occluder count). The fan is rotated by a per-frame golden-angle offset and the
+// result blended with the previous frame reprojected through the camera, so a few
+// rays per frame converge to a smooth result.
+
+const MAX_EMITTERS: u32 = 32u;
+const MAX_OCCLUDERS: u32 = 64u;
+const TAU: f32 = 6.2831853;
+const GOLDEN: f32 = 2.39996323;
+
+struct Emitter {
+    pos_radius: vec4<f32>,
+    color: vec4<f32>,
+}
+
+struct Occluder {
+    pos_radius: vec4<f32>,
+}
+
+struct FieldUniforms {
+    inv_vp_0: vec4<f32>,
+    inv_vp_1: vec4<f32>,
+    inv_vp_2: vec4<f32>,
+    prev_vp_0: vec4<f32>,
+    prev_vp_1: vec4<f32>,
+    prev_vp_2: vec4<f32>,
+    cur_vp_0: vec4<f32>,
+    cur_vp_1: vec4<f32>,
+    cur_vp_2: vec4<f32>,
+    // num_rays, frame_index, temporal_blend, history_valid
+    params: vec4<f32>,
+    // use_sdf, _, _, _
+    flags: vec4<f32>,
+    // num_emitters, num_occluders, max_dist, max_steps
+    counts: vec4<f32>,
+    emitters: array<Emitter, MAX_EMITTERS>,
+    occluders: array<Occluder, MAX_OCCLUDERS>,
+}
+
+@group(0) @binding(0)
+var t_history: texture_2d<f32>;
+@group(0) @binding(1)
+var s_history: sampler;
+
+@group(1) @binding(0)
+var<uniform> u: FieldUniforms;
+
+@group(2) @binding(0)
+var t_sdf: texture_2d<f32>;
+@group(2) @binding(1)
+var s_sdf: sampler;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    out.tex_coord = fullscreen_uv_from_clip(vertex.position);
+    return out;
+}
+
+fn unproject(uv: vec2<f32>) -> vec2<f32> {
+    let clip = vec2<f32>(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0);
+    let inv = mat3x3<f32>(u.inv_vp_0.xyz, u.inv_vp_1.xyz, u.inv_vp_2.xyz);
+    let h = inv * vec3<f32>(clip, 1.0);
+    return h.xy / h.z;
+}
+
+fn hash12(p: vec2<f32>) -> f32 {
+    var p3 = fract(vec3<f32>(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+// Distance to the nearest occluder at world point `p`: a jump-flooded SDF texture
+// fetch when `use_sdf`, otherwise the analytic minimum over the occluder discs.
+fn occluder_distance(p: vec2<f32>) -> f32 {
+    if (u.flags.x > 0.5) {
+        let clip = mat3x3<f32>(u.cur_vp_0.xyz, u.cur_vp_1.xyz, u.cur_vp_2.xyz) * vec3<f32>(p, 1.0);
+        let uv = vec2<f32>((clip.x + 1.0) * 0.5, (1.0 - clip.y) * 0.5);
+        // Off-screen has no captured occluder data → treat as open.
+        if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+            return 1e9;
+        }
+        // Bias the unsigned field so it crosses zero just outside the surface.
+        return textureSampleLevel(t_sdf, s_sdf, uv, 0.0).r - u.flags.y;
+    }
+
+    let num_occluders = u32(u.counts.y);
+    var d = 1e9;
+    for (var i = 0u; i < num_occluders; i = i + 1u) {
+        let o = u.occluders[i];
+        d = min(d, length(p - o.pos_radius.xy) - o.pos_radius.z);
+    }
+    return d;
+}
+
+fn trace(origin: vec2<f32>, dir: vec2<f32>) -> vec3<f32> {
+    let num_emitters = u32(u.counts.x);
+    let max_dist = u.counts.z;
+    let max_steps = u32(u.counts.w);
+
+    var t = 1.0;
+    for (var step = 0u; step < max_steps; step = step + 1u) {
+        let p = origin + dir * t;
+
+        var d_emit = 1e9;
+        var emit_idx = 0u;
+        for (var i = 0u; i < num_emitters; i = i + 1u) {
+            let e = u.emitters[i];
+            let d = length(p - e.pos_radius.xy) - e.pos_radius.z;
+            if (d < d_emit) {
+                d_emit = d;
+                emit_idx = i;
+            }
+        }
+
+        let d_occ = occluder_distance(p);
+
+        if (d_emit <= 0.0) {
+            let e = u.emitters[emit_idx];
+            return e.color.rgb * e.pos_radius.w;
+        }
+        if (d_occ <= 0.0) {
+            return vec3<f32>(0.0);
+        }
+
+        t += max(min(d_emit, d_occ), 0.5);
+        if (t > max_dist) {
+            break;
+        }
+    }
+    return vec3<f32>(0.0);
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let world = unproject(in.tex_coord);
+    let num_rays = max(u32(u.params.x), 1u);
+    let frame = u.params.y;
+    let blend = u.params.z;
+    let history_valid = u.params.w;
+
+    let jitter = hash12(in.tex_coord * 4096.0) + frame * GOLDEN;
+
+    var irradiance = vec3<f32>(0.0);
+    for (var r = 0u; r < num_rays; r = r + 1u) {
+        let a = (f32(r) + jitter) / f32(num_rays) * TAU;
+        irradiance += trace(world, vec2<f32>(cos(a), sin(a)));
+    }
+    irradiance /= f32(num_rays);
+
+    if (history_valid > 0.5 && blend > 0.0) {
+        let prev_vp = mat3x3<f32>(u.prev_vp_0.xyz, u.prev_vp_1.xyz, u.prev_vp_2.xyz);
+        let clip = prev_vp * vec3<f32>(world, 1.0);
+        let prev_uv = vec2<f32>((clip.x + 1.0) * 0.5, (1.0 - clip.y) * 0.5);
+        if (prev_uv.x >= 0.0 && prev_uv.x <= 1.0 && prev_uv.y >= 0.0 && prev_uv.y <= 1.0) {
+            let hist = textureSampleLevel(t_history, s_history, prev_uv, 0.0).rgb;
+            irradiance = mix(irradiance, hist, blend);
+        }
+    }
+
+    return vec4<f32>(irradiance, 1.0);
+}

--- a/src/builtin/gi2d_jfa.wgsl
+++ b/src/builtin/gi2d_jfa.wgsl
@@ -1,0 +1,89 @@
+import package::common::unpack_mat3;
+// Jump-flood step and resolve passes for the 2D occluder distance field.
+//
+// `fs_step` runs once per halving step size: each texel adopts, from itself and its
+// eight neighbors at the current step offset, the seed whose stored world position
+// is nearest — so after log2(size) passes every texel holds the nearest occluder
+// seed. `fs_resolve` turns those seeds into a scalar world-space distance field that
+// the GI march samples.
+
+struct JfaUniforms {
+    inv_vp_0: vec4<f32>,
+    inv_vp_1: vec4<f32>,
+    inv_vp_2: vec4<f32>,
+    // step, size_x, size_y, _
+    aux: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var t_seed: texture_2d<f32>;
+
+@group(1) @binding(0)
+var<uniform> u: JfaUniforms;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    return out;
+}
+
+fn texel_world(coord: vec2<i32>, size: vec2<f32>) -> vec2<f32> {
+    let uv = (vec2<f32>(coord) + 0.5) / size;
+    let clip = vec2<f32>(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0);
+    let inv = mat3x3<f32>(u.inv_vp_0.xyz, u.inv_vp_1.xyz, u.inv_vp_2.xyz);
+    let h = inv * vec3<f32>(clip, 1.0);
+    return h.xy / h.z;
+}
+
+@fragment
+fn fs_step(@builtin(position) frag: vec4<f32>) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(frag.xy);
+    let size = vec2<f32>(u.aux.y, u.aux.z);
+    let isize = vec2<i32>(i32(u.aux.y), i32(u.aux.z));
+    let step = i32(u.aux.x);
+    let world_self = texel_world(coord, size);
+
+    var best = textureLoad(t_seed, coord, 0);
+    var best_d = select(1e18, distance(world_self, best.xy), best.z > 0.5);
+
+    for (var dy = -1; dy <= 1; dy = dy + 1) {
+        for (var dx = -1; dx <= 1; dx = dx + 1) {
+            let c = coord + vec2<i32>(dx, dy) * step;
+            if (c.x < 0 || c.y < 0 || c.x >= isize.x || c.y >= isize.y) {
+                continue;
+            }
+            let s = textureLoad(t_seed, c, 0);
+            if (s.z > 0.5) {
+                let d = distance(world_self, s.xy);
+                if (d < best_d) {
+                    best_d = d;
+                    best = s;
+                }
+            }
+        }
+    }
+    return best;
+}
+
+@fragment
+fn fs_resolve(@builtin(position) frag: vec4<f32>) -> @location(0) vec4<f32> {
+    let coord = vec2<i32>(frag.xy);
+    let size = vec2<f32>(u.aux.y, u.aux.z);
+    let world_self = texel_world(coord, size);
+
+    let s = textureLoad(t_seed, coord, 0);
+    var dist = 1e9;
+    if (s.z > 0.5) {
+        dist = distance(world_self, s.xy);
+    }
+    return vec4<f32>(dist, 0.0, 0.0, 0.0);
+}

--- a/src/builtin/gi2d_jfa_seed.wgsl
+++ b/src/builtin/gi2d_jfa_seed.wgsl
@@ -1,0 +1,82 @@
+import package::common::{unpack_mat3, fullscreen_uv_from_clip};
+// Jump-flood seed pass for the 2D occluder distance field. Each low-res texel is
+// classified against the analytic occluder discs: texels inside any occluder become
+// seeds storing their own world position (xy) with a valid flag (z = 1); empty
+// texels store z = 0. The jump-flood passes then propagate the nearest seed.
+
+const MAX_EMITTERS: u32 = 32u;
+const MAX_OCCLUDERS: u32 = 64u;
+
+struct Emitter {
+    pos_radius: vec4<f32>,
+    color: vec4<f32>,
+}
+
+struct Occluder {
+    pos_radius: vec4<f32>,
+}
+
+// Same layout as FieldUniforms in gi2d_field.wgsl (the field uniform buffer is reused).
+struct FieldUniforms {
+    inv_vp_0: vec4<f32>,
+    inv_vp_1: vec4<f32>,
+    inv_vp_2: vec4<f32>,
+    prev_vp_0: vec4<f32>,
+    prev_vp_1: vec4<f32>,
+    prev_vp_2: vec4<f32>,
+    cur_vp_0: vec4<f32>,
+    cur_vp_1: vec4<f32>,
+    cur_vp_2: vec4<f32>,
+    params: vec4<f32>,
+    flags: vec4<f32>,
+    counts: vec4<f32>,
+    emitters: array<Emitter, MAX_EMITTERS>,
+    occluders: array<Occluder, MAX_OCCLUDERS>,
+}
+
+@group(0) @binding(0)
+var<uniform> u: FieldUniforms;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.clip_position = vec4<f32>(vertex.position, 0.0, 1.0);
+    out.tex_coord = fullscreen_uv_from_clip(vertex.position);
+    return out;
+}
+
+fn unproject(uv: vec2<f32>) -> vec2<f32> {
+    let clip = vec2<f32>(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0);
+    let inv = mat3x3<f32>(u.inv_vp_0.xyz, u.inv_vp_1.xyz, u.inv_vp_2.xyz);
+    let h = inv * vec3<f32>(clip, 1.0);
+    return h.xy / h.z;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let world = unproject(in.tex_coord);
+    let num_occluders = u32(u.counts.y);
+
+    var inside = false;
+    for (var i = 0u; i < num_occluders; i = i + 1u) {
+        let o = u.occluders[i];
+        if (length(world - o.pos_radius.xy) <= o.pos_radius.z) {
+            inside = true;
+            break;
+        }
+    }
+
+    if (inside) {
+        return vec4<f32>(world, 1.0, 0.0);
+    }
+    return vec4<f32>(0.0, 0.0, 0.0, 0.0);
+}

--- a/src/builtin/hdr_oit.wgsl
+++ b/src/builtin/hdr_oit.wgsl
@@ -29,5 +29,10 @@ fn fs_composite(in: VsOut) -> @location(0) vec4<f32> {
     let reveal = textureLoad(t_reveal, coord, 0).r;
     // Weighted-average color of all transparent fragments at this pixel.
     let color = accum.rgb / max(accum.a, 1.0e-5);
+    // The alpha output (1 - reveal) is the transparent coverage; it drives the
+    // SrcAlpha/OneMinusSrcAlpha *color* blend. The pipeline's alpha blend keeps
+    // the destination alpha, so this does NOT overwrite the scene's alpha channel
+    // (which the tonemap forwards to the surface — clobbering it to 0 here made
+    // the canvas transparent → white page on browsers that composite canvas alpha).
     return vec4<f32>(color, 1.0 - reveal);
 }

--- a/src/builtin/hdr_tonemap.wgsl
+++ b/src/builtin/hdr_tonemap.wgsl
@@ -17,7 +17,8 @@ struct TonemapUniforms {
     bloom_intensity: f32,
     // 1.0 when the adapted exposure texture should override `exposure`.
     auto_exposure: f32,
-    // Color grading: white-balance gain (rgb) + unused.
+    // Color grading: white-balance gain (rgb) + force-opaque flag (w: 1.0 writes
+    // alpha = 1.0 to the output, else the HDR scene alpha is forwarded).
     white_balance: vec4<f32>,
     // (saturation, contrast, gamma, hue).
     grading: vec4<f32>,
@@ -102,5 +103,8 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     // Artistic color grading, then the tonemap operator.
     let hdr = color_grade(exposed);
 
-    return vec4<f32>(apply_tonemap(hdr, u.tonemap_op), scene.a);
+    // Forward the scene alpha, unless force-opaque is set for on-screen surfaces
+    // (a transparent canvas would show the page through it on some browsers).
+    let out_a = select(scene.a, 1.0, u.white_balance.w > 0.5);
+    return vec4<f32>(apply_tonemap(hdr, u.tonemap_op), out_a);
 }

--- a/src/builtin/lit2d.wgsl
+++ b/src/builtin/lit2d.wgsl
@@ -1,0 +1,159 @@
+import package::common::{unpack_mat2, unpack_mat3};
+// 2D lit material: diffuse + specular shading from dynamic 2D lights, with optional
+// normal mapping. Lights live slightly above the plane (their height), so a
+// normal-mapped sprite reacts with per-pixel shading; without a normal map the
+// surface is flat (+Z) and lights contribute a smooth radial falloff.
+
+const MAX_LIGHTS: u32 = 16u;
+
+struct Light {
+    // position.xy, height, kind (0 = point, 1 = spot)
+    pos_height: vec4<f32>,
+    // color.rgb, intensity
+    color_intensity: vec4<f32>,
+    // direction.xy, cos(inner_angle), cos(outer_angle)
+    dir_cone: vec4<f32>,
+    // radius, _, _, _
+    radius: vec4<f32>,
+}
+
+struct FrameUniforms {
+    view_0: vec4<f32>,
+    view_1: vec4<f32>,
+    view_2: vec4<f32>,
+    proj_0: vec4<f32>,
+    proj_1: vec4<f32>,
+    proj_2: vec4<f32>,
+    // ambient.rgb, num_lights
+    ambient_count: vec4<f32>,
+    lights: array<Light, MAX_LIGHTS>,
+}
+
+@group(0) @binding(0)
+var<uniform> frame: FrameUniforms;
+
+struct ObjectUniforms {
+    model_0: vec4<f32>,
+    model_1: vec4<f32>,
+    model_2: vec4<f32>,
+    scale_0: vec4<f32>,
+    scale_1: vec4<f32>,
+    color: vec4<f32>,
+    // specular_strength, shininess, normal_strength, has_normal_map
+    params: vec4<f32>,
+}
+
+@group(1) @binding(0)
+var<uniform> obj: ObjectUniforms;
+
+@group(2) @binding(0)
+var t_albedo: texture_2d<f32>;
+@group(2) @binding(1)
+var s_albedo: sampler;
+@group(2) @binding(2)
+var t_normal: texture_2d<f32>;
+@group(2) @binding(3)
+var s_normal: sampler;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) tex_coord: vec2<f32>,
+}
+
+struct InstanceInput {
+    @location(2) inst_tra: vec2<f32>,
+    @location(3) inst_color: vec4<f32>,
+    @location(4) inst_def_0: vec2<f32>,
+    @location(5) inst_def_1: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+    @location(1) world: vec2<f32>,
+    @location(2) inst_color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    var out: VertexOutput;
+
+    let view = unpack_mat3(frame.view_0, frame.view_1, frame.view_2);
+    let proj = unpack_mat3(frame.proj_0, frame.proj_1, frame.proj_2);
+    let model = unpack_mat3(obj.model_0, obj.model_1, obj.model_2);
+    let scale = unpack_mat2(obj.scale_0, obj.scale_1);
+    let def = mat2x2<f32>(instance.inst_def_0, instance.inst_def_1);
+
+    let deformed = def * (scale * vertex.position);
+    let model_pos = model * vec3<f32>(deformed, 1.0);
+    let world = vec3<f32>(instance.inst_tra, 0.0) + model_pos;
+    var projected = proj * view * world;
+    projected.z = 0.0;
+
+    out.clip_position = vec4<f32>(projected, 1.0);
+    out.tex_coord = vertex.tex_coord;
+    out.world = world.xy;
+    out.inst_color = instance.inst_color;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let albedo = textureSample(t_albedo, s_albedo, in.tex_coord) * obj.color * in.inst_color;
+
+    let specular_strength = obj.params.x;
+    let shininess = max(obj.params.y, 1.0);
+    let normal_strength = obj.params.z;
+    let has_normal_map = obj.params.w;
+
+    var n = vec3<f32>(0.0, 0.0, 1.0);
+    if (has_normal_map > 0.5) {
+        let sampled = textureSample(t_normal, s_normal, in.tex_coord).xyz * 2.0 - vec3<f32>(1.0);
+        n = normalize(vec3<f32>(sampled.xy * normal_strength, max(sampled.z, 0.05)));
+    }
+
+    let ambient = frame.ambient_count.rgb;
+    var lit = ambient * albedo.rgb;
+
+    let frag = vec3<f32>(in.world, 0.0);
+    let view_dir = vec3<f32>(0.0, 0.0, 1.0);
+    let count = u32(frame.ambient_count.w);
+
+    for (var i = 0u; i < count; i = i + 1u) {
+        let light = frame.lights[i];
+        let radius = light.radius.x;
+        let to_light = vec3<f32>(light.pos_height.xy, light.pos_height.z) - frag;
+        let planar_dist = length(to_light.xy);
+        if (planar_dist >= radius) {
+            continue;
+        }
+        let l = normalize(to_light);
+
+        // Smooth distance attenuation (quadratic falloff to zero at the radius).
+        var atten = clamp(1.0 - planar_dist / radius, 0.0, 1.0);
+        atten = atten * atten;
+
+        // Spot cone factor (1 for point lights).
+        var cone = 1.0;
+        if (light.pos_height.w > 0.5) {
+            let spot_dir = normalize(light.dir_cone.xy);
+            let frag_dir = normalize(in.world - light.pos_height.xy);
+            let cos_ang = dot(frag_dir, spot_dir);
+            cone = smoothstep(light.dir_cone.w, light.dir_cone.z, cos_ang);
+        }
+
+        let n_dot_l = max(dot(n, l), 0.0);
+        let diffuse = n_dot_l * atten * cone;
+
+        var spec = 0.0;
+        if (n_dot_l > 0.0 && specular_strength > 0.0) {
+            let h = normalize(l + view_dir);
+            spec = pow(max(dot(n, h), 0.0), shininess) * specular_strength * atten * cone;
+        }
+
+        let radiance = light.color_intensity.rgb * light.color_intensity.w;
+        lit += radiance * (diffuse * albedo.rgb + spec);
+    }
+
+    return vec4<f32>(lit, albedo.a);
+}

--- a/src/builtin/lit_material2d.rs
+++ b/src/builtin/lit_material2d.rs
@@ -1,0 +1,595 @@
+//! Dynamically-lit 2D material with optional normal mapping.
+//!
+//! [`LitMaterial2d`] shades a sprite with the 2D lights from the global
+//! [`Light2dManager`](crate::light2d::Light2dManager): an ambient term plus per-light
+//! diffuse and specular. With a normal map ([`ObjectData2d::set_normal_map`]) the
+//! shading is per-pixel; without one the sprite is flat and still picks up each
+//! light's radial falloff. Per-object shading knobs travel in [`LitParams`].
+
+use crate::camera::Camera2d;
+use crate::context::Context;
+use crate::light2d::{Light2dKind, Light2dManager, MAX_LIGHTS_2D};
+use crate::resource::vertex_index::VERTEX_INDEX_FORMAT;
+use crate::resource::{
+    multisample_state, GpuData, GpuMesh2d, Material2d, MaterialManager2d, PipelineCache,
+    RenderContext2d, Texture,
+};
+use crate::scene::{InstancesBuffer2d, ObjectData2d};
+use bytemuck::{Pod, Zeroable};
+use glamx::{Mat2, Mat3, Pose2, Vec2};
+use std::any::Any;
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Per-object shading parameters for [`LitMaterial2d`], stored in
+/// [`ObjectData2d::lit_params`].
+#[derive(Copy, Clone, Debug)]
+pub struct LitParams {
+    /// Specular highlight strength (0 disables specular).
+    pub specular_strength: f32,
+    /// Specular exponent (higher = tighter highlight).
+    pub shininess: f32,
+    /// Scales the normal map's tangent-space XY, controlling bump strength.
+    pub normal_strength: f32,
+}
+
+impl Default for LitParams {
+    fn default() -> Self {
+        LitParams {
+            specular_strength: 0.0,
+            shininess: 16.0,
+            normal_strength: 1.0,
+        }
+    }
+}
+
+impl LitParams {
+    /// New parameters with the given specular strength and exponent.
+    pub fn with_specular(mut self, strength: f32, shininess: f32) -> Self {
+        self.specular_strength = strength;
+        self.shininess = shininess;
+        self
+    }
+
+    /// Sets the normal-map bump strength.
+    pub fn with_normal_strength(mut self, strength: f32) -> Self {
+        self.normal_strength = strength;
+        self
+    }
+}
+
+/// One GPU light, matching `Light` in `lit2d.wgsl`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct GpuLight {
+    pos_height: [f32; 4],
+    color_intensity: [f32; 4],
+    dir_cone: [f32; 4],
+    radius: [f32; 4],
+}
+
+/// Frame uniforms matching `FrameUniforms` in `lit2d.wgsl`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct FrameUniforms {
+    view: [[f32; 4]; 3],
+    proj: [[f32; 4]; 3],
+    ambient_count: [f32; 4],
+    lights: [GpuLight; MAX_LIGHTS_2D],
+}
+
+/// Per-object uniforms matching `ObjectUniforms` in `lit2d.wgsl`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct ObjectUniforms {
+    model: [[f32; 4]; 3],
+    scale: [[f32; 4]; 2],
+    color: [f32; 4],
+    params: [f32; 4],
+}
+
+/// Per-object GPU data for [`LitMaterial2d`].
+pub struct LitMaterial2dGpuData {
+    object_uniform_buffer: wgpu::Buffer,
+    object_bind_group: Option<wgpu::BindGroup>,
+    texture_bind_group: Option<wgpu::BindGroup>,
+    cached_albedo_ptr: usize,
+    cached_normal_ptr: usize,
+}
+
+impl LitMaterial2dGpuData {
+    fn new() -> Self {
+        let ctxt = Context::get();
+        let object_uniform_buffer = ctxt.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("lit2d_object_uniform_buffer"),
+            size: std::mem::size_of::<ObjectUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        LitMaterial2dGpuData {
+            object_uniform_buffer,
+            object_bind_group: None,
+            texture_bind_group: None,
+            cached_albedo_ptr: 0,
+            cached_normal_ptr: 0,
+        }
+    }
+}
+
+impl GpuData for LitMaterial2dGpuData {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// A material that shades 2D objects with the global dynamic 2D lights (see the
+/// [module docs](self)).
+pub struct LitMaterial2d {
+    pipeline: PipelineCache,
+    object_bind_group_layout: wgpu::BindGroupLayout,
+    texture_bind_group_layout: wgpu::BindGroupLayout,
+    frame_uniform_buffer: wgpu::Buffer,
+    frame_bind_group: wgpu::BindGroup,
+    default_normal_map: Arc<Texture>,
+    frame_counter: Cell<u64>,
+    last_frame: Cell<u64>,
+}
+
+impl Default for LitMaterial2d {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LitMaterial2d {
+    /// The name the lit material is registered under in the global 2D material manager.
+    pub const NAME: &'static str = "lit2d";
+
+    /// Creates a new lit material.
+    pub fn new() -> LitMaterial2d {
+        let ctxt = Context::get();
+
+        let frame_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("lit2d_frame_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        let object_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("lit2d_object_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        let tex_entry = |binding| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count: None,
+        };
+        let samp_entry = |binding| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+            count: None,
+        };
+        let texture_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("lit2d_texture_bind_group_layout"),
+                entries: &[tex_entry(0), samp_entry(1), tex_entry(2), samp_entry(3)],
+            });
+
+        let pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("lit2d_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&frame_bind_group_layout),
+                Some(&object_bind_group_layout),
+                Some(&texture_bind_group_layout),
+            ],
+            immediate_size: 0,
+        });
+
+        let shader = ctxt.create_shader_module(
+            Some("lit2d_shader"),
+            &crate::builtin::compile_shader_with_common("package::lit2d", include_str!("lit2d.wgsl")),
+        );
+
+        let pipeline = PipelineCache::new(move |sample_count| {
+            let ctxt = Context::get();
+            let vertex_buffer_layouts = [
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 0,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 1,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 2,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 3,
+                        format: wgpu::VertexFormat::Float32x4,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            offset: 0,
+                            shader_location: 4,
+                            format: wgpu::VertexFormat::Float32x2,
+                        },
+                        wgpu::VertexAttribute {
+                            offset: 8,
+                            shader_location: 5,
+                            format: wgpu::VertexFormat::Float32x2,
+                        },
+                    ],
+                },
+            ];
+
+            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("lit2d_pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &vertex_buffer_layouts,
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: Context::render_format(),
+                        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: multisample_state(sample_count),
+                multiview_mask: None,
+                cache: None,
+            })
+        });
+
+        let frame_uniform_buffer = ctxt.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("lit2d_frame_uniform_buffer"),
+            size: std::mem::size_of::<FrameUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let frame_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("lit2d_frame_bind_group"),
+            layout: &frame_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: frame_uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        LitMaterial2d {
+            pipeline,
+            object_bind_group_layout,
+            texture_bind_group_layout,
+            frame_uniform_buffer,
+            frame_bind_group,
+            default_normal_map: Texture::new_default_normal_map(),
+            frame_counter: Cell::new(0),
+            last_frame: Cell::new(u64::MAX),
+        }
+    }
+
+    /// Returns the shared lit material from the global manager, registering it on
+    /// first use. Used by [`SceneNode2d::lit_sprite`](crate::scene::SceneNode2d::lit_sprite).
+    pub fn shared() -> Rc<std::cell::RefCell<Box<dyn Material2d + 'static>>> {
+        MaterialManager2d::get_global_manager(|mm| {
+            if let Some(mat) = mm.get(Self::NAME) {
+                mat
+            } else {
+                let mat: Rc<std::cell::RefCell<Box<dyn Material2d + 'static>>> = Rc::new(
+                    std::cell::RefCell::new(Box::new(LitMaterial2d::new()) as Box<dyn Material2d>),
+                );
+                mm.add(mat.clone(), Self::NAME);
+                mat
+            }
+        })
+    }
+
+    fn mat3_to_padded(m: &Mat3) -> [[f32; 4]; 3] {
+        let c = m.to_cols_array_2d();
+        [
+            [c[0][0], c[0][1], c[0][2], 0.0],
+            [c[1][0], c[1][1], c[1][2], 0.0],
+            [c[2][0], c[2][1], c[2][2], 0.0],
+        ]
+    }
+
+    fn mat2_to_padded(m: &Mat2) -> [[f32; 4]; 2] {
+        let c = m.to_cols_array_2d();
+        [[c[0][0], c[0][1], 0.0, 0.0], [c[1][0], c[1][1], 0.0, 0.0]]
+    }
+
+    fn create_texture_bind_group(
+        &self,
+        albedo: &Texture,
+        normal: &Texture,
+    ) -> wgpu::BindGroup {
+        let ctxt = Context::get();
+        ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("lit2d_texture_bind_group"),
+            layout: &self.texture_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&albedo.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&albedo.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&normal.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::Sampler(&normal.sampler),
+                },
+            ],
+        })
+    }
+}
+
+impl Material2d for LitMaterial2d {
+    fn create_gpu_data(&self) -> Box<dyn GpuData> {
+        Box::new(LitMaterial2dGpuData::new())
+    }
+
+    fn begin_frame(&mut self) {
+        self.frame_counter
+            .set(self.frame_counter.get().wrapping_add(1));
+    }
+
+    fn prepare(
+        &mut self,
+        transform: Pose2,
+        scale: Vec2,
+        camera: &mut dyn Camera2d,
+        data: &ObjectData2d,
+        _mesh: &mut GpuMesh2d,
+        _instances: &mut InstancesBuffer2d,
+        gpu_data: &mut dyn GpuData,
+        _context: &RenderContext2d,
+    ) {
+        let ctxt = Context::get();
+        let gpu_data = gpu_data
+            .as_any_mut()
+            .downcast_mut::<LitMaterial2dGpuData>()
+            .expect("LitMaterial2d requires LitMaterial2dGpuData");
+
+        // Frame uniforms (view/proj + lights) once per frame, pulled from the global
+        // 2D light manager.
+        let current_frame = self.frame_counter.get();
+        if current_frame != self.last_frame.get() {
+            self.last_frame.set(current_frame);
+            let (view, proj) = camera.view_transform_pair();
+            let mut frame = FrameUniforms {
+                view: Self::mat3_to_padded(&view),
+                proj: Self::mat3_to_padded(&proj),
+                ambient_count: [0.0; 4],
+                lights: [GpuLight::zeroed(); MAX_LIGHTS_2D],
+            };
+            Light2dManager::get_global_manager(|mm| {
+                let amb = mm.ambient();
+                let lights = mm.lights();
+                let n = lights.len().min(MAX_LIGHTS_2D);
+                frame.ambient_count = [amb.r, amb.g, amb.b, n as f32];
+                for (slot, light) in frame.lights.iter_mut().zip(lights.iter()) {
+                    let kind = match light.kind {
+                        Light2dKind::Point => 0.0,
+                        Light2dKind::Spot => 1.0,
+                    };
+                    let dir = light.direction.normalize_or_zero();
+                    *slot = GpuLight {
+                        pos_height: [light.position.x, light.position.y, light.height, kind],
+                        color_intensity: [
+                            light.color.r,
+                            light.color.g,
+                            light.color.b,
+                            light.intensity,
+                        ],
+                        dir_cone: [
+                            dir.x,
+                            dir.y,
+                            light.inner_angle.cos(),
+                            light.outer_angle.cos(),
+                        ],
+                        radius: [light.radius, 0.0, 0.0, 0.0],
+                    };
+                }
+            });
+            ctxt.write_buffer(&self.frame_uniform_buffer, 0, bytemuck::bytes_of(&frame));
+        }
+
+        // Per-object uniforms.
+        let params = data.lit_params().unwrap_or_default();
+        let has_normal = data.normal_map().is_some();
+        let color = data.color();
+        let uniforms = ObjectUniforms {
+            model: Self::mat3_to_padded(&transform.to_mat3()),
+            scale: Self::mat2_to_padded(&Mat2::from_diagonal(scale)),
+            color: [color.r, color.g, color.b, color.a],
+            params: [
+                params.specular_strength,
+                params.shininess,
+                params.normal_strength,
+                if has_normal { 1.0 } else { 0.0 },
+            ],
+        };
+        ctxt.write_buffer(
+            &gpu_data.object_uniform_buffer,
+            0,
+            bytemuck::bytes_of(&uniforms),
+        );
+
+        if gpu_data.object_bind_group.is_none() {
+            gpu_data.object_bind_group = Some(ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("lit2d_object_bind_group"),
+                layout: &self.object_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: gpu_data.object_uniform_buffer.as_entire_binding(),
+                }],
+            }));
+        }
+
+        // (Re)build the texture bind group when the albedo or normal map changes.
+        let albedo = data.texture();
+        let normal = data.normal_map().unwrap_or(&self.default_normal_map);
+        let albedo_ptr = Arc::as_ptr(albedo) as usize;
+        let normal_ptr = Arc::as_ptr(normal) as usize;
+        if gpu_data.texture_bind_group.is_none()
+            || gpu_data.cached_albedo_ptr != albedo_ptr
+            || gpu_data.cached_normal_ptr != normal_ptr
+        {
+            gpu_data.texture_bind_group = Some(self.create_texture_bind_group(albedo, normal));
+            gpu_data.cached_albedo_ptr = albedo_ptr;
+            gpu_data.cached_normal_ptr = normal_ptr;
+        }
+    }
+
+    fn render(
+        &mut self,
+        _transform: Pose2,
+        _scale: Vec2,
+        _camera: &mut dyn Camera2d,
+        _data: &ObjectData2d,
+        mesh: &mut GpuMesh2d,
+        instances: &mut InstancesBuffer2d,
+        gpu_data: &mut dyn GpuData,
+        render_pass: &mut wgpu::RenderPass<'_>,
+        context: &RenderContext2d,
+    ) {
+        let gpu_data = gpu_data
+            .as_any_mut()
+            .downcast_mut::<LitMaterial2dGpuData>()
+            .expect("LitMaterial2d requires LitMaterial2dGpuData");
+
+        let num_instances = instances.len();
+        instances.positions.load_to_gpu();
+        instances.colors.load_to_gpu();
+        instances.deformations.load_to_gpu();
+        mesh.load_to_gpu();
+
+        let inst_positions_buf = match instances.positions.buffer() {
+            Some(b) => b,
+            None => return,
+        };
+        let inst_colors_buf = match instances.colors.buffer() {
+            Some(b) => b,
+            None => return,
+        };
+        let inst_deformations_buf = match instances.deformations.buffer() {
+            Some(b) => b,
+            None => return,
+        };
+
+        let coords_buffer = mesh.coords().read().unwrap();
+        let uvs_buffer = mesh.uvs().read().unwrap();
+        let faces_buffer = mesh.faces().read().unwrap();
+        let coords_buf = match coords_buffer.buffer() {
+            Some(b) => b,
+            None => return,
+        };
+        let uvs_buf = match uvs_buffer.buffer() {
+            Some(b) => b,
+            None => return,
+        };
+        let faces_buf = match faces_buffer.buffer() {
+            Some(b) => b,
+            None => return,
+        };
+
+        let object_bind_group = match gpu_data.object_bind_group.as_ref() {
+            Some(bg) => bg,
+            None => return,
+        };
+        let texture_bind_group = match gpu_data.texture_bind_group.as_ref() {
+            Some(bg) => bg,
+            None => return,
+        };
+
+        let pipeline = self.pipeline.get(context.sample_count);
+        render_pass.set_pipeline(&pipeline);
+        render_pass.set_bind_group(0, &self.frame_bind_group, &[]);
+        render_pass.set_bind_group(1, object_bind_group, &[]);
+        render_pass.set_bind_group(2, texture_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, coords_buf.slice(..));
+        render_pass.set_vertex_buffer(1, uvs_buf.slice(..));
+        render_pass.set_vertex_buffer(2, inst_positions_buf.slice(..));
+        render_pass.set_vertex_buffer(3, inst_colors_buf.slice(..));
+        render_pass.set_vertex_buffer(4, inst_deformations_buf.slice(..));
+        render_pass.set_index_buffer(faces_buf.slice(..), VERTEX_INDEX_FORMAT);
+        render_pass.draw_indexed(0..mesh.num_indices(), 0, 0..num_instances as u32);
+    }
+}

--- a/src/builtin/lit_material2d.rs
+++ b/src/builtin/lit_material2d.rs
@@ -127,7 +127,7 @@ impl GpuData for LitMaterial2dGpuData {
 }
 
 /// A material that shades 2D objects with the global dynamic 2D lights (see the
-/// [module docs](self)).
+/// [module docs](crate::builtin)).
 pub struct LitMaterial2d {
     pipeline: PipelineCache,
     object_bind_group_layout: wgpu::BindGroupLayout,
@@ -217,7 +217,10 @@ impl LitMaterial2d {
 
         let shader = ctxt.create_shader_module(
             Some("lit2d_shader"),
-            &crate::builtin::compile_shader_with_common("package::lit2d", include_str!("lit2d.wgsl")),
+            &crate::builtin::compile_shader_with_common(
+                "package::lit2d",
+                include_str!("lit2d.wgsl"),
+            ),
         );
 
         let pipeline = PipelineCache::new(move |sample_count| {
@@ -369,11 +372,7 @@ impl LitMaterial2d {
         [[c[0][0], c[0][1], 0.0, 0.0], [c[1][0], c[1][1], 0.0, 0.0]]
     }
 
-    fn create_texture_bind_group(
-        &self,
-        albedo: &Texture,
-        normal: &Texture,
-    ) -> wgpu::BindGroup {
+    fn create_texture_bind_group(&self, albedo: &Texture, normal: &Texture) -> wgpu::BindGroup {
         let ctxt = Context::get();
         ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("lit2d_texture_bind_group"),

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -74,6 +74,7 @@ pub use self::normals_material::{NormalsMaterial, NORMAL_FRAGMENT_SRC, NORMAL_VE
 pub use self::object_material::{ObjectMaterial, OBJECT_FRAGMENT_SRC, OBJECT_VERTEX_SRC};
 pub use self::uvs_material::{UvsMaterial, UVS_FRAGMENT_SRC, UVS_VERTEX_SRC};
 
+pub use self::lit_material2d::{LitMaterial2d, LitMaterial2dGpuData, LitParams};
 pub use self::object_material2d::ObjectMaterial2d;
 pub use self::shadow::{ShadowMapper, MAX_SHADOW_VIEWS};
 
@@ -85,4 +86,5 @@ mod object_material;
 mod shadow;
 mod uvs_material;
 
+mod lit_material2d;
 mod object_material2d;

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -76,6 +76,7 @@ pub use self::uvs_material::{UvsMaterial, UVS_FRAGMENT_SRC, UVS_VERTEX_SRC};
 
 pub use self::lit_material2d::{LitMaterial2d, LitMaterial2dGpuData, LitParams};
 pub use self::object_material2d::ObjectMaterial2d;
+pub use self::skinned_material2d::{Bone2d, SkinVertex2d, SkinnedMesh2d, MAX_JOINTS_2D};
 pub use self::shadow::{ShadowMapper, MAX_SHADOW_VIEWS};
 
 mod aov;
@@ -88,3 +89,4 @@ mod uvs_material;
 
 mod lit_material2d;
 mod object_material2d;
+mod skinned_material2d;

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -76,8 +76,8 @@ pub use self::uvs_material::{UvsMaterial, UVS_FRAGMENT_SRC, UVS_VERTEX_SRC};
 
 pub use self::lit_material2d::{LitMaterial2d, LitMaterial2dGpuData, LitParams};
 pub use self::object_material2d::ObjectMaterial2d;
-pub use self::skinned_material2d::{Bone2d, SkinVertex2d, SkinnedMesh2d, MAX_JOINTS_2D};
 pub use self::shadow::{ShadowMapper, MAX_SHADOW_VIEWS};
+pub use self::skinned_material2d::{Bone2d, SkinVertex2d, SkinnedMesh2d, MAX_JOINTS_2D};
 
 mod aov;
 pub(crate) mod clustered;

--- a/src/builtin/object2d.wgsl
+++ b/src/builtin/object2d.wgsl
@@ -29,10 +29,14 @@ struct ObjectUniforms {
 @group(1) @binding(0)
 var<uniform> object: ObjectUniforms;
 
-// Bind group 2: Texture and sampler
-@group(2) @binding(0)
+// Bind group 2: Texture and sampler.
+// Gated by the `textured` feature: solid-color objects (those still using the
+// default white texture) compile the untextured variant, which strips these
+// bindings and the sample below for higher occupancy. The pipeline layout is shared
+// across variants, so the (now unused) bindings simply strip away.
+@if(textured) @group(2) @binding(0)
 var t_diffuse: texture_2d<f32>;
-@group(2) @binding(1)
+@if(textured) @group(2) @binding(1)
 var s_diffuse: sampler;
 
 // Vertex input
@@ -95,7 +99,10 @@ fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let tex_color = textureSample(t_diffuse, s_diffuse, in.tex_coord);
+    var tex_color = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    @if(textured) {
+        tex_color = textureSample(t_diffuse, s_diffuse, in.tex_coord);
+    }
     let final_color = tex_color * (object.color * in.vert_color);
     return final_color;
 }

--- a/src/builtin/object_material2d.rs
+++ b/src/builtin/object_material2d.rs
@@ -452,15 +452,16 @@ impl ObjectMaterial2d {
                 ],
             });
 
-        let surface_pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("planar_material_pipeline_layout"),
-            bind_group_layouts: &[
-                Some(&frame_bind_group_layout),
-                Some(&object_bind_group_layout),
-                Some(&texture_bind_group_layout),
-            ],
-            immediate_size: 0,
-        });
+        let surface_pipeline_layout =
+            ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("planar_material_pipeline_layout"),
+                bind_group_layouts: &[
+                    Some(&frame_bind_group_layout),
+                    Some(&object_bind_group_layout),
+                    Some(&texture_bind_group_layout),
+                ],
+                immediate_size: 0,
+            });
 
         // Surface shader variants and pipelines are compiled lazily on first use,
         // keyed by feature mask (textured vs. solid) / blend mode / MSAA sample count.
@@ -949,39 +950,41 @@ impl ObjectMaterial2d {
                 },
             ];
 
-            let pipeline = Rc::new(ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("planar_material_pipeline"),
-                layout: Some(&self.surface_pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &vertex_buffer_layouts,
-                    compilation_options: Default::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format: Context::render_format(), // HDR rasterization target (tonemapped to LDR in the resolve pass)
-                        blend: blend.blend_state(),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options: Default::default(),
+            let pipeline = Rc::new(
+                ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                    label: Some("planar_material_pipeline"),
+                    layout: Some(&self.surface_pipeline_layout),
+                    vertex: wgpu::VertexState {
+                        module: &shader,
+                        entry_point: Some("vs_main"),
+                        buffers: &vertex_buffer_layouts,
+                        compilation_options: Default::default(),
+                    },
+                    fragment: Some(wgpu::FragmentState {
+                        module: &shader,
+                        entry_point: Some("fs_main"),
+                        targets: &[Some(wgpu::ColorTargetState {
+                            format: Context::render_format(), // HDR rasterization target (tonemapped to LDR in the resolve pass)
+                            blend: blend.blend_state(),
+                            write_mask: wgpu::ColorWrites::ALL,
+                        })],
+                        compilation_options: Default::default(),
+                    }),
+                    primitive: wgpu::PrimitiveState {
+                        topology: wgpu::PrimitiveTopology::TriangleList,
+                        strip_index_format: None,
+                        front_face: wgpu::FrontFace::Ccw,
+                        cull_mode: None, // 2D objects typically don't need culling
+                        polygon_mode: wgpu::PolygonMode::Fill,
+                        unclipped_depth: false,
+                        conservative: false,
+                    },
+                    depth_stencil: None, // 2D rendering typically doesn't use depth
+                    multisample: multisample_state(sample_count),
+                    multiview_mask: None,
+                    cache: None,
                 }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    strip_index_format: None,
-                    front_face: wgpu::FrontFace::Ccw,
-                    cull_mode: None, // 2D objects typically don't need culling
-                    polygon_mode: wgpu::PolygonMode::Fill,
-                    unclipped_depth: false,
-                    conservative: false,
-                },
-                depth_stencil: None, // 2D rendering typically doesn't use depth
-                multisample: multisample_state(sample_count),
-                multiview_mask: None,
-                cache: None,
-            }));
+            );
             self.surface_pipelines
                 .borrow_mut()
                 .insert(key, pipeline.clone());

--- a/src/builtin/object_material2d.rs
+++ b/src/builtin/object_material2d.rs
@@ -3,13 +3,65 @@ use crate::context::Context;
 use crate::resource::vertex_index::VERTEX_INDEX_FORMAT;
 use crate::resource::{
     multisample_state, DynamicUniformBuffer, GpuData, GpuMesh2d, Material2d, PipelineCache,
-    RenderContext2d, Texture,
+    RenderContext2d, Texture, TextureManager,
 };
 use crate::scene::{Blend2d, InstancesBuffer2d, ObjectData2d};
 use bytemuck::{Pod, Zeroable};
 use glamx::{Mat2, Mat3, Pose2, Vec2};
 use std::any::Any;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Conditional-compilation features for the 2D object shader (`object2d.wgsl`).
+///
+/// Each bit maps to a WESL `@if(...)` flag; a per-object mask selects a specialized
+/// shader variant so unused paths (and their texture bindings) are stripped, raising
+/// GPU occupancy. The pipeline layout is shared across variants — stripped bindings
+/// simply go unused — so all variants reuse the same bind groups.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
+pub(crate) struct ShaderFeatures2d(u32);
+
+impl ShaderFeatures2d {
+    /// The object samples a texture (vs. a solid color using the default white texture).
+    const TEXTURED: u32 = 1 << 0;
+
+    /// `(WESL feature name, bit)` — names MUST match the `@if(...)` flags in `object2d.wgsl`.
+    const TABLE: [(&'static str, u32); 1] = [("textured", Self::TEXTURED)];
+
+    #[inline]
+    fn with(mut self, bit: u32, on: bool) -> Self {
+        if on {
+            self.0 |= bit;
+        } else {
+            self.0 &= !bit;
+        }
+        self
+    }
+
+    #[inline]
+    fn has(self, bit: u32) -> bool {
+        self.0 & bit != 0
+    }
+}
+
+/// Compiles `object2d.wgsl` to specialized WGSL for `features` via WESL conditional
+/// translation; dead-code elimination then strips the unused paths and bindings.
+fn compile_object2d_wgsl(features: ShaderFeatures2d) -> String {
+    let feats: Vec<(&str, bool)> = ShaderFeatures2d::TABLE
+        .iter()
+        .map(|(name, bit)| (*name, features.has(*bit)))
+        .collect();
+    crate::builtin::compile_wesl(
+        &[
+            ("package::object2d", include_str!("object2d.wgsl")),
+            ("package::common", crate::builtin::COMMON_WESL),
+        ],
+        "package::object2d",
+        &feats,
+    )
+}
 
 /// Frame-level uniforms (view, projection) for 2D rendering.
 #[repr(C)]
@@ -298,9 +350,16 @@ impl GpuData for ObjectMaterial2dGpuData {
 /// - Object uniforms are accumulated in a dynamic buffer and flushed once
 /// - This significantly reduces the number of `write_buffer` calls per frame
 pub struct ObjectMaterial2d {
-    /// One surface pipeline per [`Blend2d`] mode (indexed by `blend as usize`), each
-    /// a [`PipelineCache`] that lazily builds per MSAA sample count.
-    pipelines: Vec<PipelineCache>,
+    /// Pipeline layout shared by every surface-shader variant (group 0 frame, group 1
+    /// object, group 2 texture); unused bindings in a stripped variant simply go unused.
+    surface_pipeline_layout: wgpu::PipelineLayout,
+    /// Specialized surface shader modules, compiled lazily and cached per feature mask.
+    surface_shaders: RefCell<HashMap<ShaderFeatures2d, Rc<wgpu::ShaderModule>>>,
+    /// Specialized surface pipelines, keyed by `(blend mode, features, sample count)`.
+    surface_pipelines: RefCell<HashMap<(Blend2d, ShaderFeatures2d, u32), Rc<wgpu::RenderPipeline>>>,
+    /// The global default (white) texture; an object still using it gets the
+    /// untextured shader variant.
+    default_texture: Arc<Texture>,
     object_bind_group_layout: wgpu::BindGroupLayout,
     texture_bind_group_layout: wgpu::BindGroupLayout,
     // Wireframe pipeline and layouts
@@ -393,7 +452,7 @@ impl ObjectMaterial2d {
                 ],
             });
 
-        let pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        let surface_pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("planar_material_pipeline_layout"),
             bind_group_layouts: &[
                 Some(&frame_bind_group_layout),
@@ -403,25 +462,8 @@ impl ObjectMaterial2d {
             immediate_size: 0,
         });
 
-        // Load shader
-        let shader = ctxt.create_shader_module(
-            Some("planar_material_shader"),
-            &crate::builtin::compile_shader_with_common(
-                "package::object2d",
-                include_str!("object2d.wgsl"),
-            ),
-        );
-
-        // Main 2D surface pipelines: one per blend mode, each built lazily per MSAA
-        // sample count (2D content renders into the optionally-multisampled HDR film).
-        let pipelines: Vec<PipelineCache> = Blend2d::ALL
-            .iter()
-            .map(|&blend| {
-                let shader = shader.clone();
-                let pipeline_layout = pipeline_layout.clone();
-                Self::build_surface_pipeline(shader, pipeline_layout, blend)
-            })
-            .collect();
+        // Surface shader variants and pipelines are compiled lazily on first use,
+        // keyed by feature mask (textured vs. solid) / blend mode / MSAA sample count.
 
         // Create wireframe bind group layouts
         let wireframe_view_bind_group_layout =
@@ -791,7 +833,10 @@ impl ObjectMaterial2d {
         });
 
         ObjectMaterial2d {
-            pipelines,
+            surface_pipeline_layout,
+            surface_shaders: RefCell::new(HashMap::new()),
+            surface_pipelines: RefCell::new(HashMap::new()),
+            default_texture: TextureManager::get_global_manager(|tm| tm.get_default()),
             object_bind_group_layout,
             texture_bind_group_layout,
             wireframe_pipeline,
@@ -809,16 +854,36 @@ impl ObjectMaterial2d {
         }
     }
 
-    /// Builds the lazily-per-sample-count surface pipeline for one blend mode. The
-    /// shader and pipeline layout are captured by value (cheap reference-counted wgpu
-    /// handles) so each blend variant owns an independent `'static` builder closure.
-    fn build_surface_pipeline(
-        shader: wgpu::ShaderModule,
-        pipeline_layout: wgpu::PipelineLayout,
+    /// Returns the specialized surface shader module for `features`, compiling and
+    /// caching it on first use (WESL `@if` strips unused paths/bindings per variant).
+    fn surface_shader(&self, features: ShaderFeatures2d) -> Rc<wgpu::ShaderModule> {
+        if let Some(m) = self.surface_shaders.borrow().get(&features) {
+            return m.clone();
+        }
+        let wgsl = compile_object2d_wgsl(features);
+        let module =
+            Rc::new(Context::get().create_shader_module(Some("planar_material_shader"), &wgsl));
+        self.surface_shaders
+            .borrow_mut()
+            .insert(features, module.clone());
+        module
+    }
+
+    /// Returns the surface pipeline for `(blend, features, sample_count)`, building and
+    /// caching it on first use. All variants share `surface_pipeline_layout`.
+    fn surface_pipeline(
+        &self,
         blend: Blend2d,
-    ) -> PipelineCache {
-        PipelineCache::new(move |sample_count| {
-            let ctxt = Context::get();
+        features: ShaderFeatures2d,
+        sample_count: u32,
+    ) -> Rc<wgpu::RenderPipeline> {
+        let key = (blend, features, sample_count);
+        if let Some(p) = self.surface_pipelines.borrow().get(&key) {
+            return p.clone();
+        }
+        let shader = self.surface_shader(features);
+        let ctxt = Context::get();
+        {
             // Vertex buffer layouts
             // Note: We use separate buffers for instance data (positions, colors, deformations)
             // instead of interleaving them, to avoid per-frame data conversion overhead.
@@ -884,9 +949,9 @@ impl ObjectMaterial2d {
                 },
             ];
 
-            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            let pipeline = Rc::new(ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("planar_material_pipeline"),
-                layout: Some(&pipeline_layout),
+                layout: Some(&self.surface_pipeline_layout),
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: Some("vs_main"),
@@ -916,8 +981,12 @@ impl ObjectMaterial2d {
                 multisample: multisample_state(sample_count),
                 multiview_mask: None,
                 cache: None,
-            })
-        })
+            }));
+            self.surface_pipelines
+                .borrow_mut()
+                .insert(key, pipeline.clone());
+            pipeline
+        }
     }
 
     fn create_texture_bind_group(&self, texture: &Texture) -> wgpu::BindGroup {
@@ -1458,7 +1527,11 @@ impl Material2d for ObjectMaterial2d {
             };
             let object_bind_group = self.object_bind_group.as_ref().unwrap();
 
-            let pipeline = self.pipelines[data.blend() as usize].get(context.sample_count);
+            // Specialize the shader: objects still using the default white texture
+            // get the untextured variant (no texture sample), the rest the textured one.
+            let textured = !Arc::ptr_eq(data.texture(), &self.default_texture);
+            let features = ShaderFeatures2d::default().with(ShaderFeatures2d::TEXTURED, textured);
+            let pipeline = self.surface_pipeline(data.blend(), features, context.sample_count);
             render_pass.set_pipeline(&pipeline);
             render_pass.set_bind_group(0, &self.frame_bind_group, &[]);
             // Use dynamic offset for object uniforms!

--- a/src/builtin/object_material2d.rs
+++ b/src/builtin/object_material2d.rs
@@ -5,7 +5,7 @@ use crate::resource::{
     multisample_state, DynamicUniformBuffer, GpuData, GpuMesh2d, Material2d, PipelineCache,
     RenderContext2d, Texture,
 };
-use crate::scene::{InstancesBuffer2d, ObjectData2d};
+use crate::scene::{Blend2d, InstancesBuffer2d, ObjectData2d};
 use bytemuck::{Pod, Zeroable};
 use glamx::{Mat2, Mat3, Pose2, Vec2};
 use std::any::Any;
@@ -298,7 +298,9 @@ impl GpuData for ObjectMaterial2dGpuData {
 /// - Object uniforms are accumulated in a dynamic buffer and flushed once
 /// - This significantly reduces the number of `write_buffer` calls per frame
 pub struct ObjectMaterial2d {
-    pipeline: PipelineCache,
+    /// One surface pipeline per [`Blend2d`] mode (indexed by `blend as usize`), each
+    /// a [`PipelineCache`] that lazily builds per MSAA sample count.
+    pipelines: Vec<PipelineCache>,
     object_bind_group_layout: wgpu::BindGroupLayout,
     texture_bind_group_layout: wgpu::BindGroupLayout,
     // Wireframe pipeline and layouts
@@ -410,109 +412,16 @@ impl ObjectMaterial2d {
             ),
         );
 
-        // Main 2D surface pipeline, built lazily per MSAA sample count (2D content
-        // renders into the optionally-multisampled HDR film).
-        let pipeline = PipelineCache::new(move |sample_count| {
-            let ctxt = Context::get();
-            // Vertex buffer layouts
-            // Note: We use separate buffers for instance data (positions, colors, deformations)
-            // instead of interleaving them, to avoid per-frame data conversion overhead.
-            let vertex_buffer_layouts = [
-                // Buffer 0: Vertex positions (vec2)
-                wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
-                    step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[wgpu::VertexAttribute {
-                        offset: 0,
-                        shader_location: 0,
-                        format: wgpu::VertexFormat::Float32x2,
-                    }],
-                },
-                // Buffer 1: Texture coordinates (vec2)
-                wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
-                    step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[wgpu::VertexAttribute {
-                        offset: 0,
-                        shader_location: 1,
-                        format: wgpu::VertexFormat::Float32x2,
-                    }],
-                },
-                // Buffer 2: Instance positions (Point2<f32>)
-                wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
-                    step_mode: wgpu::VertexStepMode::Instance,
-                    attributes: &[wgpu::VertexAttribute {
-                        offset: 0,
-                        shader_location: 2, // inst_tra
-                        format: wgpu::VertexFormat::Float32x2,
-                    }],
-                },
-                // Buffer 3: Instance colors ([f32; 4])
-                wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
-                    step_mode: wgpu::VertexStepMode::Instance,
-                    attributes: &[wgpu::VertexAttribute {
-                        offset: 0,
-                        shader_location: 3, // inst_color
-                        format: wgpu::VertexFormat::Float32x4,
-                    }],
-                },
-                // Buffer 4: Instance deformations (2x Vector2<f32> = 2 columns of 2x2 matrix)
-                wgpu::VertexBufferLayout {
-                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress, // 2 vec2s
-                    step_mode: wgpu::VertexStepMode::Instance,
-                    attributes: &[
-                        // inst_def_0 (column 0)
-                        wgpu::VertexAttribute {
-                            offset: 0,
-                            shader_location: 4,
-                            format: wgpu::VertexFormat::Float32x2,
-                        },
-                        // inst_def_1 (column 1)
-                        wgpu::VertexAttribute {
-                            offset: 8, // 2 * sizeof(f32)
-                            shader_location: 5,
-                            format: wgpu::VertexFormat::Float32x2,
-                        },
-                    ],
-                },
-            ];
-
-            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("planar_material_pipeline"),
-                layout: Some(&pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &vertex_buffer_layouts,
-                    compilation_options: Default::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format: Context::render_format(), // HDR rasterization target (tonemapped to LDR in the resolve pass)
-                        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options: Default::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    strip_index_format: None,
-                    front_face: wgpu::FrontFace::Ccw,
-                    cull_mode: None, // 2D objects typically don't need culling
-                    polygon_mode: wgpu::PolygonMode::Fill,
-                    unclipped_depth: false,
-                    conservative: false,
-                },
-                depth_stencil: None, // 2D rendering typically doesn't use depth
-                multisample: multisample_state(sample_count),
-                multiview_mask: None,
-                cache: None,
+        // Main 2D surface pipelines: one per blend mode, each built lazily per MSAA
+        // sample count (2D content renders into the optionally-multisampled HDR film).
+        let pipelines: Vec<PipelineCache> = Blend2d::ALL
+            .iter()
+            .map(|&blend| {
+                let shader = shader.clone();
+                let pipeline_layout = pipeline_layout.clone();
+                Self::build_surface_pipeline(shader, pipeline_layout, blend)
             })
-        });
+            .collect();
 
         // Create wireframe bind group layouts
         let wireframe_view_bind_group_layout =
@@ -882,7 +791,7 @@ impl ObjectMaterial2d {
         });
 
         ObjectMaterial2d {
-            pipeline,
+            pipelines,
             object_bind_group_layout,
             texture_bind_group_layout,
             wireframe_pipeline,
@@ -898,6 +807,117 @@ impl ObjectMaterial2d {
             frame_counter: Cell::new(0),
             last_frame: Cell::new(u64::MAX),
         }
+    }
+
+    /// Builds the lazily-per-sample-count surface pipeline for one blend mode. The
+    /// shader and pipeline layout are captured by value (cheap reference-counted wgpu
+    /// handles) so each blend variant owns an independent `'static` builder closure.
+    fn build_surface_pipeline(
+        shader: wgpu::ShaderModule,
+        pipeline_layout: wgpu::PipelineLayout,
+        blend: Blend2d,
+    ) -> PipelineCache {
+        PipelineCache::new(move |sample_count| {
+            let ctxt = Context::get();
+            // Vertex buffer layouts
+            // Note: We use separate buffers for instance data (positions, colors, deformations)
+            // instead of interleaving them, to avoid per-frame data conversion overhead.
+            let vertex_buffer_layouts = [
+                // Buffer 0: Vertex positions (vec2)
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 0,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                // Buffer 1: Texture coordinates (vec2)
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 1,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                // Buffer 2: Instance positions (Point2<f32>)
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 2, // inst_tra
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                // Buffer 3: Instance colors ([f32; 4])
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 3, // inst_color
+                        format: wgpu::VertexFormat::Float32x4,
+                    }],
+                },
+                // Buffer 4: Instance deformations (2x Vector2<f32> = 2 columns of 2x2 matrix)
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress, // 2 vec2s
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[
+                        // inst_def_0 (column 0)
+                        wgpu::VertexAttribute {
+                            offset: 0,
+                            shader_location: 4,
+                            format: wgpu::VertexFormat::Float32x2,
+                        },
+                        // inst_def_1 (column 1)
+                        wgpu::VertexAttribute {
+                            offset: 8, // 2 * sizeof(f32)
+                            shader_location: 5,
+                            format: wgpu::VertexFormat::Float32x2,
+                        },
+                    ],
+                },
+            ];
+
+            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("planar_material_pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &vertex_buffer_layouts,
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: Context::render_format(), // HDR rasterization target (tonemapped to LDR in the resolve pass)
+                        blend: blend.blend_state(),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None, // 2D objects typically don't need culling
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None, // 2D rendering typically doesn't use depth
+                multisample: multisample_state(sample_count),
+                multiview_mask: None,
+                cache: None,
+            })
+        })
     }
 
     fn create_texture_bind_group(&self, texture: &Texture) -> wgpu::BindGroup {
@@ -1438,7 +1458,7 @@ impl Material2d for ObjectMaterial2d {
             };
             let object_bind_group = self.object_bind_group.as_ref().unwrap();
 
-            let pipeline = self.pipeline.get(context.sample_count);
+            let pipeline = self.pipelines[data.blend() as usize].get(context.sample_count);
             render_pass.set_pipeline(&pipeline);
             render_pass.set_bind_group(0, &self.frame_bind_group, &[]);
             // Use dynamic offset for object uniforms!

--- a/src/builtin/shadow.rs
+++ b/src/builtin/shadow.rs
@@ -32,6 +32,7 @@ use crate::context::Context;
 use crate::light::{CollectedLight, LightCollection, LightType, MAX_LIGHTS};
 use crate::scene::SceneNode3d;
 use bytemuck::{Pod, Zeroable};
+use glamx::glam::camera::rh::{proj::directx, view::look_at_mat4};
 use glamx::{Mat4, Vec3};
 
 /// Maximum number of shadow views (atlas layers) across all lights.
@@ -1933,10 +1934,10 @@ fn calculate_cascade(
     // fallen into the void) corrupt the depth range and make shadows flicker/degrade.
     let margin = 0.5 * radius;
     let light_eye = center - dir * (radius + margin);
-    let view = Mat4::look_at_rh(light_eye, center, up);
+    let view = look_at_mat4(light_eye, center, up);
     let near = 0.0_f32;
     let far = 2.0 * radius + 2.0 * margin;
-    let proj = Mat4::orthographic_rh(-radius, radius, -radius, radius, near, far);
+    let proj = directx::orthographic(-radius, radius, -radius, radius, near, far);
     let view_proj = proj * view;
 
     // Texel snap: round the projected world origin to the texel grid so a fixed
@@ -1957,8 +1958,8 @@ fn perspective_view_proj(eye: Vec3, target: Vec3, fov: f32, near: f32, far: f32)
     } else {
         Vec3::Y
     };
-    let view = Mat4::look_at_rh(eye, eye + fwd, up);
-    let proj = Mat4::perspective_rh(fov, 1.0, near, far);
+    let view = look_at_mat4(eye, eye + fwd, up);
+    let proj = directx::perspective(fov, 1.0, near, far);
     proj * view
 }
 
@@ -1966,7 +1967,7 @@ fn perspective_view_proj(eye: Vec3, target: Vec3, fov: f32, near: f32, far: f32)
 ///
 /// Face order: +X, -X, +Y, -Y, +Z, -Z, matching the selection logic in the shader.
 fn cube_face_view_projs(eye: Vec3, near: f32, far: f32) -> [Mat4; 6] {
-    let proj = Mat4::perspective_rh(std::f32::consts::FRAC_PI_2, 1.0, near, far);
+    let proj = directx::perspective(std::f32::consts::FRAC_PI_2, 1.0, near, far);
     let dirs_ups = [
         (Vec3::X, Vec3::NEG_Y),
         (Vec3::NEG_X, Vec3::NEG_Y),
@@ -1977,7 +1978,7 @@ fn cube_face_view_projs(eye: Vec3, near: f32, far: f32) -> [Mat4; 6] {
     ];
     let mut out = [Mat4::IDENTITY; 6];
     for (i, (dir, up)) in dirs_ups.iter().enumerate() {
-        let view = Mat4::look_at_rh(eye, eye + *dir, *up);
+        let view = look_at_mat4(eye, eye + *dir, *up);
         out[i] = proj * view;
     }
     out

--- a/src/builtin/skinned2d.wgsl
+++ b/src/builtin/skinned2d.wgsl
@@ -1,0 +1,82 @@
+import package::common::unpack_mat3;
+// 2D GPU skinning: each vertex is transformed by a weighted blend of up to four
+// joint matrices, then by the object model transform and the camera. Joint matrices
+// (bone world × inverse-bind, as 2D affine 3x3) are supplied per frame.
+
+const MAX_JOINTS: u32 = 32u;
+
+struct FrameUniforms {
+    view_0: vec4<f32>,
+    view_1: vec4<f32>,
+    view_2: vec4<f32>,
+    proj_0: vec4<f32>,
+    proj_1: vec4<f32>,
+    proj_2: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> frame: FrameUniforms;
+
+struct ObjectUniforms {
+    model_0: vec4<f32>,
+    model_1: vec4<f32>,
+    model_2: vec4<f32>,
+    color: vec4<f32>,
+    // Each joint is three vec4 (padded 3x3 columns): joints[3*j + {0,1,2}].
+    joints: array<vec4<f32>, 96>,
+}
+
+@group(1) @binding(0)
+var<uniform> obj: ObjectUniforms;
+
+@group(2) @binding(0)
+var t_albedo: texture_2d<f32>;
+@group(2) @binding(1)
+var s_albedo: sampler;
+
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) tex_coord: vec2<f32>,
+    @location(2) joints: vec4<u32>,
+    @location(3) weights: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) tex_coord: vec2<f32>,
+}
+
+fn joint_mat(j: u32) -> mat3x3<f32> {
+    let b = 3u * j;
+    return unpack_mat3(obj.joints[b], obj.joints[b + 1u], obj.joints[b + 2u]);
+}
+
+@vertex
+fn vs_main(vertex: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+
+    let p = vec3<f32>(vertex.position, 1.0);
+    // Weighted blend of the four influencing joints.
+    var skinned = vec3<f32>(0.0);
+    skinned += vertex.weights.x * (joint_mat(vertex.joints.x) * p);
+    skinned += vertex.weights.y * (joint_mat(vertex.joints.y) * p);
+    skinned += vertex.weights.z * (joint_mat(vertex.joints.z) * p);
+    skinned += vertex.weights.w * (joint_mat(vertex.joints.w) * p);
+
+    let view = unpack_mat3(frame.view_0, frame.view_1, frame.view_2);
+    let proj = unpack_mat3(frame.proj_0, frame.proj_1, frame.proj_2);
+    let model = unpack_mat3(obj.model_0, obj.model_1, obj.model_2);
+
+    let world = model * vec3<f32>(skinned.xy, 1.0);
+    var projected = proj * view * world;
+    projected.z = 0.0;
+
+    out.clip_position = vec4<f32>(projected, 1.0);
+    out.tex_coord = vertex.tex_coord;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(t_albedo, s_albedo, in.tex_coord) * obj.color;
+}

--- a/src/builtin/skinned_material2d.rs
+++ b/src/builtin/skinned_material2d.rs
@@ -1,0 +1,571 @@
+//! 2D skeletal mesh deformation with GPU skinning ([`SkinnedMesh2d`]).
+//!
+//! A skinned mesh binds each vertex to up to four bones of a [`Bone2d`] skeleton with
+//! blend weights. Posing a bone re-deforms the mesh on the GPU (Spine / DragonBones
+//! style): [`update`](SkinnedMesh2d::update) walks the bone hierarchy, multiplies each
+//! bone's world transform by its inverse bind pose, and uploads the resulting joint
+//! matrices, which the vertex shader blends per vertex.
+//!
+//! The mesh exposes a [`SceneNode2d`] to add to the scene; set its texture with the
+//! node's `set_texture_*` methods.
+
+use crate::camera::Camera2d;
+use crate::context::Context;
+use crate::resource::vertex_index::VERTEX_INDEX_FORMAT;
+use crate::resource::{
+    multisample_state, GpuData, GpuMesh2d, Material2d, PipelineCache, RenderContext2d,
+    TextureManager,
+};
+use crate::scene::{InstancesBuffer2d, Object2d, ObjectData2d, SceneNode2d};
+use bytemuck::{Pod, Zeroable};
+use glamx::{Mat3, Pose2, Vec2};
+use std::any::Any;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Maximum number of bones in a [`SkinnedMesh2d`] skeleton (matches `MAX_JOINTS` in
+/// `skinned2d.wgsl`).
+pub const MAX_JOINTS_2D: usize = 32;
+
+/// One vertex of a skinned 2D mesh: position, UV, and up to four bone influences.
+#[derive(Copy, Clone, Debug)]
+pub struct SkinVertex2d {
+    /// Rest-pose position.
+    pub position: Vec2,
+    /// Texture coordinate.
+    pub uv: Vec2,
+    /// Indices of the (up to four) influencing bones.
+    pub joints: [u32; 4],
+    /// Blend weights for `joints` (should sum to 1).
+    pub weights: [f32; 4],
+}
+
+/// A bone in a [`SkinnedMesh2d`] skeleton.
+#[derive(Copy, Clone, Debug)]
+pub struct Bone2d {
+    /// Parent bone index, or `None` for a root. A bone's parent must come before it.
+    pub parent: Option<usize>,
+    /// Local transform relative to the parent.
+    pub local: Pose2,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct FrameUniforms {
+    view: [[f32; 4]; 3],
+    proj: [[f32; 4]; 3],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct ObjectUniforms {
+    model: [[f32; 4]; 3],
+    color: [f32; 4],
+    joints: [[f32; 4]; MAX_JOINTS_2D * 3],
+}
+
+fn mat3_to_padded(m: &Mat3) -> [[f32; 4]; 3] {
+    let c = m.to_cols_array_2d();
+    [
+        [c[0][0], c[0][1], c[0][2], 0.0],
+        [c[1][0], c[1][1], c[1][2], 0.0],
+        [c[2][0], c[2][1], c[2][2], 0.0],
+    ]
+}
+
+/// A 2D mesh deformed by a bone skeleton via GPU skinning (see the [module docs](self)).
+pub struct SkinnedMesh2d {
+    bones: Vec<Bone2d>,
+    inverse_bind: Vec<Mat3>,
+    transform: Pose2,
+    color: [f32; 4],
+    object_uniform_buffer: wgpu::Buffer,
+    node: SceneNode2d,
+}
+
+impl SkinnedMesh2d {
+    /// Builds a skinned mesh from `vertices`, triangle `faces`, and a `bones`
+    /// skeleton. The bones' initial `local` transforms define the bind pose (used to
+    /// compute the inverse-bind matrices), so pose the skeleton into its rest shape
+    /// before calling this. Bones must be ordered parents-before-children.
+    pub fn new(vertices: Vec<SkinVertex2d>, faces: Vec<[u32; 3]>, bones: Vec<Bone2d>) -> SkinnedMesh2d {
+        assert!(
+            bones.len() <= MAX_JOINTS_2D,
+            "SkinnedMesh2d supports at most {} bones",
+            MAX_JOINTS_2D
+        );
+        let ctxt = Context::get();
+
+        // Inverse bind matrices from the initial (bind) pose.
+        let bind_world = Self::world_matrices(&bones);
+        let inverse_bind = bind_world.iter().map(|m| m.inverse()).collect();
+
+        // Split vertices into the per-attribute GPU buffers.
+        let positions: Vec<[f32; 2]> = vertices.iter().map(|v| v.position.into()).collect();
+        let uvs: Vec<[f32; 2]> = vertices.iter().map(|v| v.uv.into()).collect();
+        let joints: Vec<[u32; 4]> = vertices.iter().map(|v| v.joints).collect();
+        let weights: Vec<[f32; 4]> = vertices.iter().map(|v| v.weights).collect();
+        let indices: Vec<u32> = faces.iter().flat_map(|f| f.iter().copied()).collect();
+        let num_indices = indices.len() as u32;
+
+        let pos_buf = ctxt.create_buffer_init(
+            Some("skinned2d_pos"),
+            bytemuck::cast_slice(&positions),
+            wgpu::BufferUsages::VERTEX,
+        );
+        let uv_buf = ctxt.create_buffer_init(
+            Some("skinned2d_uv"),
+            bytemuck::cast_slice(&uvs),
+            wgpu::BufferUsages::VERTEX,
+        );
+        let joint_buf = ctxt.create_buffer_init(
+            Some("skinned2d_joints"),
+            bytemuck::cast_slice(&joints),
+            wgpu::BufferUsages::VERTEX,
+        );
+        let weight_buf = ctxt.create_buffer_init(
+            Some("skinned2d_weights"),
+            bytemuck::cast_slice(&weights),
+            wgpu::BufferUsages::VERTEX,
+        );
+        let index_buf = ctxt.create_buffer_init(
+            Some("skinned2d_indices"),
+            bytemuck::cast_slice(&indices),
+            wgpu::BufferUsages::INDEX,
+        );
+
+        let object_uniform_buffer = ctxt.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("skinned2d_object_uniform"),
+            size: std::mem::size_of::<ObjectUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let material = SkinnedMaterial2d::new(SkinnedBuffers {
+            pos: pos_buf,
+            uv: uv_buf,
+            joints: joint_buf,
+            weights: weight_buf,
+            index: index_buf,
+            num_indices,
+            object_uniform: object_uniform_buffer.clone(),
+        });
+        let material: Rc<RefCell<Box<dyn Material2d + 'static>>> =
+            Rc::new(RefCell::new(Box::new(material)));
+
+        let dummy_mesh = Rc::new(RefCell::new(GpuMesh2d::new(
+            vec![Vec2::ZERO, Vec2::ZERO, Vec2::ZERO],
+            vec![[0, 0, 0]],
+            None,
+            false,
+        )));
+        let tex = TextureManager::get_global_manager(|tm| tm.get_default());
+        let object = Object2d::new(dummy_mesh, 1.0, 1.0, 1.0, tex, material);
+        let node = SceneNode2d::new(Vec2::ONE, Pose2::IDENTITY, Some(object));
+
+        let mut mesh = SkinnedMesh2d {
+            bones,
+            inverse_bind,
+            transform: Pose2::IDENTITY,
+            color: [1.0; 4],
+            object_uniform_buffer,
+            node,
+        };
+        mesh.update();
+        mesh
+    }
+
+    /// World-space matrix of each bone (walking parents; assumes parents precede children).
+    fn world_matrices(bones: &[Bone2d]) -> Vec<Mat3> {
+        let mut world = Vec::with_capacity(bones.len());
+        for bone in bones {
+            let local = bone.local.to_mat3();
+            let m = match bone.parent {
+                Some(p) => world[p] * local,
+                None => local,
+            };
+            world.push(m);
+        }
+        world
+    }
+
+    /// The scene node rendering this mesh. Add it to the scene and set its texture.
+    pub fn node(&self) -> SceneNode2d {
+        self.node.clone()
+    }
+
+    /// Sets a bone's local transform (relative to its parent), e.g. to animate it.
+    /// Call [`update`](Self::update) afterwards to apply.
+    pub fn set_bone_local(&mut self, bone: usize, local: Pose2) {
+        if bone < self.bones.len() {
+            self.bones[bone].local = local;
+        }
+    }
+
+    /// Returns a bone's current local transform.
+    pub fn bone_local(&self, bone: usize) -> Pose2 {
+        self.bones[bone].local
+    }
+
+    /// Number of bones in the skeleton.
+    pub fn bone_count(&self) -> usize {
+        self.bones.len()
+    }
+
+    /// Sets the whole-mesh model transform (position/rotation/scale of the skeleton).
+    pub fn set_transform(&mut self, transform: Pose2) {
+        self.transform = transform;
+    }
+
+    /// Sets a uniform color/tint multiplied into the mesh's texture.
+    pub fn set_color(&mut self, color: [f32; 4]) {
+        self.color = color;
+    }
+
+    /// Recomputes joint matrices from the current bone poses and uploads them.
+    /// Call once per frame after posing bones, before rendering.
+    pub fn update(&mut self) {
+        let ctxt = Context::get();
+        let world = Self::world_matrices(&self.bones);
+
+        let mut joints = [[0.0f32; 4]; MAX_JOINTS_2D * 3];
+        for (i, (w, inv)) in world.iter().zip(self.inverse_bind.iter()).enumerate() {
+            let joint = *w * *inv;
+            let padded = mat3_to_padded(&joint);
+            joints[i * 3] = padded[0];
+            joints[i * 3 + 1] = padded[1];
+            joints[i * 3 + 2] = padded[2];
+        }
+        // Bones beyond the skeleton stay identity (so zero-weight slots are harmless).
+        for i in world.len()..MAX_JOINTS_2D {
+            joints[i * 3] = [1.0, 0.0, 0.0, 0.0];
+            joints[i * 3 + 1] = [0.0, 1.0, 0.0, 0.0];
+            joints[i * 3 + 2] = [0.0, 0.0, 1.0, 0.0];
+        }
+
+        let uniforms = ObjectUniforms {
+            model: mat3_to_padded(&self.transform.to_mat3()),
+            color: self.color,
+            joints,
+        };
+        ctxt.write_buffer(
+            &self.object_uniform_buffer,
+            0,
+            bytemuck::bytes_of(&uniforms),
+        );
+    }
+}
+
+/// Buffers handed to the skinned material (all cheap-to-clone wgpu handles).
+struct SkinnedBuffers {
+    pos: wgpu::Buffer,
+    uv: wgpu::Buffer,
+    joints: wgpu::Buffer,
+    weights: wgpu::Buffer,
+    index: wgpu::Buffer,
+    num_indices: u32,
+    object_uniform: wgpu::Buffer,
+}
+
+struct SkinnedMaterial2dGpuData {
+    object_bind_group: Option<wgpu::BindGroup>,
+    texture_bind_group: Option<wgpu::BindGroup>,
+    cached_texture_ptr: usize,
+}
+
+impl GpuData for SkinnedMaterial2dGpuData {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+struct SkinnedMaterial2d {
+    pipeline: PipelineCache,
+    frame_bind_group: wgpu::BindGroup,
+    frame_uniform_buffer: wgpu::Buffer,
+    object_bind_group_layout: wgpu::BindGroupLayout,
+    texture_bind_group_layout: wgpu::BindGroupLayout,
+    buffers: SkinnedBuffers,
+}
+
+impl SkinnedMaterial2d {
+    fn new(buffers: SkinnedBuffers) -> SkinnedMaterial2d {
+        let ctxt = Context::get();
+
+        let frame_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("skinned2d_frame_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+        let object_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("skinned2d_object_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+        let texture_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("skinned2d_texture_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("skinned2d_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&frame_bind_group_layout),
+                Some(&object_bind_group_layout),
+                Some(&texture_bind_group_layout),
+            ],
+            immediate_size: 0,
+        });
+
+        let shader = ctxt.create_shader_module(
+            Some("skinned2d_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::skinned2d",
+                include_str!("skinned2d.wgsl"),
+            ),
+        );
+
+        let pipeline = PipelineCache::new(move |sample_count| {
+            let ctxt = Context::get();
+            let vertex_layouts = [
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 0,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 1,
+                        format: wgpu::VertexFormat::Float32x2,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[u32; 4]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 2,
+                        format: wgpu::VertexFormat::Uint32x4,
+                    }],
+                },
+                wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        offset: 0,
+                        shader_location: 3,
+                        format: wgpu::VertexFormat::Float32x4,
+                    }],
+                },
+            ];
+
+            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("skinned2d_pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &vertex_layouts,
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: Context::render_format(),
+                        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: multisample_state(sample_count),
+                multiview_mask: None,
+                cache: None,
+            })
+        });
+
+        let frame_uniform_buffer = ctxt.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("skinned2d_frame_uniform"),
+            size: std::mem::size_of::<FrameUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let frame_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("skinned2d_frame_bind_group"),
+            layout: &frame_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: frame_uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        SkinnedMaterial2d {
+            pipeline,
+            frame_bind_group,
+            frame_uniform_buffer,
+            object_bind_group_layout,
+            texture_bind_group_layout,
+            buffers,
+        }
+    }
+}
+
+impl Material2d for SkinnedMaterial2d {
+    fn create_gpu_data(&self) -> Box<dyn GpuData> {
+        Box::new(SkinnedMaterial2dGpuData {
+            object_bind_group: None,
+            texture_bind_group: None,
+            cached_texture_ptr: 0,
+        })
+    }
+
+    fn prepare(
+        &mut self,
+        _transform: Pose2,
+        _scale: Vec2,
+        camera: &mut dyn Camera2d,
+        data: &ObjectData2d,
+        _mesh: &mut GpuMesh2d,
+        _instances: &mut InstancesBuffer2d,
+        gpu_data: &mut dyn GpuData,
+        _context: &RenderContext2d,
+    ) {
+        let ctxt = Context::get();
+        let (view, proj) = camera.view_transform_pair();
+        let frame = FrameUniforms {
+            view: mat3_to_padded(&view),
+            proj: mat3_to_padded(&proj),
+        };
+        ctxt.write_buffer(&self.frame_uniform_buffer, 0, bytemuck::bytes_of(&frame));
+
+        let gpu_data = gpu_data
+            .as_any_mut()
+            .downcast_mut::<SkinnedMaterial2dGpuData>()
+            .expect("SkinnedMaterial2d requires SkinnedMaterial2dGpuData");
+
+        if gpu_data.object_bind_group.is_none() {
+            gpu_data.object_bind_group = Some(ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("skinned2d_object_bind_group"),
+                layout: &self.object_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.buffers.object_uniform.as_entire_binding(),
+                }],
+            }));
+        }
+
+        let texture = data.texture();
+        let texture_ptr = std::sync::Arc::as_ptr(texture) as usize;
+        if gpu_data.texture_bind_group.is_none() || gpu_data.cached_texture_ptr != texture_ptr {
+            gpu_data.texture_bind_group = Some(ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("skinned2d_texture_bind_group"),
+                layout: &self.texture_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&texture.view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&texture.sampler),
+                    },
+                ],
+            }));
+            gpu_data.cached_texture_ptr = texture_ptr;
+        }
+    }
+
+    fn render(
+        &mut self,
+        _transform: Pose2,
+        _scale: Vec2,
+        _camera: &mut dyn Camera2d,
+        _data: &ObjectData2d,
+        _mesh: &mut GpuMesh2d,
+        _instances: &mut InstancesBuffer2d,
+        gpu_data: &mut dyn GpuData,
+        render_pass: &mut wgpu::RenderPass<'_>,
+        context: &RenderContext2d,
+    ) {
+        let gpu_data = gpu_data
+            .as_any_mut()
+            .downcast_mut::<SkinnedMaterial2dGpuData>()
+            .expect("SkinnedMaterial2d requires SkinnedMaterial2dGpuData");
+        let object_bind_group = match gpu_data.object_bind_group.as_ref() {
+            Some(bg) => bg,
+            None => return,
+        };
+        let texture_bind_group = match gpu_data.texture_bind_group.as_ref() {
+            Some(bg) => bg,
+            None => return,
+        };
+
+        let pipeline = self.pipeline.get(context.sample_count);
+        render_pass.set_pipeline(&pipeline);
+        render_pass.set_bind_group(0, &self.frame_bind_group, &[]);
+        render_pass.set_bind_group(1, object_bind_group, &[]);
+        render_pass.set_bind_group(2, texture_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.buffers.pos.slice(..));
+        render_pass.set_vertex_buffer(1, self.buffers.uv.slice(..));
+        render_pass.set_vertex_buffer(2, self.buffers.joints.slice(..));
+        render_pass.set_vertex_buffer(3, self.buffers.weights.slice(..));
+        render_pass.set_index_buffer(self.buffers.index.slice(..), VERTEX_INDEX_FORMAT);
+        render_pass.draw_indexed(0..self.buffers.num_indices, 0, 0..1);
+    }
+}

--- a/src/builtin/skinned_material2d.rs
+++ b/src/builtin/skinned_material2d.rs
@@ -73,7 +73,7 @@ fn mat3_to_padded(m: &Mat3) -> [[f32; 4]; 3] {
     ]
 }
 
-/// A 2D mesh deformed by a bone skeleton via GPU skinning (see the [module docs](self)).
+/// A 2D mesh deformed by a bone skeleton via GPU skinning (see the [module docs](crate::builtin)).
 pub struct SkinnedMesh2d {
     bones: Vec<Bone2d>,
     inverse_bind: Vec<Mat3>,
@@ -88,7 +88,11 @@ impl SkinnedMesh2d {
     /// skeleton. The bones' initial `local` transforms define the bind pose (used to
     /// compute the inverse-bind matrices), so pose the skeleton into its rest shape
     /// before calling this. Bones must be ordered parents-before-children.
-    pub fn new(vertices: Vec<SkinVertex2d>, faces: Vec<[u32; 3]>, bones: Vec<Bone2d>) -> SkinnedMesh2d {
+    pub fn new(
+        vertices: Vec<SkinVertex2d>,
+        faces: Vec<[u32; 3]>,
+        bones: Vec<Bone2d>,
+    ) -> SkinnedMesh2d {
         assert!(
             bones.len() <= MAX_JOINTS_2D,
             "SkinnedMesh2d supports at most {} bones",
@@ -513,20 +517,21 @@ impl Material2d for SkinnedMaterial2d {
         let texture = data.texture();
         let texture_ptr = std::sync::Arc::as_ptr(texture) as usize;
         if gpu_data.texture_bind_group.is_none() || gpu_data.cached_texture_ptr != texture_ptr {
-            gpu_data.texture_bind_group = Some(ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("skinned2d_texture_bind_group"),
-                layout: &self.texture_bind_group_layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::TextureView(&texture.view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::Sampler(&texture.sampler),
-                    },
-                ],
-            }));
+            gpu_data.texture_bind_group =
+                Some(ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("skinned2d_texture_bind_group"),
+                    layout: &self.texture_bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(&texture.view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Sampler(&texture.sampler),
+                        },
+                    ],
+                }));
             gpu_data.cached_texture_ptr = texture_ptr;
         }
     }

--- a/src/camera/first_person3d.rs
+++ b/src/camera/first_person3d.rs
@@ -1,6 +1,7 @@
 use crate::camera::Camera3d;
 use crate::event::{Action, Key, MouseButton, WindowEvent};
 use crate::window::Canvas;
+use glamx::glam::camera::rh::proj::opengl;
 use glamx::{Mat4, Pose3, Rot3, Vec2, Vec3};
 use std::f32;
 
@@ -316,7 +317,7 @@ impl FirstPersonCamera3d {
     fn update_projviews(&mut self) {
         self.view = self.view_transform().to_mat4();
         let aspect = self.last_framebuffer_size.x / self.last_framebuffer_size.y;
-        self.proj = Mat4::perspective_rh_gl(self.fov, aspect, self.znear, self.zfar);
+        self.proj = opengl::perspective(self.fov, aspect, self.znear, self.zfar);
         self.proj_view = self.proj * self.view;
         self.inverse_proj_view = self.proj_view.inverse();
     }

--- a/src/camera/first_person_stereo3d.rs
+++ b/src/camera/first_person_stereo3d.rs
@@ -1,5 +1,6 @@
 use std::f32;
 
+use glamx::glam::camera::rh::proj::opengl;
 use glamx::{Mat4, Pose3, Vec2, Vec3};
 
 use crate::camera::Camera3d;
@@ -180,7 +181,7 @@ impl FirstPersonCamera3dStereo {
 
     fn update_projviews(&mut self) {
         let aspect = self.last_framebuffer_size.x / self.last_framebuffer_size.y;
-        self.proj = Mat4::perspective_rh_gl(self.fov, aspect, self.znear, self.zfar);
+        self.proj = opengl::perspective(self.fov, aspect, self.znear, self.zfar);
         self.proj_view = self.proj * self.view_transform().to_mat4();
         self.inverse_proj_view = self.proj_view.inverse();
         self.view_left = self.view_transform_left().to_mat4();

--- a/src/camera/fixed_view3d.rs
+++ b/src/camera/fixed_view3d.rs
@@ -1,6 +1,7 @@
 use crate::camera::Camera3d;
 use crate::event::WindowEvent;
 use crate::window::Canvas;
+use glamx::glam::camera::rh::proj::opengl;
 use glamx::{Mat4, Pose3, Vec3};
 use std::f32;
 
@@ -44,7 +45,7 @@ impl FixedView3d {
 
     fn update_projviews(&mut self) {
         let aspect = self.last_framebuffer_size.0 / self.last_framebuffer_size.1;
-        self.proj = Mat4::perspective_rh_gl(self.fov, aspect, self.znear, self.zfar);
+        self.proj = opengl::perspective(self.fov, aspect, self.znear, self.zfar);
         self.inv_proj = self.proj.inverse();
     }
 }

--- a/src/camera/orbit3d.rs
+++ b/src/camera/orbit3d.rs
@@ -2,6 +2,7 @@ use crate::camera::first_person3d::CoordSystemRh;
 use crate::camera::Camera3d;
 use crate::event::{Action, Key, Modifiers, MouseButton, WindowEvent};
 use crate::window::Canvas;
+use glamx::glam::camera::rh::proj::{directx, opengl};
 use glamx::{Mat4, Pose3, Vec2, Vec3};
 use std::f32;
 
@@ -457,7 +458,7 @@ impl OrbitCamera3d {
         let aspect = self.last_framebuffer_size.x / self.last_framebuffer_size.y;
         self.proj = match self.projection {
             super::Projection::Perspective => {
-                Mat4::perspective_rh_gl(self.fov, aspect, self.znear, self.zfar)
+                opengl::perspective(self.fov, aspect, self.znear, self.zfar)
             }
             super::Projection::Orthographic => {
                 // Derive the orthographic half-height from the orbit distance and
@@ -472,7 +473,7 @@ impl OrbitCamera3d {
                 // clipped — i.e. the whole scene vanishes. (Perspective gets away with
                 // `_rh_gl` only because its nonlinear depth keeps the visible scene in
                 // [0, 1] bar a thin near sliver.)
-                Mat4::orthographic_rh(-half_w, half_w, -half_h, half_h, self.znear, self.zfar)
+                directx::orthographic(-half_w, half_w, -half_h, half_h, self.znear, self.zfar)
             }
         };
         self.view = self.view_transform().to_mat4();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub mod color;
 pub mod context;
 pub mod event;
 pub mod light;
+pub mod light2d;
 pub mod loader;
 pub mod post_processing;
 pub mod procedural;
@@ -146,6 +147,7 @@ pub mod prelude {
     pub use crate::context::*;
     pub use crate::event::*;
     pub use crate::light::*;
+    pub use crate::light2d::*;
     pub use crate::loader::*;
     pub use crate::renderer::*;
     pub use crate::resource::*;

--- a/src/light2d.rs
+++ b/src/light2d.rs
@@ -1,0 +1,179 @@
+//! Dynamic lights for 2D scenes.
+//!
+//! 2D lights illuminate objects drawn with
+//! [`LitMaterial2d`](crate::builtin::LitMaterial2d). A light lives slightly *above*
+//! the 2D plane (its [`height`](Light2d::height)), so a normal-mapped sprite reacts
+//! to it with diffuse and specular shading just like a 3D surface would. Without a
+//! normal map a sprite is treated as flat (facing the camera) and the light still
+//! contributes a smooth radial falloff.
+//!
+//! The active lights and ambient term are stored in a thread-local
+//! [`Light2dManager`]; populate it each frame before rendering a lit 2D scene.
+
+use crate::color::Color;
+use glamx::Vec2;
+use std::cell::RefCell;
+
+/// Maximum number of simultaneous 2D lights (the lit shader stores them in a
+/// fixed-size uniform array, so this is a hard cap).
+pub const MAX_LIGHTS_2D: usize = 16;
+
+/// The kind of 2D light source.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+pub enum Light2dKind {
+    /// Emits in all directions from its position.
+    #[default]
+    Point,
+    /// Emits a cone of light along [`Light2d::direction`], fading between the inner
+    /// and outer cone angles.
+    Spot,
+}
+
+/// A dynamic 2D light. Build one with [`Light2d::point`] or [`Light2d::spot`] and add
+/// it to the [`Light2dManager`].
+#[derive(Copy, Clone, Debug)]
+pub struct Light2d {
+    /// World-space position in the 2D plane.
+    pub position: Vec2,
+    /// Height above the plane. Larger values flatten the incidence angle (softer
+    /// normal-map shading); 0 puts the light in the plane.
+    pub height: f32,
+    /// Light color.
+    pub color: Color,
+    /// Luminous intensity multiplier.
+    pub intensity: f32,
+    /// Distance beyond which the light contributes nothing.
+    pub radius: f32,
+    /// Point vs. spot.
+    pub kind: Light2dKind,
+    /// Spot direction in the plane (normalized internally); ignored for point lights.
+    pub direction: Vec2,
+    /// Spot inner cone half-angle (radians): full intensity within it.
+    pub inner_angle: f32,
+    /// Spot outer cone half-angle (radians): intensity reaches zero at it.
+    pub outer_angle: f32,
+}
+
+impl Default for Light2d {
+    fn default() -> Self {
+        Light2d {
+            position: Vec2::ZERO,
+            height: 60.0,
+            color: Color::new(1.0, 1.0, 1.0, 1.0),
+            intensity: 1.0,
+            radius: 300.0,
+            kind: Light2dKind::Point,
+            direction: Vec2::new(0.0, -1.0),
+            inner_angle: 0.3,
+            outer_angle: 0.6,
+        }
+    }
+}
+
+impl Light2d {
+    /// A point light at `position` with the given `color`, `intensity` and falloff `radius`.
+    pub fn point(position: Vec2, color: Color, intensity: f32, radius: f32) -> Self {
+        Light2d {
+            position,
+            color,
+            intensity,
+            radius,
+            kind: Light2dKind::Point,
+            ..Default::default()
+        }
+    }
+
+    /// A spot light at `position` aimed along `direction`, fading between the
+    /// `inner` and `outer` cone half-angles (radians).
+    pub fn spot(
+        position: Vec2,
+        direction: Vec2,
+        color: Color,
+        intensity: f32,
+        radius: f32,
+        inner: f32,
+        outer: f32,
+    ) -> Self {
+        Light2d {
+            position,
+            direction,
+            color,
+            intensity,
+            radius,
+            kind: Light2dKind::Spot,
+            inner_angle: inner,
+            outer_angle: outer,
+            ..Default::default()
+        }
+    }
+
+    /// Sets the light's height above the plane.
+    pub fn with_height(mut self, height: f32) -> Self {
+        self.height = height;
+        self
+    }
+}
+
+/// Thread-local store of the active 2D lights and ambient term, consumed each frame
+/// by [`LitMaterial2d`](crate::builtin::LitMaterial2d).
+pub struct Light2dManager {
+    lights: Vec<Light2d>,
+    ambient: Color,
+}
+
+thread_local!(static KEY_LIGHT2D_MANAGER: RefCell<Light2dManager> = RefCell::new(Light2dManager::new()));
+
+impl Default for Light2dManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Light2dManager {
+    /// Creates an empty manager with a dim default ambient.
+    pub fn new() -> Self {
+        Light2dManager {
+            lights: Vec::new(),
+            ambient: Color::new(0.1, 0.1, 0.1, 1.0),
+        }
+    }
+
+    /// Runs `f` with the global 2D-light manager.
+    pub fn get_global_manager<T, F: FnMut(&mut Light2dManager) -> T>(mut f: F) -> T {
+        KEY_LIGHT2D_MANAGER.with(|m| f(&mut m.borrow_mut()))
+    }
+
+    /// Replaces the active lights (truncated to [`MAX_LIGHTS_2D`]).
+    pub fn set_lights(&mut self, lights: &[Light2d]) {
+        self.lights.clear();
+        self.lights
+            .extend(lights.iter().take(MAX_LIGHTS_2D).copied());
+    }
+
+    /// Adds one light (ignored once [`MAX_LIGHTS_2D`] is reached).
+    pub fn push(&mut self, light: Light2d) {
+        if self.lights.len() < MAX_LIGHTS_2D {
+            self.lights.push(light);
+        }
+    }
+
+    /// Removes all lights.
+    pub fn clear(&mut self) {
+        self.lights.clear();
+    }
+
+    /// The active lights.
+    pub fn lights(&self) -> &[Light2d] {
+        &self.lights
+    }
+
+    /// Sets the scene-wide ambient color (applied to every lit object).
+    pub fn set_ambient(&mut self, ambient: Color) {
+        self.ambient = ambient;
+    }
+
+    /// The scene-wide ambient color.
+    pub fn ambient(&self) -> Color {
+        self.ambient
+    }
+}

--- a/src/post_processing/crt.rs
+++ b/src/post_processing/crt.rs
@@ -1,0 +1,291 @@
+//! A CRT stylization post-process: screen curvature, chromatic aberration,
+//! scanlines and a vignette — a classic retro look for 2D scenes.
+
+use crate::context::Context;
+use crate::post_processing::post_processing_effect::{PostProcessingContext, PostProcessingEffect};
+use crate::resource::RenderTarget;
+use bytemuck::{Pod, Zeroable};
+
+/// Vertex data for the full-screen quad.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct QuadVertex {
+    position: [f32; 2],
+}
+
+/// Uniforms mirroring `CrtUniforms` in `crt.wgsl`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct CrtUniforms {
+    curvature: f32,
+    aberration: f32,
+    scanline_intensity: f32,
+    scanline_count: f32,
+    vignette: f32,
+    _pad: [f32; 3],
+}
+
+/// A CRT-television stylization effect: barrel-distorted screen curvature,
+/// chromatic aberration, scanlines and a vignette.
+///
+/// Each term is independently adjustable and disabled by setting its strength to 0.
+/// Apply it to a 2D scene with
+/// [`Window::render_2d_with`](crate::window::Window::render_2d_with).
+///
+/// ```no_run
+/// # use kiss3d::post_processing::Crt;
+/// let mut crt = Crt::new();
+/// crt.set_curvature(0.15);
+/// crt.set_scanlines(0.3, 480.0);
+/// ```
+pub struct Crt {
+    pipeline: wgpu::RenderPipeline,
+    texture_bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buffer: wgpu::Buffer,
+    uniform_bind_group: wgpu::BindGroup,
+    vertex_buffer: wgpu::Buffer,
+    uniforms: CrtUniforms,
+}
+
+impl Default for Crt {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Crt {
+    /// Creates a CRT effect with moderate, all-on default settings.
+    pub fn new() -> Crt {
+        let ctxt = Context::get();
+
+        let texture_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("crt_texture_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let uniform_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("crt_uniform_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        let pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("crt_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&texture_bind_group_layout),
+                Some(&uniform_bind_group_layout),
+            ],
+            immediate_size: 0,
+        });
+
+        let shader = ctxt.create_shader_module(
+            Some("crt_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::crt",
+                include_str!("../builtin/crt.wgsl"),
+            ),
+        );
+
+        let vertex_buffer_layout = wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<QuadVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[wgpu::VertexAttribute {
+                offset: 0,
+                shader_location: 0,
+                format: wgpu::VertexFormat::Float32x2,
+            }],
+        };
+
+        let pipeline = ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("crt_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[vertex_buffer_layout],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: ctxt.surface_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let vertices = [
+            QuadVertex {
+                position: [-1.0, -1.0],
+            },
+            QuadVertex {
+                position: [1.0, -1.0],
+            },
+            QuadVertex {
+                position: [-1.0, 1.0],
+            },
+            QuadVertex {
+                position: [1.0, 1.0],
+            },
+        ];
+        let vertex_buffer = ctxt.create_buffer_init(
+            Some("crt_vertex_buffer"),
+            bytemuck::cast_slice(&vertices),
+            wgpu::BufferUsages::VERTEX,
+        );
+
+        let uniform_buffer = ctxt.create_buffer_simple(
+            Some("crt_uniform_buffer"),
+            std::mem::size_of::<CrtUniforms>() as u64,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        );
+        let uniform_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("crt_uniform_bind_group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        Crt {
+            pipeline,
+            texture_bind_group_layout,
+            uniform_buffer,
+            uniform_bind_group,
+            vertex_buffer,
+            uniforms: CrtUniforms {
+                curvature: 0.12,
+                aberration: 0.004,
+                scanline_intensity: 0.25,
+                scanline_count: 480.0,
+                vignette: 0.35,
+                _pad: [0.0; 3],
+            },
+        }
+    }
+
+    /// Sets the screen-curvature (barrel-distortion) strength; 0 disables it.
+    pub fn set_curvature(&mut self, curvature: f32) {
+        self.uniforms.curvature = curvature;
+    }
+
+    /// Sets the chromatic-aberration strength (UV offset at the screen edge); 0 disables it.
+    pub fn set_aberration(&mut self, aberration: f32) {
+        self.uniforms.aberration = aberration;
+    }
+
+    /// Sets the scanline darkening `intensity` (`[0, 1]`) and the number of scanlines
+    /// down the screen. An intensity of 0 disables scanlines.
+    pub fn set_scanlines(&mut self, intensity: f32, count: f32) {
+        self.uniforms.scanline_intensity = intensity;
+        self.uniforms.scanline_count = count;
+    }
+
+    /// Sets the vignette strength (`[0, 1]`); 0 disables it.
+    pub fn set_vignette(&mut self, vignette: f32) {
+        self.uniforms.vignette = vignette;
+    }
+}
+
+impl PostProcessingEffect for Crt {
+    fn update(&mut self, _dt: f32, _w: f32, _h: f32, _znear: f32, _zfar: f32) {}
+
+    fn draw(&mut self, target: &RenderTarget, context: &mut PostProcessingContext) {
+        let ctxt = Context::get();
+
+        let (color_view, sampler) = match target {
+            RenderTarget::Offscreen(o) => (&o.color_view, &o.sampler),
+            RenderTarget::Screen => return,
+        };
+
+        ctxt.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&self.uniforms));
+
+        let texture_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("crt_texture_bind_group"),
+            layout: &self.texture_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(color_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+        });
+
+        let mut render_pass = context
+            .encoder
+            .begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("crt_render_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: context.output_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &texture_bind_group, &[]);
+        render_pass.set_bind_group(1, &self.uniform_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        render_pass.draw(0..4, 0..1);
+    }
+}

--- a/src/post_processing/gi2d.rs
+++ b/src/post_processing/gi2d.rs
@@ -1,0 +1,1220 @@
+//! Screen-space 2D global illumination ([`Gi2d`]).
+//!
+//! A post-processing effect that lights the scene by ray-marching incoming light
+//! against analytic emitter/occluder discs, giving soft shadows and colored light
+//! bleed. This is the brute-force form of the technique that *radiance cascades*
+//! accelerate.
+//!
+//! To stay real-time it runs in two passes with three optimizations:
+//! 1. the irradiance field is computed at a fraction of screen resolution
+//!    ([`set_resolution_scale`](Gi2d::set_resolution_scale)) and bilinearly upsampled
+//!    when composited — GI is low-frequency, so the quality cost is small;
+//! 2. **temporal accumulation** ([`set_temporal_blend`](Gi2d::set_temporal_blend)):
+//!    the ray fan is rotated each frame and blended with the reprojected previous
+//!    frame, so a handful of rays converge to a smooth result;
+//! 3. a **blue-noise-jittered**, distance-capped, step-capped march
+//!    ([`set_rays`](Gi2d::set_rays), [`set_max_distance`](Gi2d::set_max_distance),
+//!    [`set_max_steps`](Gi2d::set_max_steps)).
+//!
+//! Optionally ([`set_sdf_occluders`](Gi2d::set_sdf_occluders)) the occluders are
+//! baked into a distance field each frame with the **jump-flood algorithm**, so the
+//! march costs one texture fetch per step regardless of occluder count (vs. a loop
+//! over every disc). This is screen-space — occluders outside the view don't cast
+//! shadows — so it's best with many on-screen occluders; the default analytic path
+//! stays global.
+//!
+//! Apply it with [`Window::render_2d_with`](crate::window::Window::render_2d_with) or
+//! in a chain; each frame set the camera and the emitters/occluders.
+
+use crate::camera::Camera2d;
+use crate::color::Color;
+use crate::context::Context;
+use crate::post_processing::post_processing_effect::{PostProcessingContext, PostProcessingEffect};
+use crate::post_processing::HDR_FORMAT;
+use crate::resource::RenderTarget;
+use bytemuck::{Pod, Zeroable};
+use glamx::{Mat3, Vec2};
+
+/// Maximum number of emitter discs (matches `MAX_EMITTERS` in `gi2d_field.wgsl`).
+pub const MAX_EMITTERS: usize = 32;
+/// Maximum number of occluder discs (matches `MAX_OCCLUDERS` in `gi2d_field.wgsl`).
+pub const MAX_OCCLUDERS: usize = 64;
+
+const SEED_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba32Float;
+const SDF_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::R16Float;
+
+/// A disc that emits light into the 2D GI solution.
+#[derive(Copy, Clone, Debug)]
+pub struct GiEmitter2d {
+    /// World-space center.
+    pub position: Vec2,
+    /// Disc radius (its size as an area light).
+    pub radius: f32,
+    /// Emitted color.
+    pub color: Color,
+    /// Radiance multiplier.
+    pub intensity: f32,
+}
+
+impl GiEmitter2d {
+    /// A new emitter disc.
+    pub fn new(position: Vec2, radius: f32, color: Color, intensity: f32) -> Self {
+        GiEmitter2d {
+            position,
+            radius,
+            color,
+            intensity,
+        }
+    }
+}
+
+/// A disc that blocks light (casts shadows) in the 2D GI solution.
+#[derive(Copy, Clone, Debug)]
+pub struct GiOccluder2d {
+    /// World-space center.
+    pub position: Vec2,
+    /// Disc radius.
+    pub radius: f32,
+}
+
+impl GiOccluder2d {
+    /// A new occluder disc.
+    pub fn new(position: Vec2, radius: f32) -> Self {
+        GiOccluder2d { position, radius }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct GpuEmitter {
+    pos_radius: [f32; 4],
+    color: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct GpuOccluder {
+    pos_radius: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct FieldUniforms {
+    inv_vp: [[f32; 4]; 3],
+    prev_vp: [[f32; 4]; 3],
+    cur_vp: [[f32; 4]; 3],
+    params: [f32; 4],
+    flags: [f32; 4],
+    counts: [f32; 4],
+    emitters: [GpuEmitter; MAX_EMITTERS],
+    occluders: [GpuOccluder; MAX_OCCLUDERS],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct JfaUniforms {
+    inv_vp: [[f32; 4]; 3],
+    aux: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct CompositeUniforms {
+    ambient: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct CascadeParams {
+    v0: [f32; 4],
+    v1: [f32; 4],
+    v2: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct CascadeCompositeUniforms {
+    v0: [f32; 4],
+    v1: [f32; 4],
+    ambient: [f32; 4],
+}
+
+/// Maximum number of radiance-cascade levels (sizes the per-level uniform pool).
+const MAX_CASCADES: usize = 8;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct QuadVertex {
+    position: [f32; 2],
+}
+
+fn mat3_to_padded(m: &Mat3) -> [[f32; 4]; 3] {
+    let c = m.to_cols_array_2d();
+    [
+        [c[0][0], c[0][1], c[0][2], 0.0],
+        [c[1][0], c[1][1], c[1][2], 0.0],
+        [c[2][0], c[2][1], c[2][2], 0.0],
+    ]
+}
+
+/// A render-target + sampleable texture used for a GI buffer.
+struct GiTexture {
+    view: wgpu::TextureView,
+}
+
+impl GiTexture {
+    fn new(width: u32, height: u32, format: wgpu::TextureFormat) -> Self {
+        let ctxt = Context::get();
+        let texture = ctxt.create_texture(&wgpu::TextureDescriptor {
+            label: Some("gi2d_texture"),
+            size: wgpu::Extent3d {
+                width: width.max(1),
+                height: height.max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        GiTexture {
+            view: texture.create_view(&wgpu::TextureViewDescriptor::default()),
+        }
+    }
+}
+
+/// Screen-space 2D global-illumination post-processing effect (see the [module docs](self)).
+pub struct Gi2d {
+    field_pipeline: wgpu::RenderPipeline,
+    composite_pipeline: wgpu::RenderPipeline,
+    jfa_seed_pipeline: wgpu::RenderPipeline,
+    jfa_step_pipeline: wgpu::RenderPipeline,
+    jfa_resolve_pipeline: wgpu::RenderPipeline,
+    tex_bind_group_layout: wgpu::BindGroupLayout,
+    tex_only_bind_group_layout: wgpu::BindGroupLayout,
+    uniform_bind_group_layout: wgpu::BindGroupLayout,
+    field_uniform_buffer: wgpu::Buffer,
+    field_uniform_bind_group: wgpu::BindGroup,
+    composite_uniform_buffer: wgpu::Buffer,
+    composite_uniform_bind_group: wgpu::BindGroup,
+    sampler: wgpu::Sampler,
+    vertex_buffer: wgpu::Buffer,
+
+    // Ping-pong GI history textures (low resolution).
+    history: [GiTexture; 2],
+    cur: usize,
+    gi_size: (u32, u32),
+    history_valid: bool,
+    frame_index: u32,
+
+    // Jump-flood occluder SDF resources (low resolution).
+    seed: [GiTexture; 2],
+    sdf: GiTexture,
+    jfa_step_buffers: Vec<wgpu::Buffer>,
+    jfa_step_bind_groups: Vec<wgpu::BindGroup>,
+    jfa_resolve_buffer: wgpu::Buffer,
+    jfa_resolve_bind_group: wgpu::BindGroup,
+    jfa_passes: u32,
+
+    // Radiance-cascade resources.
+    cascade_pipeline: wgpu::RenderPipeline,
+    cascade_composite_pipeline: wgpu::RenderPipeline,
+    cascade: [GiTexture; 2],
+    /// Current allocated size of the (decoupled) cascade textures.
+    cascade_tex_size: (u32, u32),
+    cascade_param_buffers: Vec<wgpu::Buffer>,
+    cascade_param_bind_groups: Vec<wgpu::BindGroup>,
+    cascade_composite_buffer: wgpu::Buffer,
+    cascade_composite_bind_group: wgpu::BindGroup,
+    radiance_cascades: bool,
+    cascade_count: u32,
+    /// Cascade-0 direction-tile edge: base direction count is `base_block^2`. Larger →
+    /// finer angular resolution → sharper shadow contours. Decoupled from probe spacing.
+    base_block: u32,
+    /// Cascade-0 probe spacing in field pixels (independent of `base_block`).
+    probe_spacing: u32,
+
+    // Parameters.
+    inv_vp: Mat3,
+    vp: Mat3,
+    prev_vp: Mat3,
+    ambient: Color,
+    num_rays: u32,
+    max_distance: f32,
+    max_steps: u32,
+    resolution_scale: u32,
+    temporal_blend: f32,
+    sdf_occluders: bool,
+    emitters: Vec<GiEmitter2d>,
+    occluders: Vec<GiOccluder2d>,
+}
+
+impl Default for Gi2d {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Gi2d {
+    /// Creates a new GI effect with real-time defaults: half-resolution field, 8 rays
+    /// per pixel, temporal accumulation, analytic (global) occluders.
+    pub fn new() -> Gi2d {
+        let ctxt = Context::get();
+
+        let tex_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("gi2d_tex_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        // Texture-only layout for the jump-flood seed reads (sampled via textureLoad,
+        // so the unfilterable Rgba32Float seed needs no sampler).
+        let tex_only_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("gi2d_tex_only_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                }],
+            });
+
+        let uniform_bind_group_layout =
+            ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("gi2d_uniform_bind_group_layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        let field_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gi2d_field_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&tex_bind_group_layout),
+                Some(&uniform_bind_group_layout),
+                Some(&tex_bind_group_layout),
+            ],
+            immediate_size: 0,
+        });
+        let composite_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gi2d_composite_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&tex_bind_group_layout),
+                Some(&tex_bind_group_layout),
+                Some(&uniform_bind_group_layout),
+            ],
+            immediate_size: 0,
+        });
+        let jfa_seed_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gi2d_jfa_seed_pipeline_layout"),
+            bind_group_layouts: &[Some(&uniform_bind_group_layout)],
+            immediate_size: 0,
+        });
+        let jfa_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gi2d_jfa_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&tex_only_bind_group_layout),
+                Some(&uniform_bind_group_layout),
+            ],
+            immediate_size: 0,
+        });
+
+        let field_shader = ctxt.create_shader_module(
+            Some("gi2d_field_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::gi2d_field",
+                include_str!("../builtin/gi2d_field.wgsl"),
+            ),
+        );
+        let composite_shader = ctxt.create_shader_module(
+            Some("gi2d_composite_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::gi2d_composite",
+                include_str!("../builtin/gi2d_composite.wgsl"),
+            ),
+        );
+        let jfa_seed_shader = ctxt.create_shader_module(
+            Some("gi2d_jfa_seed_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::gi2d_jfa_seed",
+                include_str!("../builtin/gi2d_jfa_seed.wgsl"),
+            ),
+        );
+        let jfa_shader = ctxt.create_shader_module(
+            Some("gi2d_jfa_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::gi2d_jfa",
+                include_str!("../builtin/gi2d_jfa.wgsl"),
+            ),
+        );
+
+        let vertex_buffer_layout = wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<QuadVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[wgpu::VertexAttribute {
+                offset: 0,
+                shader_location: 0,
+                format: wgpu::VertexFormat::Float32x2,
+            }],
+        };
+
+        let make_pipeline = |label: &str,
+                             layout: &wgpu::PipelineLayout,
+                             shader: &wgpu::ShaderModule,
+                             fs_entry: &str,
+                             format: wgpu::TextureFormat| {
+            ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(layout),
+                vertex: wgpu::VertexState {
+                    module: shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[vertex_buffer_layout.clone()],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: shader,
+                    entry_point: Some(fs_entry),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        let field_pipeline = make_pipeline(
+            "gi2d_field_pipeline",
+            &field_layout,
+            &field_shader,
+            "fs_main",
+            HDR_FORMAT,
+        );
+        let composite_pipeline = make_pipeline(
+            "gi2d_composite_pipeline",
+            &composite_layout,
+            &composite_shader,
+            "fs_main",
+            ctxt.surface_format,
+        );
+        let jfa_seed_pipeline = make_pipeline(
+            "gi2d_jfa_seed_pipeline",
+            &jfa_seed_layout,
+            &jfa_seed_shader,
+            "fs_main",
+            SEED_FORMAT,
+        );
+        let jfa_step_pipeline = make_pipeline(
+            "gi2d_jfa_step_pipeline",
+            &jfa_layout,
+            &jfa_shader,
+            "fs_step",
+            SEED_FORMAT,
+        );
+        let jfa_resolve_pipeline = make_pipeline(
+            "gi2d_jfa_resolve_pipeline",
+            &jfa_layout,
+            &jfa_shader,
+            "fs_resolve",
+            SDF_FORMAT,
+        );
+
+        // Radiance-cascade pipelines.
+        let cascade_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gi2d_cascade_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&tex_only_bind_group_layout), // upper cascade (textureLoad)
+                Some(&uniform_bind_group_layout),  // per-cascade params
+                Some(&uniform_bind_group_layout),  // shared field uniforms (scene)
+                Some(&tex_bind_group_layout),      // occluder SDF (when enabled)
+            ],
+            immediate_size: 0,
+        });
+        let cascade_composite_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("gi2d_cascade_composite_pipeline_layout"),
+            bind_group_layouts: &[
+                Some(&tex_bind_group_layout),      // scene
+                Some(&tex_only_bind_group_layout), // cascade 0 (textureLoad)
+                Some(&uniform_bind_group_layout),  // composite uniforms
+            ],
+            immediate_size: 0,
+        });
+        let cascade_shader = ctxt.create_shader_module(
+            Some("gi2d_cascade_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::gi2d_cascade",
+                include_str!("../builtin/gi2d_cascade.wgsl"),
+            ),
+        );
+        let cascade_composite_shader = ctxt.create_shader_module(
+            Some("gi2d_cascade_composite_shader"),
+            &crate::builtin::compile_shader_with_common(
+                "package::gi2d_cascade_composite",
+                include_str!("../builtin/gi2d_cascade_composite.wgsl"),
+            ),
+        );
+        let cascade_pipeline = make_pipeline(
+            "gi2d_cascade_pipeline",
+            &cascade_layout,
+            &cascade_shader,
+            "fs_main",
+            HDR_FORMAT,
+        );
+        let cascade_composite_pipeline = make_pipeline(
+            "gi2d_cascade_composite_pipeline",
+            &cascade_composite_layout,
+            &cascade_composite_shader,
+            "fs_main",
+            ctxt.surface_format,
+        );
+
+        // Per-level cascade uniform pool (filled each frame for the levels in use).
+        let mut cascade_param_buffers = Vec::with_capacity(MAX_CASCADES);
+        let mut cascade_param_bind_groups = Vec::with_capacity(MAX_CASCADES);
+        for _ in 0..MAX_CASCADES {
+            let buf = ctxt.create_buffer_simple(
+                Some("gi2d_cascade_param_buffer"),
+                std::mem::size_of::<CascadeParams>() as u64,
+                wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            );
+            let bg = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("gi2d_cascade_param_bind_group"),
+                layout: &uniform_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buf.as_entire_binding(),
+                }],
+            });
+            cascade_param_buffers.push(buf);
+            cascade_param_bind_groups.push(bg);
+        }
+        let cascade_composite_buffer = ctxt.create_buffer_simple(
+            Some("gi2d_cascade_composite_buffer"),
+            std::mem::size_of::<CascadeCompositeUniforms>() as u64,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        );
+        let cascade_composite_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_cascade_composite_bind_group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: cascade_composite_buffer.as_entire_binding(),
+            }],
+        });
+
+        let vertices = [
+            QuadVertex {
+                position: [-1.0, -1.0],
+            },
+            QuadVertex {
+                position: [1.0, -1.0],
+            },
+            QuadVertex {
+                position: [-1.0, 1.0],
+            },
+            QuadVertex {
+                position: [1.0, 1.0],
+            },
+        ];
+        let vertex_buffer = ctxt.create_buffer_init(
+            Some("gi2d_vertex_buffer"),
+            bytemuck::cast_slice(&vertices),
+            wgpu::BufferUsages::VERTEX,
+        );
+
+        let field_uniform_buffer = ctxt.create_buffer_simple(
+            Some("gi2d_field_uniform_buffer"),
+            std::mem::size_of::<FieldUniforms>() as u64,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        );
+        let field_uniform_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_field_uniform_bind_group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: field_uniform_buffer.as_entire_binding(),
+            }],
+        });
+        let composite_uniform_buffer = ctxt.create_buffer_simple(
+            Some("gi2d_composite_uniform_buffer"),
+            std::mem::size_of::<CompositeUniforms>() as u64,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        );
+        let composite_uniform_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_composite_uniform_bind_group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: composite_uniform_buffer.as_entire_binding(),
+            }],
+        });
+        // Resolve uses one fixed uniform buffer (step is unused for the resolve pass).
+        let jfa_resolve_buffer = ctxt.create_buffer_simple(
+            Some("gi2d_jfa_resolve_buffer"),
+            std::mem::size_of::<JfaUniforms>() as u64,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        );
+        let jfa_resolve_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_jfa_resolve_bind_group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: jfa_resolve_buffer.as_entire_binding(),
+            }],
+        });
+
+        let sampler = ctxt.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("gi2d_sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
+        });
+
+        Gi2d {
+            field_pipeline,
+            composite_pipeline,
+            jfa_seed_pipeline,
+            jfa_step_pipeline,
+            jfa_resolve_pipeline,
+            tex_bind_group_layout,
+            tex_only_bind_group_layout,
+            uniform_bind_group_layout,
+            field_uniform_buffer,
+            field_uniform_bind_group,
+            composite_uniform_buffer,
+            composite_uniform_bind_group,
+            sampler,
+            vertex_buffer,
+            history: [
+                GiTexture::new(1, 1, HDR_FORMAT),
+                GiTexture::new(1, 1, HDR_FORMAT),
+            ],
+            cur: 0,
+            gi_size: (0, 0),
+            history_valid: false,
+            frame_index: 0,
+            seed: [
+                GiTexture::new(1, 1, SEED_FORMAT),
+                GiTexture::new(1, 1, SEED_FORMAT),
+            ],
+            sdf: GiTexture::new(1, 1, SDF_FORMAT),
+            jfa_step_buffers: Vec::new(),
+            jfa_step_bind_groups: Vec::new(),
+            jfa_resolve_buffer,
+            jfa_resolve_bind_group,
+            jfa_passes: 0,
+            cascade_pipeline,
+            cascade_composite_pipeline,
+            cascade: [
+                GiTexture::new(1, 1, HDR_FORMAT),
+                GiTexture::new(1, 1, HDR_FORMAT),
+            ],
+            cascade_tex_size: (0, 0),
+            cascade_param_buffers,
+            cascade_param_bind_groups,
+            cascade_composite_buffer,
+            cascade_composite_bind_group,
+            radiance_cascades: false,
+            cascade_count: 5,
+            // 16 base directions (4x4 tile) with a fine 2px probe grid — decoupled, so
+            // sharp shadow edges without coarsening the probe grid (the cascade
+            // textures grow by base_block/probe_spacing in each axis instead).
+            base_block: 4,
+            probe_spacing: 2,
+            inv_vp: Mat3::IDENTITY,
+            vp: Mat3::IDENTITY,
+            prev_vp: Mat3::IDENTITY,
+            ambient: Color::new(0.08, 0.08, 0.1, 1.0),
+            num_rays: 8,
+            max_distance: 2000.0,
+            max_steps: 32,
+            resolution_scale: 2,
+            temporal_blend: 0.85,
+            sdf_occluders: false,
+            emitters: Vec::new(),
+            occluders: Vec::new(),
+        }
+    }
+
+    /// Captures `camera`'s view-projection so the GI pass can reconstruct world space
+    /// and reproject the temporal history. Call once per frame before rendering.
+    pub fn set_camera(&mut self, camera: &impl Camera2d) {
+        let (view, proj) = camera.view_transform_pair();
+        self.vp = proj * view;
+        self.inv_vp = self.vp.inverse();
+    }
+
+    /// Replaces the emitter discs (truncated to [`MAX_EMITTERS`]).
+    pub fn set_emitters(&mut self, emitters: &[GiEmitter2d]) {
+        self.emitters.clear();
+        self.emitters
+            .extend(emitters.iter().take(MAX_EMITTERS).copied());
+    }
+
+    /// Replaces the occluder discs (truncated to [`MAX_OCCLUDERS`]).
+    pub fn set_occluders(&mut self, occluders: &[GiOccluder2d]) {
+        self.occluders.clear();
+        self.occluders
+            .extend(occluders.iter().take(MAX_OCCLUDERS).copied());
+    }
+
+    /// Sets the scene-wide ambient term applied where no light reaches.
+    pub fn set_ambient(&mut self, ambient: Color) {
+        self.ambient = ambient;
+    }
+
+    /// Sets the number of rays cast per pixel *per frame*. With temporal accumulation
+    /// enabled the effective sample count is far higher, so this can stay small.
+    pub fn set_rays(&mut self, rays: u32) {
+        self.num_rays = rays.max(1);
+    }
+
+    /// Sets the maximum ray-march distance in world units (cap it to the scene bounds).
+    pub fn set_max_distance(&mut self, distance: f32) {
+        self.max_distance = distance;
+    }
+
+    /// Sets the maximum number of sphere-trace steps per ray.
+    pub fn set_max_steps(&mut self, steps: u32) {
+        self.max_steps = steps.max(1);
+    }
+
+    /// Sets the irradiance-field downscale factor: 1 = full resolution, 2 = half (the
+    /// default), 4 = quarter, … Larger is faster and softer. Changing it rebuilds the
+    /// field textures.
+    pub fn set_resolution_scale(&mut self, scale: u32) {
+        self.resolution_scale = scale.max(1);
+    }
+
+    /// Sets the temporal-accumulation blend (fraction of the reprojected previous
+    /// frame kept each frame), in `[0, 1)`. 0 disables accumulation; higher is
+    /// smoother but ghosts more on fast motion. Default 0.85.
+    pub fn set_temporal_blend(&mut self, blend: f32) {
+        self.temporal_blend = blend.clamp(0.0, 0.99);
+    }
+
+    /// Switches the solver to **radiance cascades**: instead of marching long rays
+    /// per pixel, light is gathered into a hierarchy of probe grids (coarser probes
+    /// with more directions and longer rays per level) and merged top-down into a
+    /// final irradiance, which is far cheaper for the same coverage. Off by default
+    /// (the direct ray-march). Temporal accumulation is unused on this path.
+    pub fn set_radiance_cascades(&mut self, enabled: bool) {
+        self.radiance_cascades = enabled;
+    }
+
+    /// Sets the number of radiance-cascade levels (clamped to what the field
+    /// resolution supports). More levels reach farther light. Default 5.
+    pub fn set_cascade_count(&mut self, count: u32) {
+        self.cascade_count = count.clamp(1, MAX_CASCADES as u32);
+    }
+
+    /// Sets the cascade-0 base direction count (radiance cascades only), rounded to a
+    /// supported value. More directions sharpen shadow contours; the probe grid stays
+    /// fine (the cascade textures grow instead). Default 16; typical values 4 / 16 / 64.
+    pub fn set_cascade_base_directions(&mut self, directions: u32) {
+        let edge = (directions as f32).sqrt().round() as u32;
+        self.base_block = edge.max(2).next_power_of_two();
+    }
+
+    /// Enables baking occluders into a jump-flooded distance field each frame so the
+    /// march cost is independent of occluder count (one texture fetch per step). This
+    /// is screen-space — off-screen occluders cast no shadows. Off by default (the
+    /// analytic, global per-disc path). See the [module docs](self).
+    pub fn set_sdf_occluders(&mut self, enabled: bool) {
+        self.sdf_occluders = enabled;
+    }
+
+    /// (Re)creates the per-size textures and jump-flood pass buffers, resetting
+    /// temporal history when the size changes.
+    fn ensure_textures(&mut self, width: u32, height: u32) {
+        let cw = (width / self.resolution_scale).max(1);
+        let ch = (height / self.resolution_scale).max(1);
+        if self.gi_size == (cw, ch) {
+            return;
+        }
+        let ctxt = Context::get();
+
+        self.history = [
+            GiTexture::new(cw, ch, HDR_FORMAT),
+            GiTexture::new(cw, ch, HDR_FORMAT),
+        ];
+        self.seed = [
+            GiTexture::new(cw, ch, SEED_FORMAT),
+            GiTexture::new(cw, ch, SEED_FORMAT),
+        ];
+        self.sdf = GiTexture::new(cw, ch, SDF_FORMAT);
+        self.gi_size = (cw, ch);
+        self.history_valid = false;
+        self.cur = 0;
+
+        // One jump-flood pass per halving step, down to step 1.
+        let maxdim = cw.max(ch);
+        let passes = (32 - (maxdim.max(1) - 1).leading_zeros()).max(1); // ceil(log2(maxdim))
+        self.jfa_passes = passes;
+        self.jfa_step_buffers.clear();
+        self.jfa_step_bind_groups.clear();
+        for _ in 0..passes {
+            let buf = ctxt.create_buffer_simple(
+                Some("gi2d_jfa_step_buffer"),
+                std::mem::size_of::<JfaUniforms>() as u64,
+                wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            );
+            let bg = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("gi2d_jfa_step_bind_group"),
+                layout: &self.uniform_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buf.as_entire_binding(),
+                }],
+            });
+            self.jfa_step_buffers.push(buf);
+            self.jfa_step_bind_groups.push(bg);
+        }
+    }
+
+    fn build_field_uniforms(&self) -> FieldUniforms {
+        let mut emitters = [GpuEmitter::zeroed(); MAX_EMITTERS];
+        for (slot, e) in emitters.iter_mut().zip(self.emitters.iter()) {
+            slot.pos_radius = [e.position.x, e.position.y, e.radius, e.intensity];
+            slot.color = [e.color.r, e.color.g, e.color.b, 0.0];
+        }
+        let mut occluders = [GpuOccluder::zeroed(); MAX_OCCLUDERS];
+        for (slot, o) in occluders.iter_mut().zip(self.occluders.iter()) {
+            slot.pos_radius = [o.position.x, o.position.y, o.radius, 0.0];
+        }
+        FieldUniforms {
+            inv_vp: mat3_to_padded(&self.inv_vp),
+            prev_vp: mat3_to_padded(&self.prev_vp),
+            cur_vp: mat3_to_padded(&self.vp),
+            params: [
+                self.num_rays as f32,
+                (self.frame_index % 4096) as f32,
+                self.temporal_blend,
+                if self.history_valid { 1.0 } else { 0.0 },
+            ],
+            // flags: use_sdf, sdf_bias (world units ≈ a couple field texels). The
+            // jump-flood field is unsigned (0 inside occluders), so we shift its
+            // zero-crossing slightly outside the true surface — making it
+            // effectively signed near the boundary so the march's `d <= 0` blocked
+            // test fires reliably instead of letting grazing rays tunnel through.
+            flags: [
+                if self.sdf_occluders { 1.0 } else { 0.0 },
+                {
+                    let cw = self.gi_size.0.max(1) as f32;
+                    let wpp = (2.0 / cw) / self.vp.x_axis.x.abs().max(1e-6);
+                    wpp * 2.0
+                },
+                0.0,
+                0.0,
+            ],
+            counts: [
+                self.emitters.len().min(MAX_EMITTERS) as f32,
+                self.occluders.len().min(MAX_OCCLUDERS) as f32,
+                self.max_distance,
+                self.max_steps as f32,
+            ],
+            emitters,
+            occluders,
+        }
+    }
+
+    fn tex_bind_group(&self, view: &wgpu::TextureView, label: &str) -> wgpu::BindGroup {
+        Context::get().create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(label),
+            layout: &self.tex_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+        })
+    }
+
+    fn tex_only_bind_group(&self, view: &wgpu::TextureView) -> wgpu::BindGroup {
+        Context::get().create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_seed_bind_group"),
+            layout: &self.tex_only_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(view),
+            }],
+        })
+    }
+
+    fn fullscreen_pass(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        label: &str,
+        target: &wgpu::TextureView,
+        pipeline: &wgpu::RenderPipeline,
+        bind_groups: &[&wgpu::BindGroup],
+    ) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some(label),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        for (i, bg) in bind_groups.iter().enumerate() {
+            pass.set_bind_group(i as u32, *bg, &[]);
+        }
+        pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        pass.draw(0..4, 0..1);
+    }
+
+    /// Bakes the occluder distance field for this frame (seed → jump-flood → resolve).
+    fn build_sdf(&mut self, encoder: &mut wgpu::CommandEncoder) {
+        let ctxt = Context::get();
+        let (cw, ch) = self.gi_size;
+        let inv_vp = mat3_to_padded(&self.inv_vp);
+
+        // Update the per-pass JFA uniforms (inv_vp + halving step + field size).
+        for (k, buf) in self.jfa_step_buffers.iter().enumerate() {
+            let step = (1u32 << (self.jfa_passes - 1 - k as u32)) as f32;
+            let u = JfaUniforms {
+                inv_vp,
+                aux: [step, cw as f32, ch as f32, 0.0],
+            };
+            ctxt.write_buffer(buf, 0, bytemuck::bytes_of(&u));
+        }
+        let resolve_u = JfaUniforms {
+            inv_vp,
+            aux: [0.0, cw as f32, ch as f32, 0.0],
+        };
+        ctxt.write_buffer(&self.jfa_resolve_buffer, 0, bytemuck::bytes_of(&resolve_u));
+
+        // Seed pass (reuses the field uniform buffer for the occluder list) → seed[0].
+        self.fullscreen_pass(
+            encoder,
+            "gi2d_jfa_seed_pass",
+            &self.seed[0].view,
+            &self.jfa_seed_pipeline,
+            &[&self.field_uniform_bind_group],
+        );
+
+        // Jump-flood passes, ping-ponging the seed textures.
+        let mut src = 0usize;
+        for k in 0..self.jfa_passes as usize {
+            let dst = 1 - src;
+            let seed_bg = self.tex_only_bind_group(&self.seed[src].view);
+            self.fullscreen_pass(
+                encoder,
+                "gi2d_jfa_step_pass",
+                &self.seed[dst].view,
+                &self.jfa_step_pipeline,
+                &[&seed_bg, &self.jfa_step_bind_groups[k]],
+            );
+            src = dst;
+        }
+
+        // Resolve the final seeds into the scalar distance field.
+        let seed_bg = self.tex_only_bind_group(&self.seed[src].view);
+        self.fullscreen_pass(
+            encoder,
+            "gi2d_jfa_resolve_pass",
+            &self.sdf.view,
+            &self.jfa_resolve_pipeline,
+            &[&seed_bg, &self.jfa_resolve_bind_group],
+        );
+    }
+
+    /// (Re)creates the ping-pong cascade textures at the given (decoupled) size.
+    fn ensure_cascade_textures(&mut self, tw: u32, th: u32) {
+        if self.cascade_tex_size != (tw, th) {
+            self.cascade = [
+                GiTexture::new(tw, th, HDR_FORMAT),
+                GiTexture::new(tw, th, HDR_FORMAT),
+            ];
+            self.cascade_tex_size = (tw, th);
+        }
+    }
+
+    /// Builds the radiance-cascade hierarchy top-down and composites cascade 0's
+    /// irradiance over the scene into `output_view`.
+    fn render_cascades(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        output_view: &wgpu::TextureView,
+        scene_view: &wgpu::TextureView,
+        scene_sampler: &wgpu::Sampler,
+    ) {
+        let ctxt = Context::get();
+        let (cw, ch) = self.gi_size;
+        let e0 = self.base_block;
+        let s0 = self.probe_spacing;
+
+        // Decoupled layout: probe spacing `s` and direction-tile edge `e` are
+        // independent, so the cascade texture is (W·e0/s0) × (H·e0/s0) — wider than
+        // the field when there are more directions than the probe grid is fine.
+        let tw = (cw * e0 / s0).max(1);
+        let th = (ch * e0 / s0).max(1);
+        self.ensure_cascade_textures(tw, th);
+
+        // Bake the occluder distance field so the cascade march costs one fetch per
+        // step instead of looping every occluder (big win for many-occluder scenes).
+        if self.sdf_occluders {
+            self.build_sdf(encoder);
+        }
+
+        let mindim = cw.min(ch);
+        // Highest level whose probe spacing (s0 * 2^c) still fits the field.
+        let max_n = (32 - (mindim / s0).max(1).leading_zeros()).max(1);
+        let n = self.cascade_count.min(max_n).min(MAX_CASCADES as u32).max(1);
+
+        // World units per field pixel (uniform 2D camera) → ray-interval scale.
+        let wpp = (2.0 / cw as f32) / self.vp.x_axis.x.abs().max(1e-6);
+        let base = wpp * s0 as f32;
+
+        for c in 0..n {
+            let e_c = e0 << c;
+            let s_c = s0 << c;
+            let e_up = e0 << (c + 1);
+            let s_up = s0 << (c + 1);
+            let up_px = (cw / s_up).max(1);
+            let up_py = (ch / s_up).max(1);
+            // Telescoping radial intervals: start_c = base·(4^c−1)/3, end_c = start_{c+1}.
+            let p4 = 4.0f32.powi(c as i32);
+            let start_c = base * (p4 - 1.0) / 3.0;
+            let end_c = base * (p4 * 4.0 - 1.0) / 3.0;
+            let params = CascadeParams {
+                v0: [e_c as f32, s_c as f32, cw as f32, ch as f32],
+                v1: [e_up as f32, s_up as f32, up_px as f32, up_py as f32],
+                v2: [
+                    start_c,
+                    end_c,
+                    self.max_steps as f32,
+                    if c == n - 1 { 1.0 } else { 0.0 },
+                ],
+            };
+            ctxt.write_buffer(
+                &self.cascade_param_buffers[c as usize],
+                0,
+                bytemuck::bytes_of(&params),
+            );
+        }
+
+        // Build top-down; level `l` writes cascade[l % 2] and reads cascade[(l+1) % 2].
+        let sdf_bg = self.tex_bind_group(&self.sdf.view, "gi2d_cascade_sdf_bg");
+        for level in (0..n).rev() {
+            let dst = (level % 2) as usize;
+            let upper = ((level + 1) % 2) as usize;
+            let upper_bg = self.tex_only_bind_group(&self.cascade[upper].view);
+            self.fullscreen_pass(
+                encoder,
+                "gi2d_cascade_pass",
+                &self.cascade[dst].view,
+                &self.cascade_pipeline,
+                &[
+                    &upper_bg,
+                    &self.cascade_param_bind_groups[level as usize],
+                    &self.field_uniform_bind_group,
+                    &sdf_bg,
+                ],
+            );
+        }
+
+        // Cascade 0 ends up in cascade[0]; gather it and composite over the scene.
+        let composite = CascadeCompositeUniforms {
+            v0: [
+                e0 as f32,
+                (e0 * e0) as f32,
+                (cw / s0).max(1) as f32,
+                (ch / s0).max(1) as f32,
+            ],
+            v1: [cw as f32, ch as f32, s0 as f32, 0.0],
+            ambient: [self.ambient.r, self.ambient.g, self.ambient.b, 0.0],
+        };
+        ctxt.write_buffer(
+            &self.cascade_composite_buffer,
+            0,
+            bytemuck::bytes_of(&composite),
+        );
+        let scene_bg = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_cascade_scene_bg"),
+            layout: &self.tex_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(scene_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(scene_sampler),
+                },
+            ],
+        });
+        let c0_bg = self.tex_only_bind_group(&self.cascade[0].view);
+        self.fullscreen_pass(
+            encoder,
+            "gi2d_cascade_composite_pass",
+            output_view,
+            &self.cascade_composite_pipeline,
+            &[&scene_bg, &c0_bg, &self.cascade_composite_bind_group],
+        );
+    }
+}
+
+impl PostProcessingEffect for Gi2d {
+    fn update(&mut self, _dt: f32, _w: f32, _h: f32, _znear: f32, _zfar: f32) {}
+
+    fn draw(&mut self, target: &RenderTarget, context: &mut PostProcessingContext) {
+        let ctxt = Context::get();
+
+        let (scene_view, scene_sampler, width, height) = match target {
+            RenderTarget::Offscreen(o) => (&o.color_view, &o.sampler, o.width, o.height),
+            RenderTarget::Screen => return,
+        };
+
+        self.ensure_textures(width, height);
+        let prev = self.cur;
+        let next = 1 - self.cur;
+
+        // Field uniforms (scene transform + emitter/occluder lists), consumed by the
+        // field/cascade march and the JFA seed pass.
+        let field_uniforms = self.build_field_uniforms();
+        ctxt.write_buffer(
+            &self.field_uniform_buffer,
+            0,
+            bytemuck::bytes_of(&field_uniforms),
+        );
+
+        // Radiance-cascade solver: its own multi-pass path; skip the direct march.
+        if self.radiance_cascades {
+            self.render_cascades(context.encoder, context.output_view, scene_view, scene_sampler);
+            self.frame_index = self.frame_index.wrapping_add(1);
+            return;
+        }
+
+        // --- Optional: bake the occluder distance field via jump flood. ---
+        if self.sdf_occluders {
+            self.build_sdf(context.encoder);
+        }
+
+        // --- Pass: ray-march + temporal accumulate into the low-res field (next). ---
+        let history_bind_group = self.tex_bind_group(&self.history[prev].view, "gi2d_history_bg");
+        let sdf_bind_group = self.tex_bind_group(&self.sdf.view, "gi2d_sdf_bg");
+        self.fullscreen_pass(
+            context.encoder,
+            "gi2d_field_pass",
+            &self.history[next].view,
+            &self.field_pipeline,
+            &[
+                &history_bind_group,
+                &self.field_uniform_bind_group,
+                &sdf_bind_group,
+            ],
+        );
+
+        // --- Pass: composite scene × (ambient + upsampled irradiance) → output. ---
+        let composite_uniforms = CompositeUniforms {
+            ambient: [self.ambient.r, self.ambient.g, self.ambient.b, 0.0],
+        };
+        ctxt.write_buffer(
+            &self.composite_uniform_buffer,
+            0,
+            bytemuck::bytes_of(&composite_uniforms),
+        );
+        let scene_bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("gi2d_scene_bg"),
+            layout: &self.tex_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(scene_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(scene_sampler),
+                },
+            ],
+        });
+        let gi_bind_group = self.tex_bind_group(&self.history[next].view, "gi2d_field_bg");
+        self.fullscreen_pass(
+            context.encoder,
+            "gi2d_composite_pass",
+            context.output_view,
+            &self.composite_pipeline,
+            &[
+                &scene_bind_group,
+                &gi_bind_group,
+                &self.composite_uniform_bind_group,
+            ],
+        );
+
+        // Advance temporal state: the field we just wrote becomes next frame's history.
+        self.cur = next;
+        self.prev_vp = self.vp;
+        self.history_valid = true;
+        self.frame_index = self.frame_index.wrapping_add(1);
+    }
+}

--- a/src/post_processing/gi2d.rs
+++ b/src/post_processing/gi2d.rs
@@ -185,7 +185,7 @@ impl GiTexture {
     }
 }
 
-/// Screen-space 2D global-illumination post-processing effect (see the [module docs](self)).
+/// Screen-space 2D global-illumination post-processing effect (see the [module docs](crate::post_processing)).
 pub struct Gi2d {
     field_pipeline: wgpu::RenderPipeline,
     composite_pipeline: wgpu::RenderPipeline,
@@ -400,7 +400,7 @@ impl Gi2d {
                 vertex: wgpu::VertexState {
                     module: shader,
                     entry_point: Some("vs_main"),
-                    buffers: &[vertex_buffer_layout.clone()],
+                    buffers: std::slice::from_ref(&vertex_buffer_layout),
                     compilation_options: Default::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
@@ -480,15 +480,16 @@ impl Gi2d {
             ],
             immediate_size: 0,
         });
-        let cascade_composite_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("gi2d_cascade_composite_pipeline_layout"),
-            bind_group_layouts: &[
-                Some(&tex_bind_group_layout),      // scene
-                Some(&tex_only_bind_group_layout), // cascade 0 (textureLoad)
-                Some(&uniform_bind_group_layout),  // composite uniforms
-            ],
-            immediate_size: 0,
-        });
+        let cascade_composite_layout =
+            ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("gi2d_cascade_composite_pipeline_layout"),
+                bind_group_layouts: &[
+                    Some(&tex_bind_group_layout),      // scene
+                    Some(&tex_only_bind_group_layout), // cascade 0 (textureLoad)
+                    Some(&uniform_bind_group_layout),  // composite uniforms
+                ],
+                immediate_size: 0,
+            });
         let cascade_shader = ctxt.create_shader_module(
             Some("gi2d_cascade_shader"),
             &crate::builtin::compile_shader_with_common(
@@ -773,7 +774,7 @@ impl Gi2d {
     /// Enables baking occluders into a jump-flooded distance field each frame so the
     /// march cost is independent of occluder count (one texture fetch per step). This
     /// is screen-space — off-screen occluders cast no shadows. Off by default (the
-    /// analytic, global per-disc path). See the [module docs](self).
+    /// analytic, global per-disc path). See the [module docs](crate::post_processing).
     pub fn set_sdf_occluders(&mut self, enabled: bool) {
         self.sdf_occluders = enabled;
     }
@@ -1029,7 +1030,11 @@ impl Gi2d {
         let mindim = cw.min(ch);
         // Highest level whose probe spacing (s0 * 2^c) still fits the field.
         let max_n = (32 - (mindim / s0).max(1).leading_zeros()).max(1);
-        let n = self.cascade_count.min(max_n).min(MAX_CASCADES as u32).max(1);
+        let n = self
+            .cascade_count
+            .min(max_n)
+            .min(MAX_CASCADES as u32)
+            .max(1);
 
         // World units per field pixel (uniform 2D camera) → ray-interval scale.
         let wpp = (2.0 / cw as f32) / self.vp.x_axis.x.abs().max(1e-6);
@@ -1150,7 +1155,12 @@ impl PostProcessingEffect for Gi2d {
 
         // Radiance-cascade solver: its own multi-pass path; skip the direct march.
         if self.radiance_cascades {
-            self.render_cascades(context.encoder, context.output_view, scene_view, scene_sampler);
+            self.render_cascades(
+                context.encoder,
+                context.output_view,
+                scene_view,
+                scene_sampler,
+            );
             self.frame_index = self.frame_index.wrapping_add(1);
             return;
         }

--- a/src/post_processing/hdr.rs
+++ b/src/post_processing/hdr.rs
@@ -170,7 +170,8 @@ struct TonemapUniforms {
     bloom_intensity: f32,
     // 1.0 when the adapted exposure texture overrides `exposure`.
     auto_exposure: f32,
-    // Color grading: white-balance gain (rgb) + unused.
+    // Color grading: white-balance gain (rgb) + force-opaque flag (w: 1.0 writes
+    // alpha = 1.0 to the output, else the HDR scene alpha is forwarded).
     white_balance: [f32; 4],
     // (saturation, contrast, gamma, hue).
     grading: [f32; 4],
@@ -949,7 +950,16 @@ impl HdrPipeline {
                             dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                             operation: wgpu::BlendOperation::Add,
                         },
-                        alpha: wgpu::BlendComponent::REPLACE,
+                        // Keep the destination alpha (out.a = dst.a). The opaque
+                        // scene's alpha is forwarded to the surface by the tonemap;
+                        // overwriting it with the OIT coverage (1 - reveal) drove it
+                        // to 0 on the background and made the canvas transparent →
+                        // white page on browsers that composite canvas alpha (Firefox).
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::Zero,
+                            dst_factor: wgpu::BlendFactor::One,
+                            operation: wgpu::BlendOperation::Add,
+                        },
                     }),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
@@ -1522,10 +1532,17 @@ impl HdrPipeline {
         write_index
     }
 
+    /// `force_opaque` writes alpha = 1.0 to the output instead of forwarding the
+    /// HDR scene's alpha. Set it for on-screen window surfaces (a browser
+    /// composites the canvas against the page using its alpha, so a sub-1.0 alpha
+    /// — e.g. left behind by a transparency pass — would make the canvas
+    /// see-through). Leave it off for offscreen/snapshot/embedding targets that
+    /// legitimately want the scene's alpha preserved.
     pub(crate) fn resolve(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
         output_view: &wgpu::TextureView,
+        force_opaque: bool,
         gpu: &mut crate::renderer::timings::GpuTimer,
     ) {
         let ctxt = Context::get();
@@ -1558,7 +1575,8 @@ impl HdrPipeline {
                 auto_exposure: if auto { 1.0 } else { 0.0 },
                 white_balance: {
                     let w = self.settings.color_grading.white_balance;
-                    [w[0], w[1], w[2], 0.0]
+                    // .w carries the force-opaque flag (see `force_opaque` above).
+                    [w[0], w[1], w[2], if force_opaque { 1.0 } else { 0.0 }]
                 },
                 grading: [
                     self.settings.color_grading.saturation,

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -3,6 +3,7 @@
 pub use crate::post_processing::cas::Cas;
 pub use crate::post_processing::crt::Crt;
 pub use crate::post_processing::fxaa::Fxaa;
+pub use crate::post_processing::gi2d::{Gi2d, GiEmitter2d, GiOccluder2d};
 pub use crate::post_processing::grayscales::Grayscales;
 pub use crate::post_processing::hdr::{
     ColorGrading, HdrPipeline, HdrSettings, Tonemap, HDR_FORMAT, OIT_ACCUM_FORMAT,
@@ -20,6 +21,7 @@ pub use crate::post_processing::waves::Waves;
 mod cas;
 mod crt;
 mod fxaa;
+mod gi2d;
 mod grayscales;
 mod hdr;
 mod loupe;

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -3,7 +3,9 @@
 pub use crate::post_processing::cas::Cas;
 pub use crate::post_processing::crt::Crt;
 pub use crate::post_processing::fxaa::Fxaa;
-pub use crate::post_processing::gi2d::{Gi2d, GiEmitter2d, GiOccluder2d};
+pub use crate::post_processing::gi2d::{
+    Gi2d, GiEmitter2d, GiOccluder2d, MAX_EMITTERS, MAX_OCCLUDERS,
+};
 pub use crate::post_processing::grayscales::Grayscales;
 pub use crate::post_processing::hdr::{
     ColorGrading, HdrPipeline, HdrSettings, Tonemap, HDR_FORMAT, OIT_ACCUM_FORMAT,

--- a/src/post_processing/mod.rs
+++ b/src/post_processing/mod.rs
@@ -1,6 +1,7 @@
 //! Post-processing effects.
 
 pub use crate::post_processing::cas::Cas;
+pub use crate::post_processing::crt::Crt;
 pub use crate::post_processing::fxaa::Fxaa;
 pub use crate::post_processing::grayscales::Grayscales;
 pub use crate::post_processing::hdr::{
@@ -17,6 +18,7 @@ pub use crate::post_processing::sobel_edge_highlight::SobelEdgeHighlight;
 pub use crate::post_processing::waves::Waves;
 
 mod cas;
+mod crt;
 mod fxaa;
 mod grayscales;
 mod hdr;

--- a/src/procedural/quad.rs
+++ b/src/procedural/quad.rs
@@ -29,9 +29,7 @@ pub fn quad(width: f32, height: f32, usubdivs: usize, vsubdivs: usize) -> Render
     let mut quad = unit_quad(usubdivs, vsubdivs);
 
     let s = Vec3::new(width, height, 1.0);
-
     quad.scale_by(s);
-    quad.replicate_vertices();
 
     quad
 }

--- a/src/procedural/quad.rs
+++ b/src/procedural/quad.rs
@@ -31,6 +31,7 @@ pub fn quad(width: f32, height: f32, usubdivs: usize, vsubdivs: usize) -> Render
     let s = Vec3::new(width, height, 1.0);
 
     quad.scale_by(s);
+    quad.replicate_vertices();
 
     quad
 }

--- a/src/renderer/egui_renderer.rs
+++ b/src/renderer/egui_renderer.rs
@@ -104,6 +104,26 @@ impl EguiRenderer {
         self.textures_delta.append(output.textures_delta);
     }
 
+    /// Registers a native wgpu texture view with egui, returning a
+    /// [`egui::TextureId`] that `ui.image((id, size))` can draw — no CPU copy
+    /// involved. The texture stays registered until
+    /// [`Self::unregister_native_texture`].
+    pub fn register_native_texture(
+        &mut self,
+        view: &wgpu::TextureView,
+        filter: wgpu::FilterMode,
+    ) -> egui::TextureId {
+        let ctxt = Context::get();
+        self.renderer
+            .register_native_texture(&ctxt.device, view, filter)
+    }
+
+    /// Frees a texture id previously returned by
+    /// [`Self::register_native_texture`].
+    pub fn unregister_native_texture(&mut self, id: egui::TextureId) {
+        self.renderer.free_texture(&id);
+    }
+
     /// Returns true if egui wants to capture the mouse (e.g., hovering over a widget).
     pub fn wants_pointer_input(&self) -> bool {
         self.egui_ctx.egui_wants_pointer_input()

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -12,8 +12,8 @@ pub use self::raytracer::{RayBackend, RayTracer, RayTracerPreset};
 pub use self::reflection_probe::{
     CubeFaceCamera, ProbeCapture, ReflectionProbe, ReflectionProbes, MAX_PROBES,
 };
-pub use self::reflector::{MirrorCamera, Reflector};
 pub(crate) use self::reflector::ReflectorOit;
+pub use self::reflector::{MirrorCamera, Reflector};
 pub use self::renderer::Renderer3d;
 pub use self::skybox::Skybox;
 pub use self::ssao::{Ssao, SsaoSettings};

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -13,6 +13,7 @@ pub use self::reflection_probe::{
     CubeFaceCamera, ProbeCapture, ReflectionProbe, ReflectionProbes, MAX_PROBES,
 };
 pub use self::reflector::{MirrorCamera, Reflector};
+pub(crate) use self::reflector::ReflectorOit;
 pub use self::renderer::Renderer3d;
 pub use self::skybox::Skybox;
 pub use self::ssao::{Ssao, SsaoSettings};

--- a/src/renderer/reflection_probe.rs
+++ b/src/renderer/reflection_probe.rs
@@ -443,7 +443,12 @@ impl CubeFaceCamera {
         let u = FACE_UP[face];
         let fwd = glamx::Vec3::new(f[0], f[1], f[2]);
         let up = glamx::Vec3::new(u[0], u[1], u[2]);
-        let proj = glamx::Mat4::perspective_rh_gl(core::f32::consts::FRAC_PI_2, 1.0, znear, zfar);
+        let proj = glamx::glam::camera::rh::proj::opengl::perspective(
+            core::f32::consts::FRAC_PI_2,
+            1.0,
+            znear,
+            zfar,
+        );
         let view = glamx::Pose3::look_at_rh(eye, eye + fwd, up);
         CubeFaceCamera {
             eye,

--- a/src/renderer/reflector.rs
+++ b/src/renderer/reflector.rs
@@ -325,3 +325,243 @@ impl Reflector {
         self.view_proj.set(vp);
     }
 }
+
+/// Weighted-blended OIT accumulation targets + composite pipeline for the
+/// reflector capture pass, so transparent (alpha < 1) surfaces also appear in
+/// mirrors. One set is shared by all reflectors of a window (each capture
+/// clears the targets).
+///
+/// The HDR pipeline owns the equivalent targets for the main pass, but those
+/// match the film's MSAA sample count while the reflector capture is always
+/// single-sampled — hence this dedicated single-sample set (same formats, same
+/// `hdr_oit.wgsl` composite).
+pub(crate) struct ReflectorOit {
+    width: u32,
+    height: u32,
+    _accum: wgpu::Texture,
+    accum_view: wgpu::TextureView,
+    _reveal: wgpu::Texture,
+    reveal_view: wgpu::TextureView,
+    layout: wgpu::BindGroupLayout,
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+}
+
+impl ReflectorOit {
+    pub fn new(width: u32, height: u32) -> ReflectorOit {
+        let ctxt = Context::get();
+        let layout = ctxt.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("reflector_oit_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let shader = ctxt.create_shader_module(
+            Some("reflector_oit_shader"),
+            include_str!("../builtin/hdr_oit.wgsl"),
+        );
+        let pipeline_layout = ctxt.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("reflector_oit_pipeline_layout"),
+            bind_group_layouts: &[Some(&layout)],
+            immediate_size: 0,
+        });
+        let vertex_layout = wgpu::VertexBufferLayout {
+            array_stride: (std::mem::size_of::<f32>() * 2) as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[wgpu::VertexAttribute {
+                offset: 0,
+                shader_location: 0,
+                format: wgpu::VertexFormat::Float32x2,
+            }],
+        };
+        let pipeline = ctxt.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("reflector_oit_composite_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: std::slice::from_ref(&vertex_layout),
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_composite"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: crate::post_processing::HDR_FORMAT,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent::REPLACE,
+                    }),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let vertices: [[f32; 2]; 4] = [[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0], [1.0, 1.0]];
+        let vertex_buffer = ctxt.create_buffer_init(
+            Some("reflector_oit_quad"),
+            bytemuck::cast_slice(&vertices),
+            wgpu::BufferUsages::VERTEX,
+        );
+
+        let (accum, accum_view, reveal, reveal_view) = Self::make_targets(width, height);
+        ReflectorOit {
+            width: width.max(1),
+            height: height.max(1),
+            _accum: accum,
+            accum_view,
+            _reveal: reveal,
+            reveal_view,
+            layout,
+            pipeline,
+            vertex_buffer,
+        }
+    }
+
+    fn make_targets(
+        w: u32,
+        h: u32,
+    ) -> (
+        wgpu::Texture,
+        wgpu::TextureView,
+        wgpu::Texture,
+        wgpu::TextureView,
+    ) {
+        let ctxt = Context::get();
+        let make = |label: &str, format: wgpu::TextureFormat| {
+            let tex = ctxt.create_texture(&wgpu::TextureDescriptor {
+                label: Some(label),
+                size: wgpu::Extent3d {
+                    width: w.max(1),
+                    height: h.max(1),
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+            (tex, view)
+        };
+        let (accum, accum_view) = make(
+            "reflector_oit_accum",
+            crate::post_processing::OIT_ACCUM_FORMAT,
+        );
+        let (reveal, reveal_view) = make(
+            "reflector_oit_reveal",
+            crate::post_processing::OIT_REVEAL_FORMAT,
+        );
+        (accum, accum_view, reveal, reveal_view)
+    }
+
+    /// Resizes the OIT targets if needed.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        let (w, h) = (width.max(1), height.max(1));
+        if self.width == w && self.height == h {
+            return;
+        }
+        let (accum, accum_view, reveal, reveal_view) = Self::make_targets(w, h);
+        self._accum = accum;
+        self.accum_view = accum_view;
+        self._reveal = reveal;
+        self.reveal_view = reveal_view;
+        self.width = w;
+        self.height = h;
+    }
+
+    /// The OIT accumulation target (additive premultiplied-weighted color).
+    pub fn accum_view(&self) -> &wgpu::TextureView {
+        &self.accum_view
+    }
+
+    /// The OIT revealage target (multiplicative coverage).
+    pub fn reveal_view(&self) -> &wgpu::TextureView {
+        &self.reveal_view
+    }
+
+    /// Composites the accumulated transparency over `target`
+    /// (SrcAlpha / OneMinusSrcAlpha, like the HDR pipeline's OIT composite).
+    pub fn composite(&self, encoder: &mut wgpu::CommandEncoder, target: &wgpu::TextureView) {
+        let ctxt = Context::get();
+        let bind_group = ctxt.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("reflector_oit_composite_bind_group"),
+            layout: &self.layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&self.accum_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&self.reveal_view),
+                },
+            ],
+        });
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("reflector_oit_composite_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        pass.draw(0..4, 0..1);
+    }
+}

--- a/src/resource/gpu_vector.rs
+++ b/src/resource/gpu_vector.rs
@@ -188,8 +188,10 @@ impl<T: Pod + Zeroable> GPUVec<T> {
             | wgpu::BufferUsages::VERTEX;
 
         let needed = (std::mem::size_of::<T>() * count.max(1)) as u64;
+        // Reallocate when the buffer is missing, too small, OR lacks the usage
+        // flags we just added.
         let realloc = match &self.buffer {
-            Some(b) => b.size() < needed,
+            Some(b) => b.size() < needed || !b.usage().contains(self.usage),
             None => true,
         };
         if realloc {

--- a/src/resource/gpu_vector.rs
+++ b/src/resource/gpu_vector.rs
@@ -183,9 +183,8 @@ impl<T: Pod + Zeroable> GPUVec<T> {
     #[inline]
     pub fn prepare_gpu_writable(&mut self, count: usize) -> &wgpu::Buffer {
         let ctxt = Context::get();
-        self.usage |= wgpu::BufferUsages::STORAGE
-            | wgpu::BufferUsages::COPY_DST
-            | wgpu::BufferUsages::VERTEX;
+        self.usage |=
+            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::VERTEX;
 
         let needed = (std::mem::size_of::<T>() * count.max(1)) as u64;
         // Reallocate when the buffer is missing, too small, OR lacks the usage

--- a/src/resource/gpu_vector.rs
+++ b/src/resource/gpu_vector.rs
@@ -169,6 +169,46 @@ impl<T: Pod + Zeroable> GPUVec<T> {
         self.buffer.as_ref()
     }
 
+    /// Prepares this vector to be filled directly by a compute shader.
+    ///
+    /// Ensures a GPU-resident buffer of at least `count` elements exists with
+    /// `STORAGE` usage added (so a compute pass on the same `wgpu::Device` can
+    /// write into it), reports a length of `count`, and detaches any CPU-side
+    /// data so a subsequent [`load_to_gpu`](Self::load_to_gpu) at render time is
+    /// a no-op and will not overwrite the compute-written contents.
+    ///
+    /// The buffer is reallocated only when it does not yet exist or is too
+    /// small, so calling this every frame at a stable `count` is cheap. Returns
+    /// the GPU buffer to bind as a compute output.
+    #[inline]
+    pub fn prepare_gpu_writable(&mut self, count: usize) -> &wgpu::Buffer {
+        let ctxt = Context::get();
+        self.usage |= wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_DST
+            | wgpu::BufferUsages::VERTEX;
+
+        let needed = (std::mem::size_of::<T>() * count.max(1)) as u64;
+        let realloc = match &self.buffer {
+            Some(b) => b.size() < needed,
+            None => true,
+        };
+        if realloc {
+            self.buffer = Some(ctxt.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("GPUVec compute-writable buffer"),
+                size: needed,
+                usage: self.usage,
+                mapped_at_creation: false,
+            }));
+        }
+
+        // Report `count` instances and detach CPU data: rendering reads `len`
+        // (since `dirty` is false) and `load_to_gpu` becomes a no-op.
+        self.len = count;
+        self.dirty = false;
+        self.data = None;
+        self.buffer.as_ref().unwrap()
+    }
+
     /// Unloads this resource from the GPU.
     #[inline]
     pub fn unload_from_gpu(&mut self) {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -2,7 +2,7 @@
 
 pub use self::animation::{AnimationChannel, AnimationClip, AnimationPlayer, Interpolation};
 pub use self::object2d::{
-    InstanceData2d, InstancesBuffer2d, Object2d, ObjectData2d, LINES_COLOR_USE_OBJECT_2D,
+    Blend2d, InstanceData2d, InstancesBuffer2d, Object2d, ObjectData2d, LINES_COLOR_USE_OBJECT_2D,
     LINES_WIDTH_USE_OBJECT_2D, POINTS_COLOR_USE_OBJECT_2D, POINTS_SIZE_USE_OBJECT_2D,
 };
 pub use self::object3d::{

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -11,6 +11,7 @@ pub use self::object3d::{
     POINTS_SIZE_USE_OBJECT,
 };
 pub use self::scene_node2d::{SceneNode2d, SceneNodeData2d};
+pub use self::sprite::{Border, SpriteSheet};
 pub use self::scene_node3d::{GltfModel, SceneNode3d, SceneNodeData3d};
 
 mod animation;
@@ -18,3 +19,4 @@ mod object2d;
 mod object3d;
 mod scene_node2d;
 mod scene_node3d;
+mod sprite;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -2,13 +2,14 @@
 
 pub use self::animation::{AnimationChannel, AnimationClip, AnimationPlayer, Interpolation};
 pub use self::object2d::{
-    Blend2d, InstanceData2d, InstancesBuffer2d, Object2d, ObjectData2d, LINES_COLOR_USE_OBJECT_2D,
-    LINES_WIDTH_USE_OBJECT_2D, POINTS_COLOR_USE_OBJECT_2D, POINTS_SIZE_USE_OBJECT_2D,
+    Blend2d, InstanceComputeBuffers2d, InstanceData2d, InstancesBuffer2d, Object2d, ObjectData2d,
+    LINES_COLOR_USE_OBJECT_2D, LINES_WIDTH_USE_OBJECT_2D, POINTS_COLOR_USE_OBJECT_2D,
+    POINTS_SIZE_USE_OBJECT_2D,
 };
 pub use self::object3d::{
-    AlphaMode, Bsdf, InstanceData3d, InstancesBuffer3d, Object3d, ObjectData3d, ParallaxMethod,
-    Skin3d, LINES_COLOR_USE_OBJECT, LINES_WIDTH_USE_OBJECT, POINTS_COLOR_USE_OBJECT,
-    POINTS_SIZE_USE_OBJECT,
+    AlphaMode, Bsdf, InstanceComputeBuffers, InstanceData3d, InstancesBuffer3d, Object3d,
+    ObjectData3d, ParallaxMethod, Skin3d, LINES_COLOR_USE_OBJECT, LINES_WIDTH_USE_OBJECT,
+    POINTS_COLOR_USE_OBJECT, POINTS_SIZE_USE_OBJECT,
 };
 pub use self::scene_node2d::{SceneNode2d, SceneNodeData2d};
 pub use self::sprite::{Border, SpriteSheet};

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -12,9 +12,9 @@ pub use self::object3d::{
     POINTS_COLOR_USE_OBJECT, POINTS_SIZE_USE_OBJECT,
 };
 pub use self::scene_node2d::{SceneNode2d, SceneNodeData2d};
+pub use self::scene_node3d::{GltfModel, SceneNode3d, SceneNodeData3d};
 pub use self::sprite::{Border, SpriteSheet};
 pub use self::tilemap::Tilemap;
-pub use self::scene_node3d::{GltfModel, SceneNode3d, SceneNodeData3d};
 
 mod animation;
 mod object2d;

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -12,6 +12,7 @@ pub use self::object3d::{
 };
 pub use self::scene_node2d::{SceneNode2d, SceneNodeData2d};
 pub use self::sprite::{Border, SpriteSheet};
+pub use self::tilemap::Tilemap;
 pub use self::scene_node3d::{GltfModel, SceneNode3d, SceneNodeData3d};
 
 mod animation;
@@ -20,3 +21,4 @@ mod object3d;
 mod scene_node2d;
 mod scene_node3d;
 mod sprite;
+mod tilemap;

--- a/src/scene/object2d.rs
+++ b/src/scene/object2d.rs
@@ -253,6 +253,21 @@ pub const POINTS_COLOR_USE_OBJECT_2D: [f32; 4] = [0.0, 0.0, 0.0, 0.0];
 ///
 /// Contains GPU-allocated buffers for positions, deformations, colors,
 /// wireframe settings, and point settings of all 2D instances to be rendered.
+/// Raw per-instance GPU buffers prepared for direct compute writes (2D).
+///
+/// Returned by [`Object2d::instance_compute_buffers`] (and the matching
+/// [`SceneNode2d`](crate::scene::SceneNode2d) method). A compute shader running
+/// on the same `wgpu::Device` can fill these each frame instead of uploading
+/// per-instance data from the CPU via [`set_instances`](Object2d::set_instances).
+pub struct InstanceComputeBuffers2d {
+    /// One `Vec2` position per instance.
+    pub positions: wgpu::Buffer,
+    /// One RGBA color (`[f32; 4]`) per instance.
+    pub colors: wgpu::Buffer,
+    /// Two `Vec2` deformation-matrix columns per instance (4 floats / instance).
+    pub deformations: wgpu::Buffer,
+}
+
 pub struct InstancesBuffer2d {
     /// GPU buffer of instance positions.
     pub positions: GPUVec<Vec2>,
@@ -527,6 +542,28 @@ impl Object2d {
         *self.instances.borrow_mut().lines_widths.data_mut() = Some(lines_width_data);
         *self.instances.borrow_mut().points_colors.data_mut() = Some(points_col_data);
         *self.instances.borrow_mut().points_sizes.data_mut() = Some(points_size_data);
+    }
+
+    /// Prepares this object's per-instance buffers to be written directly by a
+    /// compute shader, for `count` instances, and returns the raw GPU buffers.
+    ///
+    /// The 2D analogue of
+    /// [`Object3d::instance_compute_buffers`](crate::scene::Object3d::instance_compute_buffers):
+    /// the object renders `count` instances reading position/color/deformation
+    /// straight from these buffers, which the caller fills via a compute pass on
+    /// the same `wgpu::Device`. An alternative to
+    /// [`set_instances`](Self::set_instances); use one or the other per frame.
+    pub fn instance_compute_buffers(&mut self, count: usize) -> InstanceComputeBuffers2d {
+        let mut inst = self.instances.borrow_mut();
+        let positions = inst.positions.prepare_gpu_writable(count).clone();
+        let colors = inst.colors.prepare_gpu_writable(count).clone();
+        // Two Vec2 columns (a Mat2) per instance.
+        let deformations = inst.deformations.prepare_gpu_writable(count * 2).clone();
+        InstanceComputeBuffers2d {
+            positions,
+            colors,
+            deformations,
+        }
     }
 
     /// Gets the data of this object.

--- a/src/scene/object2d.rs
+++ b/src/scene/object2d.rs
@@ -43,21 +43,6 @@ pub enum Blend2d {
 }
 
 impl Blend2d {
-    /// The number of distinct blend modes; used to size the material's pipeline table.
-    pub(crate) const COUNT: usize = 6;
-
-    /// Every blend mode, in `as usize` discriminant order. Iterated when a material
-    /// pre-builds its per-blend-mode pipeline table so that `table[mode as usize]`
-    /// indexes the matching pipeline.
-    pub(crate) const ALL: [Blend2d; Self::COUNT] = [
-        Blend2d::Alpha,
-        Blend2d::PremultipliedAlpha,
-        Blend2d::Additive,
-        Blend2d::Multiply,
-        Blend2d::Screen,
-        Blend2d::Opaque,
-    ];
-
     /// The wgpu blend state realizing this mode for a straight-(non-premultiplied)
     /// color target, or `None` for [`Blend2d::Opaque`] (blending disabled).
     pub(crate) fn blend_state(self) -> Option<wgpu::BlendState> {

--- a/src/scene/object2d.rs
+++ b/src/scene/object2d.rs
@@ -14,6 +14,91 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
+/// How a 2D object's surface is composited over what is already in the framebuffer.
+///
+/// The surface pass of [`ObjectMaterial2d`](crate::builtin::ObjectMaterial2d) builds
+/// one pipeline variant per blend mode (lazily, keyed by MSAA sample count), so
+/// switching an object's blend mode is free beyond the first use of that variant.
+/// Wireframe and point overlays always use straight alpha blending.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub enum Blend2d {
+    /// Straight (non-premultiplied) alpha blending: `src.rgb * src.a + dst.rgb * (1 - src.a)`.
+    /// The default, matching ordinary transparent sprites.
+    #[default]
+    Alpha,
+    /// Premultiplied alpha: `src.rgb + dst.rgb * (1 - src.a)`. Correct for textures
+    /// whose color is already multiplied by their alpha (avoids dark edge fringing).
+    PremultipliedAlpha,
+    /// Additive blending: `src.rgb * src.a + dst.rgb`. Light-emitting effects — fire,
+    /// sparks, glows, lasers — that should only ever brighten the background.
+    Additive,
+    /// Multiplicative blending: `src.rgb * dst.rgb`. Shadows, tints and stains that
+    /// darken the background.
+    Multiply,
+    /// Screen blending: `src.rgb + dst.rgb * (1 - src.rgb)`. A softer brightening than
+    /// additive that never blows past white.
+    Screen,
+    /// No blending: the source overwrites the destination (alpha is still written).
+    Opaque,
+}
+
+impl Blend2d {
+    /// The number of distinct blend modes; used to size the material's pipeline table.
+    pub(crate) const COUNT: usize = 6;
+
+    /// Every blend mode, in `as usize` discriminant order. Iterated when a material
+    /// pre-builds its per-blend-mode pipeline table so that `table[mode as usize]`
+    /// indexes the matching pipeline.
+    pub(crate) const ALL: [Blend2d; Self::COUNT] = [
+        Blend2d::Alpha,
+        Blend2d::PremultipliedAlpha,
+        Blend2d::Additive,
+        Blend2d::Multiply,
+        Blend2d::Screen,
+        Blend2d::Opaque,
+    ];
+
+    /// The wgpu blend state realizing this mode for a straight-(non-premultiplied)
+    /// color target, or `None` for [`Blend2d::Opaque`] (blending disabled).
+    pub(crate) fn blend_state(self) -> Option<wgpu::BlendState> {
+        use wgpu::{BlendComponent, BlendFactor, BlendOperation, BlendState};
+        let alpha_over = BlendComponent {
+            src_factor: BlendFactor::One,
+            dst_factor: BlendFactor::OneMinusSrcAlpha,
+            operation: BlendOperation::Add,
+        };
+        match self {
+            Blend2d::Alpha => Some(BlendState::ALPHA_BLENDING),
+            Blend2d::PremultipliedAlpha => Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+            Blend2d::Additive => Some(BlendState {
+                color: BlendComponent {
+                    src_factor: BlendFactor::SrcAlpha,
+                    dst_factor: BlendFactor::One,
+                    operation: BlendOperation::Add,
+                },
+                alpha: alpha_over,
+            }),
+            Blend2d::Multiply => Some(BlendState {
+                color: BlendComponent {
+                    src_factor: BlendFactor::Dst,
+                    dst_factor: BlendFactor::Zero,
+                    operation: BlendOperation::Add,
+                },
+                alpha: alpha_over,
+            }),
+            Blend2d::Screen => Some(BlendState {
+                color: BlendComponent {
+                    src_factor: BlendFactor::One,
+                    dst_factor: BlendFactor::OneMinusSrc,
+                    operation: BlendOperation::Add,
+                },
+                alpha: alpha_over,
+            }),
+            Blend2d::Opaque => None,
+        }
+    }
+}
+
 /// Set of data identifying a scene node.
 pub struct ObjectData2d {
     material: Rc<RefCell<Box<dyn Material2d + 'static>>>,
@@ -27,6 +112,7 @@ pub struct ObjectData2d {
     points_use_perspective: bool,
     draw_surface: bool,
     cull: bool,
+    blend: Blend2d,
     user_data: Box<dyn Any + 'static>,
 }
 
@@ -89,6 +175,12 @@ impl ObjectData2d {
     #[inline]
     pub fn backface_culling_enabled(&self) -> bool {
         self.cull
+    }
+
+    /// How this object's surface is composited over the framebuffer.
+    #[inline]
+    pub fn blend(&self) -> Blend2d {
+        self.blend
     }
 
     /// An user-defined data.
@@ -275,6 +367,7 @@ impl Object2d {
             points_use_perspective: true,
             draw_surface: true,
             cull: true,
+            blend: Blend2d::default(),
             material,
             user_data: Box::new(user_data),
         };
@@ -449,6 +542,20 @@ impl Object2d {
     #[inline]
     pub fn enable_backface_culling(&mut self, active: bool) {
         self.data.cull = active;
+    }
+
+    /// Sets how this object's surface is composited over the framebuffer.
+    ///
+    /// See [`Blend2d`] for the available modes. Defaults to [`Blend2d::Alpha`].
+    #[inline]
+    pub fn set_blend(&mut self, blend: Blend2d) {
+        self.data.blend = blend;
+    }
+
+    /// Returns how this object's surface is composited over the framebuffer.
+    #[inline]
+    pub fn blend(&self) -> Blend2d {
+        self.data.blend
     }
 
     /// Attaches user-defined data to this object.

--- a/src/scene/object2d.rs
+++ b/src/scene/object2d.rs
@@ -113,6 +113,8 @@ pub struct ObjectData2d {
     draw_surface: bool,
     cull: bool,
     blend: Blend2d,
+    normal_map: Option<Arc<Texture>>,
+    lit_params: Option<crate::builtin::LitParams>,
     user_data: Box<dyn Any + 'static>,
 }
 
@@ -181,6 +183,20 @@ impl ObjectData2d {
     #[inline]
     pub fn blend(&self) -> Blend2d {
         self.blend
+    }
+
+    /// The normal map used when this object is drawn with
+    /// [`LitMaterial2d`](crate::builtin::LitMaterial2d), if any.
+    #[inline]
+    pub fn normal_map(&self) -> Option<&Arc<Texture>> {
+        self.normal_map.as_ref()
+    }
+
+    /// The per-object lighting parameters used by
+    /// [`LitMaterial2d`](crate::builtin::LitMaterial2d), if any.
+    #[inline]
+    pub fn lit_params(&self) -> Option<crate::builtin::LitParams> {
+        self.lit_params
     }
 
     /// An user-defined data.
@@ -368,6 +384,8 @@ impl Object2d {
             draw_surface: true,
             cull: true,
             blend: Blend2d::default(),
+            normal_map: None,
+            lit_params: None,
             material,
             user_data: Box::new(user_data),
         };
@@ -556,6 +574,39 @@ impl Object2d {
     #[inline]
     pub fn blend(&self) -> Blend2d {
         self.data.blend
+    }
+
+    /// Sets the normal map used when this object is drawn with
+    /// [`LitMaterial2d`](crate::builtin::LitMaterial2d). `None` makes the surface flat.
+    #[inline]
+    pub fn set_normal_map(&mut self, normal_map: Option<Arc<Texture>>) {
+        self.data.normal_map = normal_map;
+    }
+
+    /// Loads a normal map from a file and sets it on this object (see [`Self::set_normal_map`]).
+    #[inline]
+    pub fn set_normal_map_from_file(&mut self, path: &Path, name: &str) {
+        let texture = TextureManager::get_global_manager(|tm| tm.add(path, name));
+        self.set_normal_map(Some(texture));
+    }
+
+    /// Returns the normal map, if any.
+    #[inline]
+    pub fn normal_map(&self) -> Option<&Arc<Texture>> {
+        self.data.normal_map.as_ref()
+    }
+
+    /// Sets the per-object lighting parameters used by
+    /// [`LitMaterial2d`](crate::builtin::LitMaterial2d). Ignored by other materials.
+    #[inline]
+    pub fn set_lit_params(&mut self, params: Option<crate::builtin::LitParams>) {
+        self.data.lit_params = params;
+    }
+
+    /// Returns the per-object lighting parameters, if any.
+    #[inline]
+    pub fn lit_params(&self) -> Option<crate::builtin::LitParams> {
+        self.data.lit_params
     }
 
     /// Attaches user-defined data to this object.

--- a/src/scene/object3d.rs
+++ b/src/scene/object3d.rs
@@ -888,6 +888,22 @@ pub struct InstancesBuffer3d {
     pub points_sizes: GPUVec<f32>,
 }
 
+/// Raw per-instance GPU buffers prepared for direct compute writes.
+///
+/// Returned by [`Object3d::instance_compute_buffers`] (and the matching
+/// [`SceneNode3d`](crate::scene::SceneNode3d) method). A compute shader running
+/// on the same `wgpu::Device` can fill these buffers each frame instead of
+/// uploading per-instance data from the CPU via
+/// [`set_instances`](Object3d::set_instances).
+pub struct InstanceComputeBuffers {
+    /// One `Vec3` position per instance.
+    pub positions: wgpu::Buffer,
+    /// One RGBA color (`[f32; 4]`) per instance.
+    pub colors: wgpu::Buffer,
+    /// Three `Vec3` deformation-matrix columns per instance (9 floats / instance).
+    pub deformations: wgpu::Buffer,
+}
+
 /// Helper function to convert Color to [f32; 4] for GPU buffers.
 #[inline]
 pub(crate) fn color_to_array(color: Color) -> [f32; 4] {
@@ -1373,6 +1389,31 @@ impl Object3d {
         *self.instances.borrow_mut().lines_widths.data_mut() = Some(lines_width_data);
         *self.instances.borrow_mut().points_colors.data_mut() = Some(points_col_data);
         *self.instances.borrow_mut().points_sizes.data_mut() = Some(points_size_data);
+    }
+
+    /// Prepares this object's per-instance buffers to be written directly by a
+    /// compute shader, for `count` instances, and returns the raw GPU buffers.
+    ///
+    /// The object will render `count` instances reading position, color and
+    /// deformation straight from these buffers. The caller must fill them — e.g.
+    /// with a compute pass on the same `wgpu::Device` — before the next frame.
+    /// This is an alternative to [`set_instances`](Self::set_instances), which
+    /// uploads the same data from the CPU; use one or the other per frame.
+    ///
+    /// Only the surface attributes (position/color/deformation) are managed
+    /// here; the wireframe/point overlay attributes keep their previous
+    /// contents, so this is intended for plain surface-rendered instances.
+    pub fn instance_compute_buffers(&mut self, count: usize) -> InstanceComputeBuffers {
+        let mut inst = self.instances.borrow_mut();
+        let positions = inst.positions.prepare_gpu_writable(count).clone();
+        let colors = inst.colors.prepare_gpu_writable(count).clone();
+        // Three Vec3 columns (a Mat3) per instance.
+        let deformations = inst.deformations.prepare_gpu_writable(count * 3).clone();
+        InstanceComputeBuffers {
+            positions,
+            colors,
+            deformations,
+        }
     }
 
     /// Enables or disables backface culling for this object.

--- a/src/scene/scene_node2d.rs
+++ b/src/scene/scene_node2d.rs
@@ -6,7 +6,7 @@ use crate::resource::{
     GpuMesh2d, Material2d, MaterialManager2d, MeshManager2d, RenderContext2d, Texture,
     TextureManager,
 };
-use crate::scene::Object2d;
+use crate::scene::{Blend2d, Object2d};
 use glamx::{Pose2, Rot2, Vec2};
 use std::cell::{Ref, RefCell, RefMut};
 use std::f32;
@@ -1017,6 +1017,29 @@ impl SceneNode2d {
     #[inline]
     pub fn set_color_recursive(&mut self, color: Color) -> Self {
         self.apply_to_objects_mut_recursive(&mut |o| o.set_color(color));
+        self.clone()
+    }
+
+    /// Sets how this node's object is composited over the framebuffer.
+    ///
+    /// See [`Blend2d`] for the available modes (additive, multiply, screen, …).
+    /// Defaults to [`Blend2d::Alpha`].
+    ///
+    /// # See also
+    /// * [`Self::set_blend_recursive`] - to also modify all descendants.
+    #[inline]
+    pub fn set_blend(&mut self, blend: Blend2d) -> Self {
+        self.apply_to_object_mut(&mut |o| o.set_blend(blend));
+        self.clone()
+    }
+
+    /// Sets how this node's object and all its descendants are composited.
+    ///
+    /// # See also
+    /// * [`Self::set_blend`] - to only modify this node.
+    #[inline]
+    pub fn set_blend_recursive(&mut self, blend: Blend2d) -> Self {
+        self.apply_to_objects_mut_recursive(&mut |o| o.set_blend(blend));
         self.clone()
     }
 

--- a/src/scene/scene_node2d.rs
+++ b/src/scene/scene_node2d.rs
@@ -1517,4 +1517,17 @@ impl SceneNode2d {
         self.data_mut().get_object_mut().set_instances(instances);
         self.clone()
     }
+
+    /// Prepares this node's per-instance buffers for direct compute writes of
+    /// `count` instances and returns the raw GPU buffers.
+    ///
+    /// See [`Object2d::instance_compute_buffers`](crate::scene::Object2d::instance_compute_buffers).
+    pub fn instance_compute_buffers(
+        &mut self,
+        count: usize,
+    ) -> crate::scene::InstanceComputeBuffers2d {
+        self.data_mut()
+            .get_object_mut()
+            .instance_compute_buffers(count)
+    }
 }

--- a/src/scene/scene_node2d.rs
+++ b/src/scene/scene_node2d.rs
@@ -6,6 +6,7 @@ use crate::resource::{
     GpuMesh2d, Material2d, MaterialManager2d, MeshManager2d, RenderContext2d, Texture,
     TextureManager,
 };
+use crate::builtin::{LitMaterial2d, LitParams};
 use crate::scene::sprite::SpriteSheet;
 use crate::scene::{Blend2d, Border, Object2d};
 use glamx::{Pose2, Rot2, Vec2};
@@ -485,6 +486,26 @@ impl SceneNode2d {
     pub fn nine_slice(size: Vec2, world: Border, uv: Border) -> SceneNode2d {
         let mesh = crate::scene::sprite::nine_slice_mesh(size, world, uv);
         Self::mesh(Rc::new(RefCell::new(mesh)), Vec2::ONE)
+    }
+
+    /// Creates a `width` × `height` sprite quad lit by the dynamic 2D lights, using
+    /// the shared [`LitMaterial2d`].
+    ///
+    /// Give it an albedo texture with `set_texture*`, optionally a normal map with
+    /// [`set_normal_map_from_file`](Self::set_normal_map_from_file), and tune shading
+    /// with [`set_lit_params`](Self::set_lit_params). Populate the lights through the
+    /// [`Light2dManager`](crate::light2d::Light2dManager) each frame.
+    pub fn lit_sprite(width: f32, height: f32) -> SceneNode2d {
+        let mut node = Self::rectangle(width, height);
+        node.set_material(LitMaterial2d::shared());
+        node
+    }
+
+    /// Adds a lit sprite as a child of this node. See [`Self::lit_sprite`].
+    pub fn add_lit_sprite(&mut self, width: f32, height: f32) -> SceneNode2d {
+        let node = Self::lit_sprite(width, height);
+        self.add_child(node.clone());
+        node
     }
 
     /// Removes this node from its parent.
@@ -1082,6 +1103,21 @@ impl SceneNode2d {
     #[inline]
     pub fn set_blend_recursive(&mut self, blend: Blend2d) -> Self {
         self.apply_to_objects_mut_recursive(&mut |o| o.set_blend(blend));
+        self.clone()
+    }
+
+    /// Sets the [`LitParams`] of this node's object (used by [`LitMaterial2d`]).
+    #[inline]
+    pub fn set_lit_params(&mut self, params: LitParams) -> Self {
+        self.apply_to_object_mut(&mut |o| o.set_lit_params(Some(params)));
+        self.clone()
+    }
+
+    /// Loads a normal map from a file and sets it on this node's object, for use with
+    /// [`LitMaterial2d`].
+    #[inline]
+    pub fn set_normal_map_from_file(&mut self, path: &Path, name: &str) -> Self {
+        self.apply_to_object_mut(&mut |o| o.set_normal_map_from_file(path, name));
         self.clone()
     }
 

--- a/src/scene/scene_node2d.rs
+++ b/src/scene/scene_node2d.rs
@@ -1,3 +1,4 @@
+use crate::builtin::{LitMaterial2d, LitParams};
 use crate::camera::Camera2d;
 use crate::color::Color;
 use crate::prelude::InstanceData2d;
@@ -6,7 +7,6 @@ use crate::resource::{
     GpuMesh2d, Material2d, MaterialManager2d, MeshManager2d, RenderContext2d, Texture,
     TextureManager,
 };
-use crate::builtin::{LitMaterial2d, LitParams};
 use crate::scene::sprite::SpriteSheet;
 use crate::scene::{Blend2d, Border, Object2d};
 use glamx::{Pose2, Rot2, Vec2};

--- a/src/scene/scene_node2d.rs
+++ b/src/scene/scene_node2d.rs
@@ -6,7 +6,8 @@ use crate::resource::{
     GpuMesh2d, Material2d, MaterialManager2d, MeshManager2d, RenderContext2d, Texture,
     TextureManager,
 };
-use crate::scene::{Blend2d, Object2d};
+use crate::scene::sprite::SpriteSheet;
+use crate::scene::{Blend2d, Border, Object2d};
 use glamx::{Pose2, Rot2, Vec2};
 use std::cell::{Ref, RefCell, RefMut};
 use std::f32;
@@ -463,6 +464,29 @@ impl SceneNode2d {
         SceneNode2d::new(scale, Pose2::IDENTITY, Some(object))
     }
 
+    /// Creates a new scene node holding a `width` × `height` sprite quad.
+    ///
+    /// A sprite is a textured rectangle: give it a texture with
+    /// [`set_texture_from_file`](Self::set_texture_from_file) (or a sibling setter),
+    /// optionally restrict it to one frame of a [`SpriteSheet`] with
+    /// [`set_sprite_frame`](Self::set_sprite_frame), and pick a [`Blend2d`] mode.
+    pub fn sprite(width: f32, height: f32) -> SceneNode2d {
+        Self::rectangle(width, height)
+    }
+
+    /// Creates a new scene node holding a 9-slice sprite.
+    ///
+    /// The sprite is `size` world units (centered on the origin). Its four corner
+    /// cells keep the `world` border width, the top/bottom and left/right edge cells
+    /// stretch along one axis, and the center cell stretches along both — so a textured
+    /// panel can be resized without distorting its rounded corners or beveled frame.
+    /// The texture is split using the `uv` border (in UV `[0, 1]` units). Attach a
+    /// texture with one of the `set_texture*` methods.
+    pub fn nine_slice(size: Vec2, world: Border, uv: Border) -> SceneNode2d {
+        let mesh = crate::scene::sprite::nine_slice_mesh(size, world, uv);
+        Self::mesh(Rc::new(RefCell::new(mesh)), Vec2::ONE)
+    }
+
     /// Removes this node from its parent.
     pub fn detach(&mut self) {
         let self_self = self.clone();
@@ -579,6 +603,24 @@ impl SceneNode2d {
         line_width: f32,
     ) -> SceneNode2d {
         let node = Self::polyline(vertices, indices, line_width);
+        self.add_child(node.clone());
+        node
+    }
+
+    /// Adds a `width` × `height` sprite quad as a child of this node.
+    ///
+    /// See [`Self::sprite`].
+    pub fn add_sprite(&mut self, width: f32, height: f32) -> SceneNode2d {
+        let node = Self::sprite(width, height);
+        self.add_child(node.clone());
+        node
+    }
+
+    /// Adds a 9-slice sprite as a child of this node.
+    ///
+    /// See [`Self::nine_slice`].
+    pub fn add_nine_slice(&mut self, size: Vec2, world: Border, uv: Border) -> SceneNode2d {
+        let node = Self::nine_slice(size, world, uv);
         self.add_child(node.clone());
         node
     }
@@ -1041,6 +1083,48 @@ impl SceneNode2d {
     pub fn set_blend_recursive(&mut self, blend: Blend2d) -> Self {
         self.apply_to_objects_mut_recursive(&mut |o| o.set_blend(blend));
         self.clone()
+    }
+
+    /// Remaps this object's texture coordinates to the `[min, max]` sub-rectangle of
+    /// its texture (UV origin at the texture's top-left), selecting a region of an
+    /// atlas or sprite sheet.
+    ///
+    /// Each vertex's UV is recomputed from its normalized position within the mesh's
+    /// bounding box, so this is repeatable (calling it again replaces the previous
+    /// rect rather than compounding) and works for any quad sprite.
+    pub fn set_uv_rect(&mut self, min: Vec2, max: Vec2) -> Self {
+        let mut verts = Vec::new();
+        self.read_vertices(&mut |v| verts.extend_from_slice(v));
+        if verts.is_empty() {
+            return self.clone();
+        }
+
+        let mut lo = verts[0];
+        let mut hi = verts[0];
+        for v in &verts {
+            lo = lo.min(*v);
+            hi = hi.max(*v);
+        }
+        let extent = (hi - lo).max(Vec2::splat(f32::EPSILON));
+        let span = max - min;
+
+        self.modify_uvs(&mut |uvs| {
+            for (uv, v) in uvs.iter_mut().zip(verts.iter()) {
+                // Normalized position in the quad: 0 at left / top (world y is up, so
+                // the top edge `hi.y` maps to UV v = 0).
+                let nx = (v.x - lo.x) / extent.x;
+                let ny = (hi.y - v.y) / extent.y;
+                *uv = min + Vec2::new(nx, ny) * span;
+            }
+        });
+        self.clone()
+    }
+
+    /// Shows frame `index` of `sheet` on this sprite by remapping its UVs to that
+    /// frame's cell. Step `index` over time for flip-book animation. See [`SpriteSheet`].
+    pub fn set_sprite_frame(&mut self, sheet: &SpriteSheet, index: u32) -> Self {
+        let (min, max) = sheet.frame_uv(index);
+        self.set_uv_rect(min, max)
     }
 
     /// Sets the texture of this node's object only.

--- a/src/scene/scene_node3d.rs
+++ b/src/scene/scene_node3d.rs
@@ -3102,6 +3102,22 @@ impl SceneNode3d {
         self.data_mut().get_object_mut().set_instances(instances);
         self.clone()
     }
+
+    /// Prepares this node's per-instance buffers for direct compute writes of
+    /// `count` instances and returns the raw GPU buffers.
+    ///
+    /// See [`Object3d::instance_compute_buffers`](crate::scene::Object3d::instance_compute_buffers):
+    /// a compute shader on the shared `wgpu::Device` fills position/color/
+    /// deformation directly, instead of uploading them from the CPU via
+    /// [`set_instances`](Self::set_instances).
+    pub fn instance_compute_buffers(
+        &mut self,
+        count: usize,
+    ) -> crate::scene::InstanceComputeBuffers {
+        self.data_mut()
+            .get_object_mut()
+            .instance_compute_buffers(count)
+    }
 }
 
 /// The proper world matrix of a node, composing full per-node TRS (`T · R · S`)

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -23,7 +23,10 @@ pub struct SpriteSheet {
 impl SpriteSheet {
     /// A sheet with `columns` × `rows` equally-sized frames.
     pub fn new(columns: u32, rows: u32) -> Self {
-        assert!(columns > 0 && rows > 0, "sprite sheet needs a non-empty grid");
+        assert!(
+            columns > 0 && rows > 0,
+            "sprite sheet needs a non-empty grid"
+        );
         SpriteSheet { columns, rows }
     }
 
@@ -50,7 +53,7 @@ impl SpriteSheet {
 }
 
 /// Per-edge insets (left, right, top, bottom), reused for both the world-space border
-/// width and the texture-space (UV) border of a [9-slice](SceneNode2d::nine_slice) sprite.
+/// width and the texture-space (UV) border of a [9-slice](crate::scene::SceneNode2d::nine_slice) sprite.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Border {
     /// Left inset.

--- a/src/scene/sprite.rs
+++ b/src/scene/sprite.rs
@@ -1,0 +1,125 @@
+//! Sprite helpers: sprite-sheet frame layout, 9-slice borders, and the mesh
+//! builders behind [`SceneNode2d::sprite`](crate::scene::SceneNode2d::sprite) and
+//! [`SceneNode2d::nine_slice`](crate::scene::SceneNode2d::nine_slice).
+
+use crate::resource::vertex_index::VertexIndex;
+use crate::resource::GpuMesh2d;
+use glamx::Vec2;
+
+/// A regular grid of equally-sized frames packed into one texture (a sprite sheet /
+/// texture atlas), used to animate or index a sprite by frame number.
+///
+/// Frames are numbered left-to-right, top-to-bottom starting at 0. Pair it with
+/// [`SceneNode2d::set_sprite_frame`](crate::scene::SceneNode2d::set_sprite_frame) to
+/// show one frame, or step `index` over time for flip-book animation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SpriteSheet {
+    /// Number of frame columns across the texture.
+    pub columns: u32,
+    /// Number of frame rows down the texture.
+    pub rows: u32,
+}
+
+impl SpriteSheet {
+    /// A sheet with `columns` × `rows` equally-sized frames.
+    pub fn new(columns: u32, rows: u32) -> Self {
+        assert!(columns > 0 && rows > 0, "sprite sheet needs a non-empty grid");
+        SpriteSheet { columns, rows }
+    }
+
+    /// The total number of frames in the sheet.
+    pub fn len(&self) -> u32 {
+        self.columns * self.rows
+    }
+
+    /// Whether the sheet has no frames (never true for a sheet built with [`Self::new`]).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The `(min, max)` UV rectangle of frame `index` (wrapping past the last frame),
+    /// with UV origin at the top-left of the texture.
+    pub fn frame_uv(&self, index: u32) -> (Vec2, Vec2) {
+        let index = index % self.len();
+        let col = index % self.columns;
+        let row = index / self.columns;
+        let cell = Vec2::new(1.0 / self.columns as f32, 1.0 / self.rows as f32);
+        let min = Vec2::new(col as f32, row as f32) * cell;
+        (min, min + cell)
+    }
+}
+
+/// Per-edge insets (left, right, top, bottom), reused for both the world-space border
+/// width and the texture-space (UV) border of a [9-slice](SceneNode2d::nine_slice) sprite.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Border {
+    /// Left inset.
+    pub left: f32,
+    /// Right inset.
+    pub right: f32,
+    /// Top inset.
+    pub top: f32,
+    /// Bottom inset.
+    pub bottom: f32,
+}
+
+impl Border {
+    /// A border with the same inset on all four edges.
+    pub fn uniform(inset: f32) -> Self {
+        Border {
+            left: inset,
+            right: inset,
+            top: inset,
+            bottom: inset,
+        }
+    }
+
+    /// A border with independent horizontal and vertical insets.
+    pub fn symmetric(horizontal: f32, vertical: f32) -> Self {
+        Border {
+            left: horizontal,
+            right: horizontal,
+            top: vertical,
+            bottom: vertical,
+        }
+    }
+}
+
+/// Builds the 16-vertex / 9-quad mesh of a 9-slice sprite of total size `size`
+/// (centered on the origin), whose corner cells keep `world` size while the center
+/// and edge cells stretch, sampling the texture split by the `uv` border.
+pub(crate) fn nine_slice_mesh(size: Vec2, world: Border, uv: Border) -> GpuMesh2d {
+    let hx = size.x * 0.5;
+    let hy = size.y * 0.5;
+
+    // Column x positions (left→right) and row y positions (top→bottom, world y-up).
+    let xs = [-hx, -hx + world.left, hx - world.right, hx];
+    let ys = [hy, hy - world.top, -hy + world.bottom, -hy];
+    // Matching UV columns/rows, UV origin at the texture's top-left.
+    let us = [0.0, uv.left, 1.0 - uv.right, 1.0];
+    let vs = [0.0, uv.top, 1.0 - uv.bottom, 1.0];
+
+    let mut coords = Vec::with_capacity(16);
+    let mut uvs = Vec::with_capacity(16);
+    for j in 0..4 {
+        for i in 0..4 {
+            coords.push(Vec2::new(xs[i], ys[j]));
+            uvs.push(Vec2::new(us[i], vs[j]));
+        }
+    }
+
+    // Two triangles per cell. Backface culling is off for 2D, so winding is free.
+    let mut faces = Vec::with_capacity(18);
+    for j in 0..3u32 {
+        for i in 0..3u32 {
+            let tl = (j * 4 + i) as VertexIndex;
+            let tr = tl + 1;
+            let bl = tl + 4;
+            let br = bl + 1;
+            faces.push([tl, bl, br]);
+            faces.push([tl, br, tr]);
+        }
+    }
+
+    GpuMesh2d::new(coords, faces, Some(uvs), false)
+}

--- a/src/scene/tilemap.rs
+++ b/src/scene/tilemap.rs
@@ -1,0 +1,174 @@
+//! A [`Tilemap`]: a grid of tiles drawn from a single texture atlas as one mesh.
+//!
+//! A tilemap bakes one textured quad per non-empty tile into a single
+//! [`SceneNode2d`] mesh, so a whole map is one draw call sharing the standard 2D
+//! material (and thus blend modes, the camera, etc.). Tiles index a [`SpriteSheet`]
+//! atlas; updating a tile rebuilds the mesh.
+
+use crate::resource::vertex_index::VertexIndex;
+use crate::resource::GpuMesh2d;
+use crate::scene::sprite::SpriteSheet;
+use crate::scene::SceneNode2d;
+use glamx::Vec2;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// A grid of tiles rendered as a single atlas-textured mesh.
+///
+/// Build one with [`Tilemap::new`], assign the atlas texture to its
+/// [`node`](Tilemap::node) (`set_texture_*`), add that node to the scene, and edit
+/// the map with [`set_tile`](Tilemap::set_tile) / [`fill`](Tilemap::fill).
+pub struct Tilemap {
+    node: SceneNode2d,
+    columns: u32,
+    rows: u32,
+    tile_size: Vec2,
+    sheet: SpriteSheet,
+    tiles: Vec<u32>,
+}
+
+impl Tilemap {
+    /// Tile value meaning "no tile here" (the cell is left empty / transparent).
+    pub const EMPTY: u32 = u32::MAX;
+
+    /// Creates a `columns` × `rows` tilemap of `tile_size`-world-unit tiles, indexing
+    /// frames of `sheet`. The map starts entirely empty and is centered on the origin.
+    pub fn new(columns: u32, rows: u32, tile_size: Vec2, sheet: SpriteSheet) -> Tilemap {
+        let tiles = vec![Self::EMPTY; (columns * rows) as usize];
+        let mesh = build_mesh(columns, rows, tile_size, &sheet, &tiles);
+        let node = SceneNode2d::mesh(Rc::new(RefCell::new(mesh)), Vec2::ONE);
+        Tilemap {
+            node,
+            columns,
+            rows,
+            tile_size,
+            sheet,
+            tiles,
+        }
+    }
+
+    /// The scene node holding the tilemap mesh. Clone it to add it to the scene or to
+    /// set its atlas texture, e.g. `tilemap.node().set_texture_with_name("atlas")`.
+    pub fn node(&self) -> SceneNode2d {
+        self.node.clone()
+    }
+
+    /// The map dimensions in tiles, `(columns, rows)`.
+    pub fn dimensions(&self) -> (u32, u32) {
+        (self.columns, self.rows)
+    }
+
+    /// The frame index at `(col, row)`, or [`Self::EMPTY`] if out of range / empty.
+    pub fn tile(&self, col: u32, row: u32) -> u32 {
+        if col < self.columns && row < self.rows {
+            self.tiles[(row * self.columns + col) as usize]
+        } else {
+            Self::EMPTY
+        }
+    }
+
+    /// Sets the frame index at `(col, row)` (use [`Self::EMPTY`] to clear it) and
+    /// rebuilds the mesh. Out-of-range coordinates are ignored.
+    pub fn set_tile(&mut self, col: u32, row: u32, index: u32) {
+        if col >= self.columns || row >= self.rows {
+            return;
+        }
+        self.tiles[(row * self.columns + col) as usize] = index;
+        self.rebuild();
+    }
+
+    /// Replaces every tile from a row-major slice (extra cells are left empty) and
+    /// rebuilds the mesh once.
+    pub fn fill(&mut self, indices: &[u32]) {
+        for (dst, &src) in self.tiles.iter_mut().zip(indices.iter()) {
+            *dst = src;
+        }
+        self.rebuild();
+    }
+
+    /// Rebuilds the mesh from the current tile grid.
+    fn rebuild(&mut self) {
+        let (coords, faces, uvs) =
+            build_mesh_data(self.columns, self.rows, self.tile_size, &self.sheet, &self.tiles);
+        // Replace the mesh contents in place so the node keeps its identity.
+        self.node.modify_vertices(&mut |v| {
+            v.clear();
+            v.extend_from_slice(&coords);
+        });
+        self.node.modify_faces(&mut |f| {
+            f.clear();
+            f.extend_from_slice(&faces);
+        });
+        self.node.modify_uvs(&mut |u| {
+            u.clear();
+            u.extend_from_slice(&uvs);
+        });
+    }
+}
+
+/// Builds the `(coords, faces, uvs)` of the tilemap mesh: one quad per non-empty tile.
+fn build_mesh_data(
+    columns: u32,
+    rows: u32,
+    tile_size: Vec2,
+    sheet: &SpriteSheet,
+    tiles: &[u32],
+) -> (Vec<Vec2>, Vec<[VertexIndex; 3]>, Vec<Vec2>) {
+    let mut coords = Vec::new();
+    let mut uvs = Vec::new();
+    let mut faces = Vec::new();
+
+    let half = Vec2::new(columns as f32, rows as f32) * tile_size * 0.5;
+
+    for row in 0..rows {
+        for col in 0..columns {
+            let index = tiles[(row * columns + col) as usize];
+            if index == Tilemap::EMPTY {
+                continue;
+            }
+
+            // Tile corners in world space (row 0 at the top, world y up).
+            let x0 = col as f32 * tile_size.x - half.x;
+            let x1 = x0 + tile_size.x;
+            let y1 = half.y - row as f32 * tile_size.y;
+            let y0 = y1 - tile_size.y;
+
+            let (uv_min, uv_max) = sheet.frame_uv(index);
+
+            let base = coords.len() as VertexIndex;
+            // top-left, top-right, bottom-right, bottom-left
+            coords.push(Vec2::new(x0, y1));
+            coords.push(Vec2::new(x1, y1));
+            coords.push(Vec2::new(x1, y0));
+            coords.push(Vec2::new(x0, y0));
+            uvs.push(Vec2::new(uv_min.x, uv_min.y));
+            uvs.push(Vec2::new(uv_max.x, uv_min.y));
+            uvs.push(Vec2::new(uv_max.x, uv_max.y));
+            uvs.push(Vec2::new(uv_min.x, uv_max.y));
+
+            faces.push([base, base + 1, base + 2]);
+            faces.push([base, base + 2, base + 3]);
+        }
+    }
+
+    // A mesh must never be empty (zero vertices breaks buffer creation); emit a
+    // single degenerate triangle when the whole map is empty.
+    if coords.is_empty() {
+        coords.push(Vec2::ZERO);
+        uvs.push(Vec2::ZERO);
+        faces.push([0, 0, 0]);
+    }
+
+    (coords, faces, uvs)
+}
+
+fn build_mesh(
+    columns: u32,
+    rows: u32,
+    tile_size: Vec2,
+    sheet: &SpriteSheet,
+    tiles: &[u32],
+) -> GpuMesh2d {
+    let (coords, faces, uvs) = build_mesh_data(columns, rows, tile_size, sheet, tiles);
+    GpuMesh2d::new(coords, faces, Some(uvs), true)
+}

--- a/src/scene/tilemap.rs
+++ b/src/scene/tilemap.rs
@@ -88,8 +88,13 @@ impl Tilemap {
 
     /// Rebuilds the mesh from the current tile grid.
     fn rebuild(&mut self) {
-        let (coords, faces, uvs) =
-            build_mesh_data(self.columns, self.rows, self.tile_size, &self.sheet, &self.tiles);
+        let (coords, faces, uvs) = build_mesh_data(
+            self.columns,
+            self.rows,
+            self.tile_size,
+            &self.sheet,
+            &self.tiles,
+        );
         // Replace the mesh contents in place so the node keeps its identity.
         self.node.modify_vertices(&mut |v| {
             v.clear();

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -21,7 +21,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::builtin::{LitParams, ObjectMaterial};
+    use crate::builtin::{Bone2d, LitParams, ObjectMaterial, SkinVertex2d, SkinnedMesh2d};
     use crate::camera::{CoordinateSystem2d, FixedView2d, OrbitCamera3d};
     use crate::light2d::{Light2d, Light2dManager};
     use crate::context::Context;
@@ -32,7 +32,7 @@ mod tests {
     use crate::renderer::RayTracer;
     use crate::scene::{AlphaMode, SceneNode2d, SceneNode3d, SpriteSheet, Tilemap};
     use crate::window::OffscreenSurface;
-    use glamx::{Vec2, Vec3};
+    use glamx::{Pose2, Vec2, Vec3};
 
     use crate::color::Color;
 
@@ -141,6 +141,43 @@ mod tests {
         s
     }
 
+    /// A small 3-bone vertical strip skinned mesh.
+    fn demo_skinned_mesh() -> SkinnedMesh2d {
+        let mut verts = Vec::new();
+        for row in 0..3u32 {
+            for &x in &[-12.0f32, 12.0] {
+                verts.push(SkinVertex2d {
+                    position: Vec2::new(x, row as f32 * 30.0),
+                    uv: Vec2::new((x + 12.0) / 24.0, row as f32 / 2.0),
+                    joints: [row, 0, 0, 0],
+                    weights: [1.0, 0.0, 0.0, 0.0],
+                });
+            }
+        }
+        // Two quads (rows 0-1 and 1-2).
+        let faces = vec![
+            [0, 1, 3],
+            [0, 3, 2],
+            [2, 3, 5],
+            [2, 5, 4],
+        ];
+        let bones = vec![
+            Bone2d {
+                parent: None,
+                local: Pose2::IDENTITY,
+            },
+            Bone2d {
+                parent: Some(0),
+                local: Pose2::from_translation(Vec2::new(0.0, 30.0)),
+            },
+            Bone2d {
+                parent: Some(1),
+                local: Pose2::from_translation(Vec2::new(0.0, 30.0)),
+            },
+        ];
+        SkinnedMesh2d::new(verts, faces, bones)
+    }
+
     #[test]
     fn all_shaders_instantiate() {
         crate::pollster::block_on(async {
@@ -203,6 +240,13 @@ mod tests {
             });
             let mut cam2 = FixedView2d::new(CoordinateSystem2d::default(), false);
             let mut scene2 = demo_scene_2d();
+            // Skinned 2D mesh: a 3-bone vertical strip, posed and rendered.
+            let mut skinned = demo_skinned_mesh();
+            skinned.set_bone_local(1, Pose2::new(Vec2::new(0.0, 60.0), 0.3));
+            skinned.update();
+            let mut snode = skinned.node();
+            snode.set_position(Vec2::new(-40.0, -30.0));
+            scene2.add_child(snode);
             surface.render_2d(&mut scene2, &mut cam2).await;
 
             // 4) Path tracer (rt_kernel / denoise / rt tonemap).

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -337,6 +337,17 @@ mod tests {
                     .await;
             }
 
+            // 6) Chained post-processing (exercises the ping-pong path: resolve → A,
+            // effect 0 A→B, effect 1 B→frame).
+            {
+                let mut a = Fxaa::new();
+                let mut b = Crt::new();
+                let mut chain: [&mut dyn PostProcessingEffect; 2] = [&mut a, &mut b];
+                surface
+                    .render_chain(Some(&mut scene), None, Some(&mut cam), None, None, &mut chain)
+                    .await;
+            }
+
             // Any invalid shader/pipeline created above is captured here.
             let err = scope.pop().await;
             assert!(err.is_none(), "shader validation error: {:?}", err);

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -21,8 +21,9 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::builtin::ObjectMaterial;
+    use crate::builtin::{LitParams, ObjectMaterial};
     use crate::camera::{CoordinateSystem2d, FixedView2d, OrbitCamera3d};
+    use crate::light2d::{Light2d, Light2dManager};
     use crate::context::Context;
     use crate::light::Light;
     use crate::post_processing::{
@@ -108,6 +109,27 @@ mod tests {
         s.add_rectangle(50.0, 50.0)
             .set_lines_width(2.0, false)
             .set_position(Vec2::new(60.0, -40.0));
+        // Non-default blend modes exercise the extra surface pipelines.
+        s.add_rectangle(40.0, 40.0)
+            .set_color(Color::new(0.8, 0.2, 0.2, 0.6))
+            .set_blend(crate::scene::Blend2d::Additive)
+            .set_position(Vec2::new(0.0, 70.0));
+        s.add_rectangle(40.0, 40.0)
+            .set_color(Color::new(0.2, 0.8, 0.2, 0.6))
+            .set_blend(crate::scene::Blend2d::Multiply)
+            .set_position(Vec2::new(20.0, 70.0));
+        // Sprite quad + 9-slice mesh (object2d shader, more vertices).
+        s.add_sprite(30.0, 30.0).set_position(Vec2::new(-60.0, 60.0));
+        s.add_nine_slice(
+            Vec2::new(60.0, 40.0),
+            crate::scene::Border::uniform(8.0),
+            crate::scene::Border::uniform(0.25),
+        )
+        .set_position(Vec2::new(-60.0, 0.0));
+        // Lit material (uses the default flat normal map + global 2D lights).
+        s.add_lit_sprite(40.0, 40.0)
+            .set_lit_params(LitParams::default().with_specular(0.5, 24.0))
+            .set_position(Vec2::new(80.0, 0.0));
         s
     }
 
@@ -155,7 +177,22 @@ mod tests {
                 surface.render_3d(&mut scene, &mut cam).await;
             }
 
-            // 3) 2D scene (object2d / points2d / polyline2d / wireframe).
+            // 3) 2D scene (object2d / points2d / polyline2d / wireframe / sdf2d / lit2d).
+            Light2dManager::get_global_manager(|m| {
+                m.set_ambient(Color::new(0.1, 0.1, 0.12, 1.0));
+                m.set_lights(&[
+                    Light2d::point(Vec2::new(80.0, 30.0), Color::new(1.0, 0.9, 0.8, 1.0), 2.0, 200.0),
+                    Light2d::spot(
+                        Vec2::new(40.0, 60.0),
+                        Vec2::new(0.0, -1.0),
+                        Color::new(0.6, 0.8, 1.0, 1.0),
+                        2.0,
+                        180.0,
+                        0.3,
+                        0.6,
+                    ),
+                ]);
+            });
             let mut cam2 = FixedView2d::new(CoordinateSystem2d::default(), false);
             let mut scene2 = demo_scene_2d();
             surface.render_2d(&mut scene2, &mut cam2).await;

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -109,6 +109,14 @@ mod tests {
         s.add_rectangle(50.0, 50.0)
             .set_lines_width(2.0, false)
             .set_position(Vec2::new(60.0, -40.0));
+        // A textured object exercises the `textured` über-shader variant (solid
+        // objects above use the default white texture → the untextured variant).
+        let tex = crate::resource::TextureManager::get_global_manager(|tm| {
+            tm.add_empty("shader_validity_tex")
+        });
+        let mut textured = s.add_rectangle(30.0, 30.0);
+        textured.data_mut().get_object_mut().set_texture(tex);
+        textured.set_position(Vec2::new(-90.0, -70.0));
         // Non-default blend modes exercise the extra surface pipelines.
         s.add_rectangle(40.0, 40.0)
             .set_color(Color::new(0.8, 0.2, 0.2, 0.6))

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -30,7 +30,7 @@ mod tests {
         Cas, Crt, Fxaa, Grayscales, OculusStereo, PostProcessingEffect, SobelEdgeHighlight, Waves,
     };
     use crate::renderer::RayTracer;
-    use crate::scene::{AlphaMode, SceneNode2d, SceneNode3d};
+    use crate::scene::{AlphaMode, SceneNode2d, SceneNode3d, SpriteSheet, Tilemap};
     use crate::window::OffscreenSurface;
     use glamx::{Vec2, Vec3};
 
@@ -130,6 +130,14 @@ mod tests {
         s.add_lit_sprite(40.0, 40.0)
             .set_lit_params(LitParams::default().with_specular(0.5, 24.0))
             .set_position(Vec2::new(80.0, 0.0));
+        // Tilemap mesh (atlas-textured single mesh, a few tiles set).
+        let mut tm = Tilemap::new(4, 4, Vec2::new(14.0, 14.0), SpriteSheet::new(2, 2));
+        tm.set_tile(0, 0, 0);
+        tm.set_tile(1, 1, 1);
+        tm.set_tile(2, 3, 2);
+        let mut tnode = tm.node();
+        tnode.set_position(Vec2::new(-90.0, 70.0));
+        s.add_child(tnode);
         s
     }
 

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -23,9 +23,9 @@
 mod tests {
     use crate::builtin::{Bone2d, LitParams, ObjectMaterial, SkinVertex2d, SkinnedMesh2d};
     use crate::camera::{CoordinateSystem2d, FixedView2d, OrbitCamera3d};
-    use crate::light2d::{Light2d, Light2dManager};
     use crate::context::Context;
     use crate::light::Light;
+    use crate::light2d::{Light2d, Light2dManager};
     use crate::post_processing::{
         Cas, Crt, Fxaa, Gi2d, GiEmitter2d, GiOccluder2d, Grayscales, OculusStereo,
         PostProcessingEffect, SobelEdgeHighlight, Waves,
@@ -128,7 +128,8 @@ mod tests {
             .set_blend(crate::scene::Blend2d::Multiply)
             .set_position(Vec2::new(20.0, 70.0));
         // Sprite quad + 9-slice mesh (object2d shader, more vertices).
-        s.add_sprite(30.0, 30.0).set_position(Vec2::new(-60.0, 60.0));
+        s.add_sprite(30.0, 30.0)
+            .set_position(Vec2::new(-60.0, 60.0));
         s.add_nine_slice(
             Vec2::new(60.0, 40.0),
             crate::scene::Border::uniform(8.0),
@@ -164,12 +165,7 @@ mod tests {
             }
         }
         // Two quads (rows 0-1 and 1-2).
-        let faces = vec![
-            [0, 1, 3],
-            [0, 3, 2],
-            [2, 3, 5],
-            [2, 5, 4],
-        ];
+        let faces = vec![[0, 1, 3], [0, 3, 2], [2, 3, 5], [2, 5, 4]];
         let bones = vec![
             Bone2d {
                 parent: None,
@@ -235,7 +231,12 @@ mod tests {
             Light2dManager::get_global_manager(|m| {
                 m.set_ambient(Color::new(0.1, 0.1, 0.12, 1.0));
                 m.set_lights(&[
-                    Light2d::point(Vec2::new(80.0, 30.0), Color::new(1.0, 0.9, 0.8, 1.0), 2.0, 200.0),
+                    Light2d::point(
+                        Vec2::new(80.0, 30.0),
+                        Color::new(1.0, 0.9, 0.8, 1.0),
+                        2.0,
+                        200.0,
+                    ),
                     Light2d::spot(
                         Vec2::new(40.0, 60.0),
                         Vec2::new(0.0, -1.0),
@@ -344,7 +345,14 @@ mod tests {
                 let mut b = Crt::new();
                 let mut chain: [&mut dyn PostProcessingEffect; 2] = [&mut a, &mut b];
                 surface
-                    .render_chain(Some(&mut scene), None, Some(&mut cam), None, None, &mut chain)
+                    .render_chain(
+                        Some(&mut scene),
+                        None,
+                        Some(&mut cam),
+                        None,
+                        None,
+                        &mut chain,
+                    )
                     .await;
             }
 

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -26,7 +26,7 @@ mod tests {
     use crate::context::Context;
     use crate::light::Light;
     use crate::post_processing::{
-        Cas, Fxaa, Grayscales, OculusStereo, PostProcessingEffect, SobelEdgeHighlight, Waves,
+        Cas, Crt, Fxaa, Grayscales, OculusStereo, PostProcessingEffect, SobelEdgeHighlight, Waves,
     };
     use crate::renderer::RayTracer;
     use crate::scene::{AlphaMode, SceneNode2d, SceneNode3d};
@@ -173,6 +173,7 @@ mod tests {
                 Box::new(Grayscales::new()),
                 Box::new(Waves::new()),
                 Box::new(OculusStereo::new()),
+                Box::new(Crt::new()),
             ];
             for eff in &mut effects {
                 surface

--- a/src/shader_validity.rs
+++ b/src/shader_validity.rs
@@ -27,7 +27,8 @@ mod tests {
     use crate::context::Context;
     use crate::light::Light;
     use crate::post_processing::{
-        Cas, Crt, Fxaa, Grayscales, OculusStereo, PostProcessingEffect, SobelEdgeHighlight, Waves,
+        Cas, Crt, Fxaa, Gi2d, GiEmitter2d, GiOccluder2d, Grayscales, OculusStereo,
+        PostProcessingEffect, SobelEdgeHighlight, Waves,
     };
     use crate::renderer::RayTracer;
     use crate::scene::{AlphaMode, SceneNode2d, SceneNode3d, SpriteSheet, Tilemap};
@@ -257,6 +258,56 @@ mod tests {
             scene2.add_child(snode);
             surface.render_2d(&mut scene2, &mut cam2).await;
 
+            // GI with the jump-flood occluder SDF path (seed / step / resolve shaders).
+            {
+                let mut gi = Gi2d::new();
+                gi.set_sdf_occluders(true);
+                gi.set_camera(&cam2);
+                gi.set_occluders(&[GiOccluder2d::new(Vec2::ZERO, 20.0)]);
+                gi.set_emitters(&[GiEmitter2d::new(
+                    Vec2::new(40.0, 0.0),
+                    8.0,
+                    Color::new(1.0, 0.9, 0.7, 1.0),
+                    2.0,
+                )]);
+                surface
+                    .render(
+                        None,
+                        Some(&mut scene2),
+                        None,
+                        Some(&mut cam2),
+                        None,
+                        Some(&mut gi),
+                    )
+                    .await;
+            }
+
+            // GI via the radiance-cascade solver (cascade + cascade-composite shaders).
+            {
+                let mut gi = Gi2d::new();
+                gi.set_radiance_cascades(true);
+                gi.set_cascade_count(4);
+                gi.set_sdf_occluders(true); // exercises the SDF-cascade march path
+                gi.set_camera(&cam2);
+                gi.set_occluders(&[GiOccluder2d::new(Vec2::ZERO, 20.0)]);
+                gi.set_emitters(&[GiEmitter2d::new(
+                    Vec2::new(60.0, 0.0),
+                    10.0,
+                    Color::new(1.0, 0.9, 0.7, 1.0),
+                    2.0,
+                )]);
+                surface
+                    .render(
+                        None,
+                        Some(&mut scene2),
+                        None,
+                        Some(&mut cam2),
+                        None,
+                        Some(&mut gi),
+                    )
+                    .await;
+            }
+
             // 4) Path tracer (rt_kernel / denoise / rt tonemap).
             let mut rt = RayTracer::new();
             let mut rt_scene = demo_scene_3d();
@@ -271,6 +322,7 @@ mod tests {
                 Box::new(Waves::new()),
                 Box::new(OculusStereo::new()),
                 Box::new(Crt::new()),
+                Box::new(Gi2d::new()),
             ];
             for eff in &mut effects {
                 surface

--- a/src/window/aov.rs
+++ b/src/window/aov.rs
@@ -132,6 +132,104 @@ impl Window {
         img
     }
 
+    /// Renders an auxiliary output (depth, normals or segmentation) of the
+    /// scene as a **display-ready image** into the window's offscreen output
+    /// texture, entirely on the GPU — no CPU read-back, so unlike the `snap_*`
+    /// methods this also works on the web.
+    ///
+    /// Meant for [`OffscreenSurface::render_aov_3d`](crate::window::OffscreenSurface::render_aov_3d):
+    /// display the result by registering the surface's
+    /// [`output_view`](crate::window::OffscreenSurface::output_view) with a
+    /// visible window's egui renderer. On native, `snap`/`snap_image` read the
+    /// visualized image back afterwards (useful for testing).
+    ///
+    /// Depth is mapped over `[0, depth_range]` world units (nearest = bright,
+    /// background = black); the other kinds ignore `depth_range`. Normals are
+    /// encoded to RGB and segmentation ids to distinct colors, exactly like
+    /// [`snap_normals`](Self::snap_normals) /
+    /// [`snap_segmentation_colored`](Self::snap_segmentation_colored).
+    pub fn render_aov_3d(
+        &mut self,
+        kind: AovKind,
+        scene: &mut SceneNode3d,
+        camera: &mut dyn Camera3d,
+        depth_range: f32,
+    ) {
+        let w = self.width().max(1);
+        let h = self.height().max(1);
+        let ctxt = Context::get();
+
+        // Make sure the camera matrices match the target size, then propagate
+        // world transforms so the AOV renderer can read them per object.
+        camera.update(&self.canvas);
+        let mut lights = LightCollection::with_ambient(self.ambient_intensity);
+        scene.data_mut().prepare(0, camera, &mut lights, w, h);
+
+        // Raw AOV target (sampled by the visualize pass below) + depth.
+        let color = ctxt.create_texture(&wgpu::TextureDescriptor {
+            label: Some("aov_color_texture"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: kind.format(),
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let color_view = color.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let depth = ctxt.create_texture(&wgpu::TextureDescriptor {
+            label: Some("aov_depth_texture"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: Context::depth_format(),
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let depth_view = depth.create_view(&wgpu::TextureViewDescriptor::default());
+
+        if self.aov_renderer.is_none() {
+            self.aov_renderer = Some(AovRenderer::new());
+        }
+
+        let out_view = self.offscreen_output_view();
+        let out_format = self.canvas.surface_format();
+
+        let mut encoder = ctxt.create_command_encoder(Some("aov_encoder"));
+        let aov = self.aov_renderer.as_mut().unwrap();
+        aov.render(kind, scene, camera, &mut encoder, &color_view, &depth_view);
+        aov.visualize_into(
+            kind,
+            &mut encoder,
+            &color_view,
+            &out_view,
+            out_format,
+            depth_range,
+        );
+        ctxt.submit(std::iter::once(encoder.finish()));
+
+        // Mirror the regular render path: copy the output into the readback
+        // texture so `snap`/`snap_image` see the visualized AOV on native.
+        let out_color = self
+            .offscreen_output_target
+            .as_ref()
+            .expect("offscreen output target was just created")
+            .color_texture()
+            .expect("offscreen render target is never the screen")
+            .clone();
+        self.canvas.copy_texture_to_readback(&out_color);
+    }
+
     /// Linearly normalizes a raw linear-depth buffer into an 8-bit grayscale
     /// image (nearest surface brightest, background black).
     pub fn depth_to_luma8(

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -49,6 +49,10 @@ pub struct CanvasSetup {
     /// let mut window = Window::new_with_setup("Title", 800, 600, setup);
     /// ```
     pub canvas_id: String,
+    /// Extra wgpu device features to request when creating the device, on top of
+    /// the ones kiss3d enables by default.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub required_features: wgpu::Features,
 }
 
 impl Default for CanvasSetup {
@@ -57,6 +61,7 @@ impl Default for CanvasSetup {
             vsync: true,
             samples: NumSamples::Four,
             canvas_id: "canvas".to_string(),
+            required_features: wgpu::Features::empty(),
         }
     }
 }

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -79,7 +79,6 @@ impl Canvas {
     }
 
     /// Open a headless canvas (no window) for off-screen rendering.
-    #[cfg(not(target_arch = "wasm32"))]
     pub async fn open_headless(
         width: u32,
         height: u32,

--- a/src/window/egui_integration.rs
+++ b/src/window/egui_integration.rs
@@ -59,6 +59,35 @@ impl Window {
         self.egui_context.renderer.context()
     }
 
+    /// Registers a native wgpu texture view with this window's egui renderer,
+    /// returning a [`egui::TextureId`] that can be drawn with
+    /// `ui.image((id, size))` inside [`Window::draw_ui`] — entirely on the
+    /// GPU, no read-back, so it works on the web too.
+    ///
+    /// Typical use: display the live output of an
+    /// [`OffscreenSurface`](crate::window::OffscreenSurface) (its
+    /// [`output_view`](crate::window::OffscreenSurface::output_view)) as a
+    /// picture-in-picture panel.
+    ///
+    /// The id stays valid until [`Window::unregister_egui_texture`]. If the
+    /// underlying texture is reallocated (e.g. the surface is resized),
+    /// re-register the new view.
+    pub fn register_egui_texture(
+        &mut self,
+        view: &wgpu::TextureView,
+        filter: wgpu::FilterMode,
+    ) -> egui::TextureId {
+        self.egui_context
+            .renderer
+            .register_native_texture(view, filter)
+    }
+
+    /// Frees a texture id previously returned by
+    /// [`Window::register_egui_texture`].
+    pub fn unregister_egui_texture(&mut self, id: egui::TextureId) {
+        self.egui_context.renderer.unregister_native_texture(id)
+    }
+
     /// Checks if egui is currently capturing mouse input.
     ///
     /// Returns `true` if the mouse is hovering over or interacting with an egui widget.

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -8,7 +8,6 @@ mod egui_integration;
 mod events;
 #[cfg(feature = "egui")]
 mod inspector;
-#[cfg(not(target_arch = "wasm32"))]
 mod offscreen;
 #[cfg(feature = "recording")]
 mod recording;
@@ -21,7 +20,6 @@ mod window_cache;
 pub use canvas::{Canvas, CanvasSetup, NumSamples};
 #[cfg(feature = "egui")]
 pub use inspector::{Inspector, InspectorTab};
-#[cfg(not(target_arch = "wasm32"))]
 pub use offscreen::OffscreenSurface;
 #[cfg(feature = "recording")]
 pub use recording::RecordingConfig;

--- a/src/window/offscreen.rs
+++ b/src/window/offscreen.rs
@@ -107,7 +107,14 @@ impl OffscreenSurface {
     ) {
         let _ = self
             .window
-            .render_chain(scene, scene_2d, camera, camera_2d, renderer, post_processing)
+            .render_chain(
+                scene,
+                scene_2d,
+                camera,
+                camera_2d,
+                renderer,
+                post_processing,
+            )
             .await;
     }
 
@@ -130,8 +137,8 @@ impl OffscreenSurface {
     ///
     /// Native only: reading the result back to the CPU requires blocking on the
     /// GPU, which is impossible on the web. Use [`Self::output_view`] +
-    /// [`Window::register_egui_texture`] to display the surface without a
-    /// read-back.
+    /// `Window::register_egui_texture` (with the `egui` feature) to display the
+    /// surface without a read-back.
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn render_image_raytraced(
         &mut self,
@@ -189,7 +196,7 @@ impl OffscreenSurface {
     /// post-tonemap output of `render_3d` / `raytrace_3d` / `render_aov_3d`).
     ///
     /// Register it with a visible window's egui renderer
-    /// ([`Window::register_egui_texture`]) to display the surface's content
+    /// (`Window::register_egui_texture`, with the `egui` feature) to display the surface's content
     /// without any GPU→CPU copy — this works on the web, where the `snap_*`
     /// read-backs don't exist.
     ///

--- a/src/window/offscreen.rs
+++ b/src/window/offscreen.rs
@@ -1,5 +1,6 @@
 //! Off-screen (headless) rendering surface.
 
+use crate::builtin::AovKind;
 use crate::camera::{Camera2d, Camera3d};
 use crate::color::Color;
 use crate::post_processing::{PostProcessingEffect, Tonemap};
@@ -7,6 +8,7 @@ use crate::renderer::{RayTracer, Renderer3d};
 use crate::scene::{SceneNode2d, SceneNode3d};
 use crate::window::{CanvasSetup, Window};
 use glamx::UVec2;
+#[cfg(not(target_arch = "wasm32"))]
 use image::{ImageBuffer, Luma, Rgb};
 
 /// A headless rendering surface.
@@ -125,6 +127,12 @@ impl OffscreenSurface {
 
     /// Path-traces a 3D scene for `samples` accumulated frames and returns the
     /// resulting image, in one call.
+    ///
+    /// Native only: reading the result back to the CPU requires blocking on the
+    /// GPU, which is impossible on the web. Use [`Self::output_view`] +
+    /// [`Window::register_egui_texture`] to display the surface without a
+    /// read-back.
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn render_image_raytraced(
         &mut self,
         scene: &mut SceneNode3d,
@@ -139,6 +147,9 @@ impl OffscreenSurface {
     }
 
     /// Renders a 3D scene and returns the resulting image, in one call.
+    ///
+    /// Native only (blocking GPU read-back).
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn render_image_3d(
         &mut self,
         scene: &mut SceneNode3d,
@@ -149,25 +160,69 @@ impl OffscreenSurface {
     }
 
     /// Captures the last rendered frame as raw RGB pixel data.
+    ///
+    /// Native only (blocking GPU read-back).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap(&self, out: &mut Vec<u8>) {
         self.window.snap(out)
     }
 
     /// Captures a rectangular region of the last rendered frame as raw RGB data.
+    ///
+    /// Native only (blocking GPU read-back).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_rect(&self, out: &mut Vec<u8>, x: usize, y: usize, width: usize, height: usize) {
         self.window.snap_rect(out, x, y, width, height)
     }
 
     /// Captures the last rendered frame as an image.
+    ///
+    /// Native only (blocking GPU read-back).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_image(&self) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
         self.window.snap_image()
     }
 
-    // === Auxiliary render outputs (AOVs) ===
+    // === GPU-resident output (no read-back; works on the web) ===
+
+    /// The texture view holding this surface's final rendered image (the LDR,
+    /// post-tonemap output of `render_3d` / `raytrace_3d` / `render_aov_3d`).
+    ///
+    /// Register it with a visible window's egui renderer
+    /// ([`Window::register_egui_texture`]) to display the surface's content
+    /// without any GPU→CPU copy — this works on the web, where the `snap_*`
+    /// read-backs don't exist.
+    ///
+    /// The view is replaced when the surface is [`resize`](Self::resize)d;
+    /// re-register it afterwards.
+    pub fn output_view(&mut self) -> wgpu::TextureView {
+        self.window.offscreen_output_view()
+    }
+
+    /// Renders an auxiliary output (depth, normals or segmentation) of the
+    /// scene as a **display-ready image** into this surface's output texture
+    /// ([`Self::output_view`]), entirely on the GPU — no read-back, so it works
+    /// on the web.
+    ///
+    /// For [`AovKind::Depth`], depth is mapped over `[0, depth_range]` world
+    /// units (near = bright, background = black); the other kinds ignore
+    /// `depth_range`. See [`Window::render_aov_3d`].
+    pub fn render_aov_3d(
+        &mut self,
+        kind: AovKind,
+        scene: &mut SceneNode3d,
+        camera: &mut impl Camera3d,
+        depth_range: f32,
+    ) {
+        self.window.render_aov_3d(kind, scene, camera, depth_range)
+    }
+
+    // === Auxiliary render outputs (AOVs, CPU read-back; native only) ===
 
     /// Renders the scene and returns per-pixel linear, eye-space depth (in world
     /// units), row-major with a top-left origin. Background pixels read back as
     /// `0.0`. See [`Window::snap_depth_raw`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_depth_raw(
         &mut self,
         scene: &mut SceneNode3d,
@@ -179,6 +234,7 @@ impl OffscreenSurface {
     /// Renders the scene and returns its depth as a normalized 8-bit grayscale
     /// image (nearest surface brightest, background black). See
     /// [`Window::snap_depth`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_depth(
         &mut self,
         scene: &mut SceneNode3d,
@@ -189,6 +245,7 @@ impl OffscreenSurface {
 
     /// Renders the scene and returns its world-space surface normals, encoded
     /// from `[-1, 1]` to `[0, 255]` per channel. See [`Window::snap_normals`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_normals(
         &mut self,
         scene: &mut SceneNode3d,
@@ -199,6 +256,7 @@ impl OffscreenSurface {
 
     /// Like [`snap_normals`](Self::snap_normals) but in camera (eye) space. See
     /// [`Window::snap_camera_normals`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_camera_normals(
         &mut self,
         scene: &mut SceneNode3d,
@@ -210,6 +268,7 @@ impl OffscreenSurface {
     /// Renders the scene and returns the per-pixel segmentation/object id (`0`
     /// for background), row-major with a top-left origin. See
     /// [`Window::snap_segmentation`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_segmentation(
         &mut self,
         scene: &mut SceneNode3d,
@@ -221,6 +280,7 @@ impl OffscreenSurface {
     /// Renders the scene and returns a colorized segmentation image (each id
     /// mapped to a distinct color, background black). See
     /// [`Window::snap_segmentation_colored`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn snap_segmentation_colored(
         &mut self,
         scene: &mut SceneNode3d,

--- a/src/window/offscreen.rs
+++ b/src/window/offscreen.rs
@@ -91,6 +91,24 @@ impl OffscreenSurface {
             .await;
     }
 
+    /// Renders one frame through an ordered chain of post-processing effects.
+    /// See [`Window::render_chain`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn render_chain(
+        &mut self,
+        scene: Option<&mut SceneNode3d>,
+        scene_2d: Option<&mut SceneNode2d>,
+        camera: Option<&mut dyn Camera3d>,
+        camera_2d: Option<&mut dyn Camera2d>,
+        renderer: Option<&mut dyn Renderer3d>,
+        post_processing: &mut [&mut dyn PostProcessingEffect],
+    ) {
+        let _ = self
+            .window
+            .render_chain(scene, scene_2d, camera, camera_2d, renderer, post_processing)
+            .await;
+    }
+
     /// Renders one path-traced frame into the off-screen texture.
     ///
     /// Call repeatedly with the same [`RayTracer`] to accumulate samples (the

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -70,6 +70,22 @@ impl Window {
             .await
     }
 
+    /// Renders a 2D scene and runs a post-processing effect over the result.
+    ///
+    /// The 2D scene is rasterized into the HDR film and tonemapped (with bloom when
+    /// [`set_bloom_enabled`](Self::set_bloom_enabled) is on) exactly as in
+    /// [`render_2d`](Self::render_2d), then `post` (e.g. [`Crt`](crate::post_processing::Crt))
+    /// runs over the LDR image before it reaches the screen.
+    pub async fn render_2d_with(
+        &mut self,
+        scene: &mut SceneNode2d,
+        camera: &mut impl Camera2d,
+        post: &mut dyn PostProcessingEffect,
+    ) -> bool {
+        self.render(None, Some(scene), None, Some(camera), None, Some(post))
+            .await
+    }
+
     // `scene`/`camera` are only taken mutably (via `as_deref_mut`) by the
     // `rt_switcher` block below; without that feature the `mut` is unused.
     #[cfg_attr(not(feature = "rt_switcher"), allow(unused_mut))]

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -1195,7 +1195,7 @@ impl Window {
                 .resolve(&mut encoder, &first_view, force_opaque, &mut self.gpu_timer);
 
             let n = post_processing.len();
-            for i in 0..n {
+            for (i, pp) in post_processing.iter_mut().enumerate() {
                 // Even effects read A and write B, odd ones read B and write A; the
                 // final effect writes `frame_view` instead of a ping-pong target.
                 let read_a = i % 2 == 0;
@@ -1219,12 +1219,12 @@ impl Window {
                 };
 
                 // TODO: use the real time value instead of 0.016!
-                post_processing[i].update(0.016, w as f32, h as f32, znear, zfar);
+                pp.update(0.016, w as f32, h as f32, znear, zfar);
                 let mut pp_context = PostProcessingContext {
                     encoder: &mut encoder,
                     output_view,
                 };
-                post_processing[i].draw(input, &mut pp_context);
+                pp.draw(input, &mut pp_context);
             }
         }
 

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -82,21 +82,74 @@ impl Window {
         camera: &mut impl Camera2d,
         post: &mut dyn PostProcessingEffect,
     ) -> bool {
-        self.render(None, Some(scene), None, Some(camera), None, Some(post))
+        self.render_2d_with_chain(scene, camera, &mut [post]).await
+    }
+
+    /// Renders a 2D scene through an ordered chain of post-processing effects.
+    ///
+    /// The effects run back to back: the tonemapped scene feeds the first, each
+    /// effect's output feeds the next, and the last writes the frame. Unlike a single
+    /// effect, this lets you combine, say, [`Gi2d`](crate::post_processing::Gi2d) then
+    /// [`Crt`](crate::post_processing::Crt). An empty chain behaves like
+    /// [`render_2d`](Self::render_2d).
+    pub async fn render_2d_with_chain(
+        &mut self,
+        scene: &mut SceneNode2d,
+        camera: &mut impl Camera2d,
+        chain: &mut [&mut dyn PostProcessingEffect],
+    ) -> bool {
+        self.render_chain(None, Some(scene), None, Some(camera), None, chain)
             .await
     }
 
+    /// Renders a 3D scene through an ordered chain of post-processing effects.
+    /// See [`render_2d_with_chain`](Self::render_2d_with_chain).
+    pub async fn render_3d_with_chain(
+        &mut self,
+        scene: &mut SceneNode3d,
+        camera: &mut impl Camera3d,
+        chain: &mut [&mut dyn PostProcessingEffect],
+    ) -> bool {
+        self.render_chain(Some(scene), None, Some(camera), None, None, chain)
+            .await
+    }
+
+    pub async fn render(
+        &mut self,
+        scene: Option<&mut SceneNode3d>,
+        scene_2d: Option<&mut SceneNode2d>,
+        camera: Option<&mut dyn Camera3d>,
+        camera_2d: Option<&mut dyn Camera2d>,
+        renderer: Option<&mut dyn Renderer3d>,
+        post_processing: Option<&mut dyn PostProcessingEffect>,
+    ) -> bool {
+        // Adapt the single-effect option to a 0-or-1-element chain.
+        let mut single;
+        let chain: &mut [&mut dyn PostProcessingEffect] = match post_processing {
+            Some(p) => {
+                single = [p];
+                &mut single
+            }
+            None => &mut [],
+        };
+        self.render_chain(scene, scene_2d, camera, camera_2d, renderer, chain)
+            .await
+    }
+
+    /// The general render entry point: an optional 3D scene, an optional 2D scene,
+    /// their cameras, an optional custom 3D renderer, and an ordered post-processing
+    /// `chain` (empty = none). The single-scene/effect helpers wrap this.
     // `scene`/`camera` are only taken mutably (via `as_deref_mut`) by the
     // `rt_switcher` block below; without that feature the `mut` is unused.
     #[cfg_attr(not(feature = "rt_switcher"), allow(unused_mut))]
-    pub async fn render(
+    pub async fn render_chain(
         &mut self,
         mut scene: Option<&mut SceneNode3d>,
         scene_2d: Option<&mut SceneNode2d>,
         mut camera: Option<&mut dyn Camera3d>,
         camera_2d: Option<&mut dyn Camera2d>,
         renderer: Option<&mut dyn Renderer3d>,
-        post_processing: Option<&mut dyn PostProcessingEffect>,
+        post_processing: &mut [&mut dyn PostProcessingEffect],
     ) -> bool {
         #[cfg(feature = "rt_switcher")]
         if let (Some(mut rt), Some(camera), Some(scene)) = (
@@ -140,7 +193,7 @@ impl Window {
         camera: &mut dyn Camera3d,
         camera_2d: &mut dyn Camera2d,
         mut renderer: Option<&mut dyn Renderer3d>,
-        mut post_processing: Option<&mut dyn PostProcessingEffect>,
+        post_processing: &mut [&mut dyn PostProcessingEffect],
     ) -> bool {
         // Frame timing: CPU wall-clock for the whole frame (and submit/present
         // below) plus per-pass GPU timestamps recorded into the GPU timer. The
@@ -206,6 +259,8 @@ impl Window {
         // `resolve_view` below) before tonemapping.
         self.hdr.resize(w, h, sample_count);
         self.post_process_render_target
+            .resize(w, h, self.canvas.surface_format());
+        self.post_process_render_target_b
             .resize(w, h, self.canvas.surface_format());
         if offscreen {
             if self.offscreen_output_target.is_none() {
@@ -1118,30 +1173,55 @@ impl Window {
             }
         }
 
-        // Tonemap + bloom resolve. Existing post-processing effects run on the
-        // tonemapped LDR image: the HDR film is tonemapped into the LDR
-        // post-process target, then the effect composites it into `frame_view`.
-        // Without an effect, the HDR film is tonemapped straight into `frame_view`.
-        if let Some(ref mut p) = post_processing {
-            let pp_ldr_view = match &self.post_process_render_target {
+        // Tonemap + bloom resolve, then the post-processing chain. Effects run on the
+        // tonemapped LDR image. With no effect the HDR film is tonemapped straight
+        // into `frame_view`. With one or more, the film is tonemapped into the first
+        // ping-pong LDR target, then each effect reads the previous target and writes
+        // the next (A→B→A→…), with the last effect writing the final `frame_view`.
+        if post_processing.is_empty() {
+            self.hdr
+                .resolve(&mut encoder, &frame_view, &mut self.gpu_timer);
+        } else {
+            // Tonemap into the first ping-pong target (A).
+            let first_view = match &self.post_process_render_target {
                 RenderTarget::Offscreen(o) => o.color_view.clone(),
                 RenderTarget::Screen => frame_view.clone(),
             };
             self.hdr
-                .resolve(&mut encoder, &pp_ldr_view, &mut self.gpu_timer);
+                .resolve(&mut encoder, &first_view, &mut self.gpu_timer);
 
-            // TODO: use the real time value instead of 0.016!
-            p.update(0.016, w as f32, h as f32, znear, zfar);
+            let n = post_processing.len();
+            for i in 0..n {
+                // Even effects read A and write B, odd ones read B and write A; the
+                // final effect writes `frame_view` instead of a ping-pong target.
+                let read_a = i % 2 == 0;
+                let input = if read_a {
+                    &self.post_process_render_target
+                } else {
+                    &self.post_process_render_target_b
+                };
+                let output_view: &wgpu::TextureView = if i == n - 1 {
+                    &frame_view
+                } else {
+                    let out_target = if read_a {
+                        &self.post_process_render_target_b
+                    } else {
+                        &self.post_process_render_target
+                    };
+                    match out_target {
+                        RenderTarget::Offscreen(o) => &o.color_view,
+                        RenderTarget::Screen => &frame_view,
+                    }
+                };
 
-            let mut pp_context = PostProcessingContext {
-                encoder: &mut encoder,
-                output_view: &frame_view,
-            };
-
-            p.draw(&self.post_process_render_target, &mut pp_context);
-        } else {
-            self.hdr
-                .resolve(&mut encoder, &frame_view, &mut self.gpu_timer);
+                // TODO: use the real time value instead of 0.016!
+                post_processing[i].update(0.016, w as f32, h as f32, znear, zfar);
+                let mut pp_context = PostProcessingContext {
+                    encoder: &mut encoder,
+                    output_view,
+                };
+                post_processing[i].draw(input, &mut pp_context);
+            }
         }
 
         // Render text

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -1178,9 +1178,13 @@ impl Window {
         // into `frame_view`. With one or more, the film is tonemapped into the first
         // ping-pong LDR target, then each effect reads the previous target and writes
         // the next (A→B→A→…), with the last effect writing the final `frame_view`.
+        // A visible window presents to a surface a browser composites against the
+        // page, so force an opaque alpha there; a hidden/offscreen target keeps the
+        // scene alpha for snapshots and host-app embedding.
+        let force_opaque = !offscreen;
         if post_processing.is_empty() {
             self.hdr
-                .resolve(&mut encoder, &frame_view, &mut self.gpu_timer);
+                .resolve(&mut encoder, &frame_view, force_opaque, &mut self.gpu_timer);
         } else {
             // Tonemap into the first ping-pong target (A).
             let first_view = match &self.post_process_render_target {
@@ -1188,7 +1192,7 @@ impl Window {
                 RenderTarget::Screen => frame_view.clone(),
             };
             self.hdr
-                .resolve(&mut encoder, &first_view, &mut self.gpu_timer);
+                .resolve(&mut encoder, &first_view, force_opaque, &mut self.gpu_timer);
 
             let n = post_processing.len();
             for i in 0..n {

--- a/src/window/rendering.rs
+++ b/src/window/rendering.rs
@@ -1696,6 +1696,15 @@ impl Window {
             jobs.push((mcam, r.color_view().clone(), r.depth_view().clone(), clip));
         });
 
+        // Mirror the main pass's phase gating so nothing visible is missing from
+        // the reflections: transparent (OIT) surfaces and refractive glass are
+        // drawn into each capture after its opaque pass.
+        let has_transparent = scene.has_transparent_surfaces();
+        let mut glass_nodes: Vec<SceneNode3d> = Vec::new();
+        if self.transmission_enabled {
+            scene.collect_refractive(&mut glass_nodes);
+        }
+
         // Fixed-light path for the capture frames (the mirror camera has no clustered
         // cull data). Reflector surfaces skip themselves during capture (handled in
         // the material via `capture_mode`).
@@ -1774,6 +1783,147 @@ impl Window {
                     .data_mut()
                     .render(0, &mut mcam, &mlights, &mut pass, &ctx);
             }
+
+            // === Transparent (OIT) surfaces in the mirror ===
+            // Same weighted-blended OIT as the main pass, but into dedicated
+            // single-sample targets, composited over the capture. Tests against
+            // the capture's opaque depth.
+            if has_transparent {
+                let oit = self
+                    .reflector_oit
+                    .get_or_insert_with(|| crate::renderer::ReflectorOit::new(w, h));
+                oit.resize(w, h);
+                let oit_ctx = RenderContext {
+                    surface_format: crate::post_processing::HDR_FORMAT,
+                    sample_count: 1,
+                    viewport_width: w,
+                    viewport_height: h,
+                    render_layers: camera.render_layers(),
+                    force_no_cull: true,
+                    shadow: Some(self.shadow_mapper.resources()),
+                    phase: RenderPhase::Transparent,
+                };
+                {
+                    let oit_ts = self.gpu_timer.render_scope("reflector_oit");
+                    let mut oit_pass = menc.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("reflector_oit_pass"),
+                        color_attachments: &[
+                            // accum: cleared to 0 (additive).
+                            Some(wgpu::RenderPassColorAttachment {
+                                view: oit.accum_view(),
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                                    store: wgpu::StoreOp::Store,
+                                },
+                                depth_slice: None,
+                            }),
+                            // revealage: cleared to 1 (nothing occluded yet).
+                            Some(wgpu::RenderPassColorAttachment {
+                                view: oit.reveal_view(),
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                                    store: wgpu::StoreOp::Store,
+                                },
+                                depth_slice: None,
+                            }),
+                        ],
+                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                            view: &depth_view,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            }),
+                            stencil_ops: None,
+                        }),
+                        timestamp_writes: oit_ts,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
+                    });
+                    scene
+                        .data_mut()
+                        .render(0, &mut mcam, &mlights, &mut oit_pass, &oit_ctx);
+                }
+                oit.composite(&mut menc, &color_view);
+            }
+
+            // === Refractive (glass) surfaces in the mirror ===
+            // Snapshot the capture (opaque + transparent) into the shared blurred
+            // mip chain, then draw the glass objects sampling it — one snapshot
+            // layer, so mirrored glass refracts the scene behind it but not other
+            // glass (unlike the main pass's multi-layer refinement). Sharing
+            // `self.transmission` with the main pass is safe: passes execute in
+            // submission order, and the main pass rebuilds the snapshot later.
+            if !glass_nodes.is_empty() {
+                {
+                    let t = self
+                        .transmission
+                        .get_or_insert_with(|| crate::renderer::Transmission::new(w, h));
+                    t.resize(w, h);
+                }
+                // Farthest from the (reflected) eye first, so nearer glass draws
+                // over glass behind it.
+                let eye = mcam.eye();
+                glass_nodes.sort_by(|a, b| {
+                    let da = a.world_position().distance_squared(eye);
+                    let db = b.world_position().distance_squared(eye);
+                    db.partial_cmp(&da).unwrap_or(std::cmp::Ordering::Equal)
+                });
+
+                let t = self.transmission.as_ref().unwrap();
+                t.build(&mut menc, &color_view, &mut self.gpu_timer);
+                {
+                    let default_mat = MaterialManager3d::get_global_manager(|mm| mm.get_default());
+                    default_mat
+                        .borrow_mut()
+                        .set_transmission_background(Some(t.view()));
+                }
+                let glass_ctx = RenderContext {
+                    surface_format: crate::post_processing::HDR_FORMAT,
+                    sample_count: 1,
+                    viewport_width: w,
+                    viewport_height: h,
+                    render_layers: camera.render_layers(),
+                    force_no_cull: true,
+                    shadow: Some(self.shadow_mapper.resources()),
+                    phase: RenderPhase::Transmission,
+                };
+                let glass_ts = self.gpu_timer.render_scope("reflector_glass");
+                let mut glass_pass = menc.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("reflector_glass_pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &color_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                        depth_slice: None,
+                    })],
+                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                        view: &depth_view,
+                        depth_ops: Some(wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        }),
+                        stencil_ops: None,
+                    }),
+                    timestamp_writes: glass_ts,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                });
+                for node in glass_nodes.iter_mut() {
+                    node.data_mut().render_object_only(
+                        0,
+                        &mut mcam,
+                        &mlights,
+                        &mut glass_pass,
+                        &glass_ctx,
+                    );
+                }
+            }
+
             ctxt.submit(std::iter::once(menc.finish()));
         }
 
@@ -1788,5 +1938,26 @@ impl Window {
         // Bump the frame counter so the per-pass loop re-prepares the main camera
         // (reflector objects then pick up the view-proj set on their Reflector above).
         MaterialManager3d::get_global_manager(|mm| mm.begin_frame());
+    }
+
+    /// The texture view holding the final (LDR, post-tonemap) image of a hidden
+    /// window or [`OffscreenSurface`](crate::window::OffscreenSurface), creating
+    /// the target on demand. The render path draws into this same target, so the
+    /// view always shows the latest rendered frame.
+    ///
+    /// The view is replaced when the window is resized; re-acquire (and
+    /// re-register with egui) afterwards.
+    pub(crate) fn offscreen_output_view(&mut self) -> wgpu::TextureView {
+        let (w, h) = (self.width().max(1), self.height().max(1));
+        if self.offscreen_output_target.is_none() {
+            self.offscreen_output_target =
+                Some(self.framebuffer_manager.new_render_target(w, h, true));
+        }
+        let target = self.offscreen_output_target.as_mut().unwrap();
+        target.resize(w, h, self.canvas.surface_format());
+        target
+            .color_view()
+            .expect("offscreen render target is never the screen")
+            .clone()
     }
 }

--- a/src/window/wgpu_canvas.rs
+++ b/src/window/wgpu_canvas.rs
@@ -69,6 +69,13 @@ fn experimental_features(required: wgpu::Features) -> ExperimentalFeatures {
     ExperimentalFeatures::disabled()
 }
 
+/// Combines the features kiss3d always wants with the consumer-requested extras from
+/// [`CanvasSetup::required_features`], dropping any the adapter doesn't support so
+/// `request_device` never fails on an unavailable feature.
+fn device_features(adapter: &wgpu::Adapter, extra: wgpu::Features) -> wgpu::Features {
+    raytracing_features(adapter) | (extra & adapter.features())
+}
+
 // Thread-local EventLoop singleton for native platforms.
 // winit only allows one EventLoop per program, so we store it in thread-local
 // storage and reuse it across window recreations. EventLoop is not Send/Sync,
@@ -280,7 +287,7 @@ impl WgpuCanvas {
             // unavailable there, which is an inherent WebGL2 limitation.
             let limits = adapter.limits();
 
-            let required_features = raytracing_features(&adapter);
+            let required_features = device_features(&adapter, canvas_setup.required_features);
             let (device, queue) = adapter
                 .request_device(&wgpu::DeviceDescriptor {
                     label: Some("kiss3d device"),
@@ -686,7 +693,7 @@ impl WgpuCanvas {
                 .await
                 .expect("Failed to find an appropriate adapter");
 
-            let required_features = raytracing_features(&adapter);
+            let required_features = device_features(&adapter, canvas_setup.required_features);
             let (device, queue) = adapter
                 .request_device(&wgpu::DeviceDescriptor {
                     label: Some("kiss3d headless device"),

--- a/src/window/wgpu_canvas.rs
+++ b/src/window/wgpu_canvas.rs
@@ -657,7 +657,6 @@ impl WgpuCanvas {
 
     /// Opens a headless canvas: a wgpu context with no window and no surface,
     /// for off-screen rendering. Works without a display server.
-    #[cfg(not(target_arch = "wasm32"))]
     pub async fn open_headless(
         width: u32,
         height: u32,
@@ -744,6 +743,7 @@ impl WgpuCanvas {
 
         WgpuCanvas {
             window: None,
+            #[cfg(not(target_arch = "wasm32"))]
             window_id: None,
             surface: None,
             surface_config,
@@ -758,6 +758,10 @@ impl WgpuCanvas {
             msaa_view,
             sample_count,
             readback_texture,
+            #[cfg(target_arch = "wasm32")]
+            pending_events: Rc::new(RefCell::new(Vec::new())),
+            #[cfg(target_arch = "wasm32")]
+            _event_closures: Vec::new(),
         }
     }
 

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -1030,7 +1030,8 @@ impl Window {
             transmission_enabled: true,
             reflector_oit: None,
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
-            post_process_render_target_b: framebuffer_manager.new_render_target(width, height, false),
+            post_process_render_target_b: framebuffer_manager
+                .new_render_target(width, height, false),
             offscreen_output_target: None,
             aov_renderer: None,
             hidden: hide,
@@ -1106,7 +1107,8 @@ impl Window {
             transmission_enabled: true,
             reflector_oit: None,
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
-            post_process_render_target_b: framebuffer_manager.new_render_target(width, height, false),
+            post_process_render_target_b: framebuffer_manager
+                .new_render_target(width, height, false),
             offscreen_output_target: None,
             aov_renderer: None,
             // A headless window has no surface; always render off-screen.

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -99,6 +99,9 @@ pub struct Window {
     /// the resolved scene each frame that contains refractive surfaces.
     pub(super) transmission: Option<crate::renderer::Transmission>,
     pub(super) transmission_enabled: bool,
+    /// Single-sample OIT targets for the planar-reflector capture pass, so
+    /// transparent surfaces appear in mirrors. Created on first use.
+    pub(super) reflector_oit: Option<crate::renderer::ReflectorOit>,
     pub(super) post_process_render_target: RenderTarget,
     /// Second LDR target, paired with `post_process_render_target` as ping-pong
     /// buffers when chaining more than one post-processing effect: each effect reads
@@ -1025,6 +1028,7 @@ impl Window {
             dof_enabled: false,
             transmission: None,
             transmission_enabled: true,
+            reflector_oit: None,
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
             post_process_render_target_b: framebuffer_manager.new_render_target(width, height, false),
             offscreen_output_target: None,
@@ -1047,7 +1051,6 @@ impl Window {
 
     /// Creates a headless window: a render target backed by no actual window,
     /// for off-screen rendering. Powers [`OffscreenSurface`](crate::window::OffscreenSurface).
-    #[cfg(not(target_arch = "wasm32"))]
     pub(super) async fn do_new_headless(
         width: u32,
         height: u32,
@@ -1101,6 +1104,7 @@ impl Window {
             dof_enabled: false,
             transmission: None,
             transmission_enabled: true,
+            reflector_oit: None,
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
             post_process_render_target_b: framebuffer_manager.new_render_target(width, height, false),
             offscreen_output_target: None,

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -100,6 +100,10 @@ pub struct Window {
     pub(super) transmission: Option<crate::renderer::Transmission>,
     pub(super) transmission_enabled: bool,
     pub(super) post_process_render_target: RenderTarget,
+    /// Second LDR target, paired with `post_process_render_target` as ping-pong
+    /// buffers when chaining more than one post-processing effect: each effect reads
+    /// one and writes the other, and the last writes the final frame.
+    pub(super) post_process_render_target_b: RenderTarget,
     /// Offscreen render target used when the window is hidden, so `snap` and
     /// recording work without a presentable surface. Created on first use.
     pub(super) offscreen_output_target: Option<RenderTarget>,
@@ -1022,6 +1026,7 @@ impl Window {
             transmission: None,
             transmission_enabled: true,
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
+            post_process_render_target_b: framebuffer_manager.new_render_target(width, height, false),
             offscreen_output_target: None,
             aov_renderer: None,
             hidden: hide,
@@ -1097,6 +1102,7 @@ impl Window {
             transmission: None,
             transmission_enabled: true,
             post_process_render_target: framebuffer_manager.new_render_target(width, height, true),
+            post_process_render_target_b: framebuffer_manager.new_render_target(width, height, false),
             offscreen_output_target: None,
             aov_renderer: None,
             // A headless window has no surface; always render off-screen.

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -994,7 +994,7 @@ impl Window {
         let mut usr_window = Window {
             should_close: false,
             first_frame: true,
-            close_key: Some(Key::Escape),
+            close_key: None,
             close_modifiers: None,
             last_timings: None,
             last_frame_instant: None,


### PR DESCRIPTION
We have made a couple of PRs for improving 3D rendering effects. This PR focuses on 2D (see changelog for details).

This also removes the default behavior that closes the window when pressing the Escape button (it can be re-enabled with `Window::rebind_close_key(Some(Key::Escape))` if needed).

- Per-object blend modes: additive, multiply, screen, premultiplied/straight alpha
- Dynamic 2D lighting: point/spot lights with normal-mapped sprites (diffuse + Blinn-Phong specular)
- Screen-space 2D global illumination: soft shadows + colored light bleed, with optional radiance cascades
- CRT post-processing: screen curvature, chromatic aberration, scanlines, vignette
- Bloom + HDR tonemapping now applied to 2D too

<img width="1085" height="681" alt="image" src="https://github.com/user-attachments/assets/89dc6c18-7f7e-477d-85bf-d6e950abaa7e" />

<img width="867" height="727" alt="image" src="https://github.com/user-attachments/assets/81fa5ef0-6148-4cb2-b8ab-de470ced8149" />

<img width="1172" height="914" alt="image" src="https://github.com/user-attachments/assets/7afb5e1b-27e8-4eb5-8d63-0bf785f60a8e" />

<img width="768" height="615" alt="image" src="https://github.com/user-attachments/assets/5dffcec1-59dc-49c0-b3ae-08a0ea35b4cf" />



